### PR TITLE
fix(installer): Disable printview redirects to enable Print entire section feature

### DIFF
--- a/docsystem/installer-sitebuild.sh
+++ b/docsystem/installer-sitebuild.sh
@@ -164,11 +164,12 @@ server {
     rewrite ^/docs-v5/(.*)/images/(.+\.(png|jpg|jpeg|gif|svg|webp|ico))\$ /docs-v5/images/\$2 permanent;
     rewrite ^/docs/images/(.+)\$ /docs-v4/images/\$1 permanent;
     
-    # Nested printview redirects
-    rewrite ^/printview/docs-v3/(.*)\$ /docs-v3/\$1 permanent;
-    rewrite ^/printview/docs-v4/(.*)\$ /docs-v4/\$1 permanent;
-    rewrite ^/printview/docs-v5/(.*)\$ /docs-v5/\$1 permanent;
-    rewrite ^/printview/(.*)\$ /docs-v5/\$1 permanent;
+    # Nested printview redirects - DISABLED to enable print functionality
+    # These redirects were preventing the "Print entire section" feature from working
+    # rewrite ^/printview/docs-v3/(.*)\$ /docs-v3/\$1 permanent;
+    # rewrite ^/printview/docs-v4/(.*)\$ /docs-v4/\$1 permanent;
+    # rewrite ^/printview/docs-v5/(.*)\$ /docs-v5/\$1 permanent;
+    # rewrite ^/printview/(.*)\$ /docs-v5/\$1 permanent;
     
     # Legacy HTML .md extension removal
     rewrite ^(/assets/files/html/.*)\\.md\$ \$1 permanent;


### PR DESCRIPTION
Fixes the 'Print entire section' functionality by commenting out nginx rewrite rules that were redirecting /printview/* URLs to regular documentation pages.

## Problem
The nginx configuration was redirecting all /printview/* URLs to regular docs pages, breaking the 'Print entire section' functionality in the right sidebar menu.

## Solution
Commented out the four rewrite rules that were preventing access to Hugo-generated print pages:
- /printview/docs-v3/* → now serves print pages
- /printview/docs-v4/* → now serves print pages  
- /printview/docs-v5/* → now serves print pages

## Testing
Tested on https://192.168.225.159/docs-v5/ - Print entire section links now work correctly and return HTTP 200 OK instead of 301 redirects.

## Files Changed
- docsystem/installer-sitebuild.sh (11 lines, 6 insertions, 5 deletions)