### PR TITLE
feat(docs-maintenance): add Fixes 48-50 for Hugo slug generation mismatches

### DIFF
--- a/docsystem/.factory/teams/docs-maintenance/PLAN-SPECIFICATION.md
+++ b/docsystem/.factory/teams/docs-maintenance/PLAN-SPECIFICATION.md
@@ -934,6 +934,25 @@ factory run @docs-maintenance-pr-bot
 
 ---
 
+## Execution History
+
+### 2025-11-23: Hugo Slug Generation Fixes (Fixes 48-50)
+
+**Issues Identified**: 3 broken links caused by mismatch between Hugo's URL slug generation and markdown link references
+
+**Root Cause**: Hugo generates URLs from page `title` field (slugified), but internal links referenced different paths
+
+**Fixes Applied**:
+- **Fix 48**: whats-new pages - Hugo generates `what-is-new-in-photon-os-4` from title "What is New in Photon OS 4", not `whats-new`
+- **Fix 49**: kickstart pages - Hugo generates `kickstart-support-in-photon-os` from title "Kickstart Support in Photon OS", not `working-with-kickstart`
+- **Fix 50**: troubleshooting-linux-kernel - Hugo generates `linux-kernel` from title "Linux Kernel", not `troubleshooting-linux-kernel`
+
+**Impact**: Fixed 3 critical broken link issues. Validation shows all pages now accessible (200 OK).
+
+**Key Learning**: Always check Hugo's actual generated URL structure (`public/` directory) versus assumed link paths. Hugo slug generation follows title field, not filename.
+
+---
+
 ## Appendix A: Tool Requirements
 
 ### Python Packages

--- a/docsystem/installer-weblinkfixes.sh
+++ b/docsystem/installer-weblinkfixes.sh
@@ -468,6 +468,34 @@ if [ -f "$I18N_FILE" ]; then
     fi
 fi
 
+# Fix 48: Fix blog and cross-reference links to whats-new (Hugo slugifies title to "what-is-new-in-photon-os-4")
+echo "48. Fixing links to whats-new pages (Hugo slug generation)..."
+find "$INSTALL_DIR/content/en" -type f -name "*.md" -exec sed -i \
+  -e 's|(docs-v3/whats-new/)|(docs-v3/overview/what-is-new-in-photon-os/)|g' \
+  -e 's|(/docs-v3/whats-new/)|(/docs-v3/overview/what-is-new-in-photon-os/)|g' \
+  -e 's|(docs-v4/whats-new/)|(docs-v4/what-is-new-in-photon-os-4/)|g' \
+  -e 's|(/docs-v4/whats-new/)|(/docs-v4/what-is-new-in-photon-os-4/)|g' \
+  -e 's|(docs-v5/whats-new/)|(docs-v5/what-is-new-in-photon-os-5/)|g' \
+  -e 's|(/docs-v5/whats-new/)|(/docs-v5/what-is-new-in-photon-os-5/)|g' \
+  {} \;
+
+# Fix 49: Fix kickstart links (Hugo slugifies title "Kickstart Support" to "kickstart-support-in-photon-os")
+echo "49. Fixing kickstart links to match Hugo slug generation..."
+find "$INSTALL_DIR/content/en" -type f -name "*.md" -exec sed -i \
+  -e 's|(/docs-v3/user-guide/working-with-kickstart/)|(/docs-v3/user-guide/kickstart-support-in-photon-os/)|g' \
+  -e 's|(/docs-v4/user-guide/working-with-kickstart/)|(/docs-v4/user-guide/kickstart-support-in-photon-os/)|g' \
+  -e 's|(/docs-v5/user-guide/working-with-kickstart/)|(/docs-v5/user-guide/kickstart-support-in-photon-os/)|g' \
+  -e 's|(../../user-guide/working-with-kickstart/)|(../../user-guide/kickstart-support-in-photon-os/)|g' \
+  -e 's|(../../../user-guide/working-with-kickstart/)|(../../../user-guide/kickstart-support-in-photon-os/)|g' \
+  {} \;
+
+# Fix 50: Fix troubleshooting-linux-kernel link (Hugo generates as "linux-kernel", not "troubleshooting-linux-kernel")
+echo "50. Fixing troubleshooting-linux-kernel links..."
+find "$INSTALL_DIR/content/en" -path "*/kernel-problems-and-boot-and-login-errors/_index.md" -exec sed -i \
+  -e 's|(./troubleshooting-linux-kernel)|(./linux-kernel/)|g' \
+  -e 's|(troubleshooting-linux-kernel)|(linux-kernel/)|g' \
+  {} \;
+
 echo "======================================================="
 echo "Fixing incorrect relative links in markdown files done."
 echo "======================================================="


### PR DESCRIPTION
## Summary
Fixed 3 critical broken link issues identified by the docs-maintenance team.

## Root Cause
Hugo generates URLs from page title field (slugified), but internal markdown links referenced different paths.

## Fixes
- Fix 48: whats-new pages - /docs-v4/whats-new/ → /docs-v4/what-is-new-in-photon-os-4/
- Fix 49: kickstart pages - /user-guide/working-with-kickstart/ → /user-guide/kickstart-support-in-photon-os/
- Fix 50: linux-kernel page - troubleshooting-linux-kernel → linux-kernel/

## Validation
✅ All 3 pages return HTTP 200 OK
✅ Tested with weblinkchecker.sh
✅ Site builds with Hugo 0.152.2

## Files Changed
- docsystem/installer-weblinkfixes.sh (+28 lines)
- docsystem/.factory/teams/docs-maintenance/PLAN-SPECIFICATION.md (+19 lines)