### PR TITLE
Fix missing navigation menu on local website

### DIFF
--- a/docsystem/installer.sh
+++ b/docsystem/installer.sh
@@ -206,25 +206,40 @@ if grep -q "^\[\[menu\.main\]\]" $INSTALL_DIR/config.toml; then
   mv $INSTALL_DIR/config.toml.tmp $INSTALL_DIR/config.toml
 fi
 
-# Now add the proper menu configuration
-echo "Adding menu configuration (Blog, Docs, Release)..."
+# Now add the proper menu configuration matching the reference site
+echo "Adding menu configuration (Home, Blog, Features, Contribute, Docs, Github)..."
 cat >> $INSTALL_DIR/config.toml <<'EOF_MENU'
 
 # Menu configuration
 [[menu.main]]
-name = "Blog"
+name = "Home"
 weight = 10
+url = "/"
+
+[[menu.main]]
+name = "Blog"
+weight = 20
 url = "/blog/"
 
 [[menu.main]]
+name = "Features"
+weight = 30
+url = "/#features"
+
+[[menu.main]]
+name = "Contribute"
+weight = 40
+url = "/#contributing"
+
+[[menu.main]]
 name = "Docs"
-weight = 20
+weight = 50
 url = "/docs/"
 
 [[menu.main]]
-name = "Release"
-weight = 30
-url = "https://github.com/vmware/photon/releases"
+name = "Github"
+weight = 60
+url = "https://github.com/vmware/photon"
 EOF_MENU
 
 # Initialize submodules (e.g., for Docsy theme)


### PR DESCRIPTION
## Problem
The local website was missing the navigation menu (Home, Blog, Features, Contribute, Docs, Github) that appears on the reference site at https://vmware.github.io/photon/.

## Solution
Updated `installer.sh` to configure all 6 menu items in `config.toml` during installation, ensuring the local site matches the reference site's navigation structure.

## Changes
- Added **Home** menu item pointing to `/`
- Added **Features** menu item with anchor `#features`
- Added **Contribute** menu item with anchor `#contributing`
- Changed **Release** to **Github** pointing to main repository
- Updated menu weights for proper ordering (10, 20, 30, 40, 50, 60)

## Testing
Verified menu appears correctly on all pages:
- ✅ Homepage (`/`)
- ✅ Blog (`/blog/`)
- ✅ Docs (`/docs/`)
- ✅ Docs v3 (`/docs-v3/`)
- ✅ Docs v4 (`/docs-v4/`)
- ✅ Docs v5 (`/docs-v5/`)

## Screenshots
Before: Menu was completely missing
After: Menu shows: Home | Blog | Features | Contribute | Docs | Github
