### PR TITLE
fix(docsystem): Prevent menu deletion in installer-weblinkfixes.sh

### DIFF
--- a/docsystem/installer-weblinkfixes.sh
+++ b/docsystem/installer-weblinkfixes.sh
@@ -310,8 +310,16 @@ echo "26: Fixing duplicated permalinks ..."
 find "$INSTALL_DIR/content/" -type f -name "*.md" -exec sed -i '/^permalink: \/docs-v[3-5]\/docs-v[3-5]\//d' {} \;
 # Ensure single [permalinks] section and set paths using :sections to handle hierarchy without duplicates
 if grep -q "\[permalinks\]" $INSTALL_DIR/config.toml; then
-  # Remove existing [permalinks] section (assuming it is at the end or we want to replace it entirely)
-  sed -i '/^\[permalinks\]/,$d' $INSTALL_DIR/config.toml
+  # Remove existing [permalinks] section without deleting everything after it
+  # Use awk to remove only the [permalinks] section and its content
+  awk '
+    /^\[permalinks\]$/ { in_perma=1; next }
+    in_perma && /^$/ { next }
+    in_perma && /^[a-zA-Z0-9_-]+ *=/ { next }
+    in_perma && (/^#/ || /^\[/) { in_perma=0 }
+    !in_perma { print }
+  ' $INSTALL_DIR/config.toml > $INSTALL_DIR/config.toml.tmp
+  mv $INSTALL_DIR/config.toml.tmp $INSTALL_DIR/config.toml
 fi
 cat >> $INSTALL_DIR/config.toml <<EOF_PERMALINKS
 


### PR DESCRIPTION
## Problem

The navigation menu (Home, Blog, Features, Contribute, Docs, Github) disappeared on the local website at https://127.0.0.1 after running installer.sh, despite PR #14 and #15 adding the menu configuration.

## Root Cause Analysis

### Execution Sequence Issue
1. **installer.sh** adds navigation menu to config.toml (lines 220-252)
2. **installer-weblinkfixes.sh** runs AFTER installer.sh
3. **Line 314** used `sed -i '/^\[permalinks\]/,$d'` which deletes from [permalinks] to **END OF FILE**
4. This inadvertently **deleted the menu configuration** added earlier

### Why This Happened
In the original repository config.toml:
- `[permalinks]` section is at line 35
- `[[menu.main]]` entries start at line 51
- **Menu comes AFTER permalinks** → gets deleted by `sed` command

## Impact

- Navigation menu missing on all pages:
  - https://127.0.0.1/
  - https://127.0.0.1/blog/
  - https://127.0.0.1/docs/
  - https://127.0.0.1/docs-v3/
  - https://127.0.0.1/docs-v4/
  - https://127.0.0.1/docs-v5/

## Solution

Replaced the destructive sed command with stateful awk logic:

### Before (Buggy):
```bash
sed -i '/^\[permalinks\]/,$d' $INSTALL_DIR/config.toml
# Deletes from [permalinks] to END OF FILE!
```

### After (Fixed):
```bash
awk '
    /^\[permalinks\]$/ { in_perma=1; next }
    in_perma && /^$/ { next }
    in_perma && /^[a-zA-Z0-9_-]+ *=/ { next }
    in_perma && (/^#/ || /^\[/) { in_perma=0 }
    !in_perma { print }
  ' $INSTALL_DIR/config.toml > $INSTALL_DIR/config.toml.tmp
mv $INSTALL_DIR/config.toml.tmp $INSTALL_DIR/config.toml
```

This awk logic:
- Removes **ONLY** the [permalinks] section and its properties
- Preserves all content after [permalinks] including menu configuration
- Uses the same pattern as installer.sh menu removal logic (PR #15)

## Testing

### Test 1: Sample Config Structure
Tested with config.toml containing:
- [params] section
- [params.ui] section
- Menu configuration (6 items)
- [permalinks] section
- [other] section

**Result**: Menu configuration preserved after [permalinks] removal ✅

### Test 2: Original Repository Config
- Tested with actual config.toml from photon-hugo branch
- Original structure: [permalinks] at line 35, [[menu.main]] starts at line 51
- **Result**: Menu preserved at lines 48-68 after awk operation ✅

### Test 3: Edge Cases
- Tested with empty lines within [permalinks] section
- Tested with various section orderings
- **Result**: Menu preserved in all cases ✅

### Test 4: Live Verification
After manually adding menu to 127.0.0.1 config.toml and rebuilding:
- ✅ Menu appears on https://127.0.0.1/
- ✅ Menu appears on https://127.0.0.1/blog/
- ✅ Menu appears on https://127.0.0.1/docs-v3/
- ✅ Menu appears on https://127.0.0.1/docs-v4/
- ✅ Menu appears on https://127.0.0.1/docs-v5/

## Comprehensive Script Analysis

Analyzed complete execution sequence:
1. ✅ installer.sh - Properly adds menu
2. ✅ installer-weblinkfixes.sh - Now preserves menu with awk
3. ✅ installer-consolebackend.sh - Does not modify config.toml menu
4. ✅ installer-searchbackend.sh - Only modifies [outputs] section
5. ✅ installer-sitebuild.sh - Does not modify config.toml
6. ✅ installer-ghinterconnection.sh - Does not modify config.toml

**Conclusion**: No commands in the current scripts remove the menu.

## Files Changed

- `docsystem/installer-weblinkfixes.sh`: Fixed permalink removal logic to preserve menu configuration

## Related PRs

- PR #14: Added navigation menu to config.toml
- PR #15: Fixed menu removal logic in installer.sh
- PR #16: Fixed menu deletion in installer-weblinkfixes.sh (this PR)