### PR TITLE
fix(installer): Remove duplicate params.versions entries in config.toml

### DIFF
--- a/docsystem/installer.sh
+++ b/docsystem/installer.sh
@@ -271,14 +271,15 @@ EOF_MENU
 # Remove any existing params.versions entries to ensure clean configuration
 if grep -q "^\[\[params\.versions\]\]" $INSTALL_DIR/config.toml; then
   echo "Removing existing version selector configuration..."
-  # Use awk to remove all [[params.versions]] blocks and the version selector header
+  # Remove the "# Version selector configuration" comment line
+  sed -i '/^# Version selector configuration$/d' $INSTALL_DIR/config.toml
+  # Use awk to remove ALL [[params.versions]] blocks (handles multiple duplicates)
   awk '
-    /^# Version selector configuration$/ { in_versions=1; next }
-    in_versions && /^\[\[params\.versions\]\]/ { in_block=1; next }
-    in_versions && in_block && /^(version|url) *=/ { next }
-    in_versions && in_block && /^$/ { in_block=0; next }
-    in_versions && !in_block && (/^#/ || /^\[/) { in_versions=0 }
-    !in_versions || (!in_block && !/^\[\[params\.versions\]\]/)
+    /^\[\[params\.versions\]\]/ { in_block=1; next }
+    in_block && /^[[:space:]]*(version|url) *=/ { next }
+    in_block && /^[[:space:]]*$/ { next }
+    in_block && (/^\[/ || /^[a-zA-Z]/) { in_block=0 }
+    !in_block
   ' $INSTALL_DIR/config.toml > $INSTALL_DIR/config.toml.tmp
   mv $INSTALL_DIR/config.toml.tmp $INSTALL_DIR/config.toml
 fi


### PR DESCRIPTION
## Problem
The website navigation was showing duplicate 'Release' menu items because the `[[params.versions]]` configuration was being duplicated in config.toml.

## Root Cause
The previous awk logic in installer.sh for removing `[[params.versions]]` blocks was not robust enough to handle multiple duplicate entries. Each run of the installer would add another set of version entries without properly removing the old ones.

## Solution
- Added explicit `sed` command to remove the comment header
- Simplified and improved the `awk` logic to handle ALL `[[params.versions]]` blocks, regardless of duplicates
- Made the removal idempotent (safe to run multiple times)

## Testing
- Tested with existing config.toml containing 12 duplicate entries (2 sets × 6 versions)
- After fix: correctly reduced to 6 entries (1 set × 6 versions)
- Re-ran the logic multiple times to verify idempotency
- Verified no duplicate 'Release' menu items

## Impact
Fixes the duplicate Release dropdown entries in the website navigation menu.