### PR TITLE
fix(installer): ensure menu configuration is always added to config.toml

### DIFF
--- a/docsystem/installer.sh
+++ b/docsystem/installer.sh
@@ -198,8 +198,17 @@ if ! grep -q "^\[params\.ui\]" $INSTALL_DIR/config.toml; then
 fi
 
 # Add menu configuration if not present
-if ! grep -q "^\[\[menu\.main\]\]" $INSTALL_DIR/config.toml; then
-  cat >> $INSTALL_DIR/config.toml <<'EOF_MENU'
+# Remove any existing menu.main entries to ensure clean configuration
+if grep -q "^\[\[menu\.main\]\]" $INSTALL_DIR/config.toml; then
+  echo "Removing existing menu configuration..."
+  # Use awk to remove all [[menu.main]] blocks
+  awk '/^# Menu configuration$/ {skip=1} /^\[\[menu\.main\]\]/ {skip=1} skip && /^$/ {skip=0; next} !skip' $INSTALL_DIR/config.toml > $INSTALL_DIR/config.toml.tmp
+  mv $INSTALL_DIR/config.toml.tmp $INSTALL_DIR/config.toml
+fi
+
+# Now add the proper menu configuration
+echo "Adding menu configuration (Blog, Docs, Release)..."
+cat >> $INSTALL_DIR/config.toml <<'EOF_MENU'
 
 # Menu configuration
 [[menu.main]]
@@ -217,7 +226,6 @@ name = "Release"
 weight = 30
 url = "https://github.com/vmware/photon/releases"
 EOF_MENU
-fi
 
 # Initialize submodules (e.g., for Docsy theme)
 if [ -d .git ]; then


### PR DESCRIPTION
## Problem
The menu configuration (Blog, Docs, Release) was not appearing in the local Photon OS nginx webserver created by `docsystem/installer.sh`. The reference website at https://vmware.github.io/photon displays these menu items, but the local build was missing them.

## Root Cause
The conditional check `if ! grep -q "^\[\[menu\.main\]\]"` would skip adding menu items if any `[[menu.main]]` entries already existed in config.toml, resulting in no menu entries being added during installation.

## Solution
Modified `docsystem/installer.sh` to:
- Remove any existing menu.main entries before adding new ones using awk
- Always add menu configuration (removed conditional check)
- Ensure Blog, Docs, and Release menu items are properly added to config.toml

## Changes Made
- Lines 200-228 in `docsystem/installer.sh`:
  - Added cleanup of existing menu configuration
  - Removed conditional check that prevented menu from being added
  - Menu items now always added: Blog, Docs, Release

## Preserved Features
✅ All subscripts remain intact:
- `installer-weblinkfixes.sh`
- `installer-consolebackend.sh`
- `installer-searchbackend.sh`
- `installer-sitebuild.sh`
- `installer-ghinterconnection.sh`

✅ Console window feature preserved (terminal icon in navbar)

## Testing
After this fix, running `installer.sh` will result in a local Photon OS documentation site that matches the reference website with proper menu navigation.