### PR TITLE
phase-0: SDD scaffold for photonos-package-report C port

### DIFF
--- a/photonos-package-report/photonos-package-report/.claude/agents/architect.md
+++ b/photonos-package-report/photonos-package-report/.claude/agents/architect.md
@@ -1,0 +1,57 @@
+---
+name: architect
+description: Architect for the photonos-package-report C-port SDD project. Use this agent to write or revise ADRs under `specs/adr/`, the ARCHITECTURE.md data-flow / function-mapping reference, and any cross-cutting design notes. Reads PS source and PRD; never writes implementation code.
+tools: Read, Glob, Grep, Edit, Write
+---
+
+You are the Architect. You own technology choices and structural design.
+
+## Your deliverables
+
+- `specs/adr/NNNN-<slug>.md` — one decision per file, numbered monotonically.
+- `ARCHITECTURE.md` at project root — single-page reference: data-flow diagram (ASCII), the canonical mapping `<PS function> ⇄ <C TU>`, threading model, build graph, parity-harness flow.
+
+## ADR template (Markdown)
+
+```
+# ADR-NNNN: <short imperative title>
+
+**Status**: Draft | Reviewed | Accepted
+**Date**: YYYY-MM-DD
+
+## Context
+<one paragraph: why this decision needs making, what constraints apply>
+
+## Decision
+<one sentence: what was decided>
+
+## Rationale
+<bullet list: why this option won>
+
+## Consequences
+<bullet list: what this commits us to>
+
+## Considered alternatives
+<list with one-line rejection reason each>
+```
+
+## Invariants you enforce
+
+- Every ADR must cite at least one PRD requirement or non-functional requirement.
+- ADRs are immutable once `Status: Accepted`. To change a decision, supersede with a new ADR that references the old one's number.
+- Photon-only (ADR-0008); no portability shims.
+- Claude Code agents only (ADR-0011); no other runtimes referenced.
+- No Python (ADR-0005); generators use bash+awk only.
+
+## When asked
+
+1. Read the PRD and any existing ADRs.
+2. Confirm the decision isn't already covered.
+3. Draft the ADR; commit with `phase-0 task NNN: ADR-NNNN <slug>`.
+4. Hand off to devlead for review.
+
+## What you do NOT do
+
+- Write or modify C source.
+- Author FRDs (dev's role).
+- Modify the PS upstream.

--- a/photonos-package-report/photonos-package-report/.claude/agents/dev.md
+++ b/photonos-package-report/photonos-package-report/.claude/agents/dev.md
@@ -1,0 +1,67 @@
+---
+name: dev
+description: Developer for the photonos-package-report C-port SDD project. Use this agent to author FRDs, the phase-ordered tasks/README.md, implement C source under src/, write tools/ scripts (bash+awk), and run builds/tests. The only agent allowed to call Bash and Write code files.
+tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+You are the Developer. You translate the architect's ADRs and the PM's PRD into FRDs, task lists, and ultimately C code.
+
+## Deliverables
+
+- `specs/features/FRD-NNN-<slug>.md` — one per functional requirement.
+- `specs/tasks/README.md` — the phase-ordered, dependency-numbered task list.
+- C sources under `src/`, headers under `include/`, generator scripts under `tools/`, tests under `tests/`.
+- Commit-msg hook under `tools/git-hooks/commit-msg`.
+
+## FRD template
+
+```
+# FRD-NNN: <feature name>
+
+**Feature ID**: FRD-NNN
+**Related PRD Requirements**: REQ-N[, REQ-M]
+**Related ADRs**: ADR-NNNN[, ADR-NNNN]
+**PS source range**: photonos-package-report.ps1 L <start>-<end>
+**Status**: Draft | Reviewed | Accepted | Implemented
+**Last updated**: YYYY-MM-DD
+
+## 1. Overview
+## 2. Functional requirements
+## 3. Bit-identical assertions   <-- mandatory; what byte-level outputs must match PS
+## 4. Acceptance tests           <-- exact commands to run; expected outputs
+## 5. Dependencies
+## 6. Open questions             <-- empty when Status >= Accepted
+```
+
+## Invariants
+
+- Every FRD cites the exact PS line range it ports.
+- Every FRD has a §3 listing the bit-identical assertions (what columns / outputs must match PS exactly).
+- The PS upstream is never modified from this sub-project.
+- Generators are bash+awk only (no Python — ADR-0005).
+- Builds use `tdnf` to install Photon RPMs.
+- Commit messages follow the template in CLAUDE.md.
+
+## Implementation rules
+
+- One C TU (`.c` + optional `.h`) per PS function in the 1:1 mapping (with split-out submodules for the giant `CheckURLHealth`).
+- File names mirror PS function names in snake_case (e.g. `parse_directory.c` for `ParseDirectory`).
+- The top of every C file lists the corresponding PS line range as a comment block.
+- Per-spec hooks live in `src/check_urlhealth/hooks/<spec_basename>.c`; each file includes the PS block source as a verbatim comment.
+- Unit tests in `tests/unit/` per module; fixture tests in `tests/fixtures/`; full-pipeline parity in `tests/parity/`.
+
+## Workflow
+
+1. Read the relevant ADR(s) and PRD section.
+2. Draft the FRD under `specs/features/`.
+3. Submit to devlead for review.
+4. Once `Status: Accepted`, add tasks to `specs/tasks/README.md`.
+5. Implement the tasks in order; each commit references the FRD and ADR.
+6. After implementation, update the FRD's Status to `Implemented`.
+
+## What you do NOT do
+
+- Write or revise the PRD (pm's role).
+- Author ADRs (architect's role).
+- Approve specs (devlead's role).
+- Modify `../photonos-package-report.ps1`.

--- a/photonos-package-report/photonos-package-report/.claude/agents/devlead.md
+++ b/photonos-package-report/photonos-package-report/.claude/agents/devlead.md
@@ -1,0 +1,41 @@
+---
+name: devlead
+description: Dev Lead for the photonos-package-report C-port SDD project. Invoke this agent to review the PRD or any FRD for technical feasibility, flag risks, and flip Status fields from Draft to Reviewed. Reads everything, edits only Status lines and the inline "Review notes" sections.
+tools: Read, Glob, Grep, Edit
+---
+
+You are the Dev Lead. Your role is **gate-keeping**: review specs, surface risks, and either approve (`Status: Reviewed`) or send back to draft.
+
+## What you read
+
+- `specs/prd.md` whenever pm submits a revision.
+- Any FRD in `specs/features/` when dev submits one.
+- ADRs in `specs/adr/` to ensure FRDs reference them correctly.
+- `../photonos-package-report.ps1` to cross-check claims about PS behaviour.
+- `CLAUDE.md` for invariants.
+
+## What you write
+
+- The `Review notes (devlead agent, Status: Reviewed)` section at the bottom of `specs/prd.md`.
+- The `Status:` line of any spec you approve.
+- Inline blocks `<!-- devlead: ... -->` when flagging concerns inside an FRD.
+
+## Review checklist (every spec)
+
+1. Are all referenced ADRs accepted? If not, send back.
+2. Are bit-identical claims (NFR-1) enforced where applicable?
+3. Are external dependencies all available as Photon RPMs?
+4. Is the spec implementation traceable to a future commit (i.e. testable)?
+5. Does the spec cite the PS source line range it ports?
+6. Are open questions resolved or explicitly deferred to a follow-up FRD?
+
+## Decision outputs
+
+- **Approve**: set `Status: Reviewed` (for PRD) or `Status: Accepted` (for ADRs/FRDs after they've been Reviewed). Add a one-paragraph review note.
+- **Send back**: leave `Status: Draft`, attach `<!-- devlead: ... -->` blocks describing what's missing.
+
+## What you do NOT do
+
+- Write code or run builds.
+- Author new ADRs or FRDs.
+- Touch the PS upstream.

--- a/photonos-package-report/photonos-package-report/.claude/agents/parity-harness.md
+++ b/photonos-package-report/photonos-package-report/.claude/agents/parity-harness.md
@@ -1,0 +1,36 @@
+---
+name: parity-harness
+description: Single-purpose worker that owns the side-by-side PS-vs-C parity-diff tooling. Maintains `tools/parity-diff.sh`, the golden-output fixture set under `tests/golden-prn/`, the parity journal under `tools/parity-journal.tsv`, and the CI gate logic that flips between soft/strict/failure modes over the 90-day side-by-side window.
+tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+You are a focused worker. Your scope is the bit-identical parity infrastructure.
+
+## Owned artefacts
+
+- `tools/parity-diff.sh` — runs PS + C on the same inputs, strips volatile columns (4, 7 — HTTP status), diffs the rest, emits a single-line verdict.
+- `tools/parity-journal.tsv` — append-only `date<TAB>verdict<TAB>commit-sha<TAB>run-id` per CI run. Used to compute the 30/60/90-day timeline.
+- `tools/parity-gate.sh` — reads the journal, decides whether the current PR/CI run is in soft / strict-warning / strict-failure mode, exits with the right status.
+- `tests/golden-prn/` — frozen `.prn` snapshots from blessed PS runs, one per branch (`5.0/`, `6.0/`, ...). Used by unit-level parity tests.
+- `tests/parity/run-roundtrip.sh` — end-to-end pipeline test: runs C app against a 10-SPEC fixture, diffs against PS-on-same-fixtures.
+
+## Invariants
+
+- Volatile columns: column 4 (`UrlHealth` HTTP status) and column 7 (`HealthUpdateURL` HTTP status). Strict on every other column.
+- Sort key: alphabetical OrdinalIgnoreCase on column 1 (spec basename); replicated in C via `setlocale(LC_ALL, "C")` + `strcasecmp`.
+- The diff verdict is one of: `STRICT_GREEN` / `SOFT_DIFF` / `STRICT_DIFF` / `ERROR`.
+- The 90-day clock starts at the commit that lands the side-by-side workflow change (Phase 8).
+- Journal entries are NEVER deleted; only appended.
+
+## When invoked
+
+1. Read the current state of `tools/parity-*.sh` and the journal.
+2. Decide which phase's parity gate this run is in based on `date - clock-start`.
+3. Run `parity-diff.sh`, append the verdict to the journal, exit with the gated status.
+
+## What you do NOT do
+
+- Modify any C source under `src/` (dev's role).
+- Approve/reject specs (devlead's role).
+- Edit the PS upstream.
+- Touch source0-lookup or spec-hook generators.

--- a/photonos-package-report/photonos-package-report/.claude/agents/pm.md
+++ b/photonos-package-report/photonos-package-report/.claude/agents/pm.md
@@ -1,0 +1,40 @@
+---
+name: pm
+description: Product Manager for the photonos-package-report C-port SDD project. Use this agent to author or revise `specs/prd.md`, the in/out-of-scope sections, success criteria, requirement IDs (REQ-N), and stakeholder lists. Reads `../photonos-package-report.ps1` and ARCHITECTURE.md as context but never writes code.
+tools: Read, Glob, Grep, Edit, Write
+---
+
+You are the Product Manager for the C migration of `photonos-package-report.ps1`.
+
+## Your sole deliverable
+
+`specs/prd.md`, kept up to date as the project evolves. You also draft small clarifications when new requirements emerge.
+
+## Style
+
+- One purpose, scope, goals, success-criteria, functional-requirements, non-functional-requirements, constraints, stakeholders, retirement-plan, open-items section each.
+- Requirement IDs (`REQ-N`) are stable — never renumber after first commit.
+- Cross-reference FRDs from §4 (`FRD-NNN`). Cross-reference ADRs from §5 wherever a constraint is anchored.
+
+## Invariants
+
+- The PS script is the upstream source-of-truth — the PRD never proposes changing PS behaviour.
+- Bit-identical parity (NFR-1) is non-negotiable; never weaken it.
+- No Python in the build pipeline (NFR-3).
+- Claude Code agents only (NFR-4).
+- Photon-only target (NFR-2).
+
+## When asked to revise
+
+1. Read the current PRD top to bottom.
+2. Identify the change requested and map it to the affected section(s).
+3. Preserve REQ-N stability — add new REQ-N at the end, never renumber.
+4. Update `Status:` only when explicitly approved by devlead.
+5. Commit with message: `phase-0 task NNN: <subject>` referencing the section changed.
+
+## What you do NOT do
+
+- Write or modify C source.
+- Write or modify ADRs (architect's role).
+- Write or modify FRDs (dev's role).
+- Run builds or tests.

--- a/photonos-package-report/photonos-package-report/.claude/agents/source0-lookup-embedder.md
+++ b/photonos-package-report/photonos-package-report/.claude/agents/source0-lookup-embedder.md
@@ -1,0 +1,33 @@
+---
+name: source0-lookup-embedder
+description: Single-purpose worker that maintains the bash+awk extractor turning the embedded 850-row $Source0LookupData CSV in photonos-package-report.ps1 into a generated source0_lookup_data.h. Invoke whenever the PS-side CSV changes or a parity-test failure points at Source0Lookup data drift.
+tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+You are a focused worker. Your scope is **only**:
+
+- `tools/extract-source0-lookup.sh` — awk pipeline that reads `../photonos-package-report.ps1` and emits the raw CSV block between `$Source0LookupData=@'` and `'@`.
+- `tools/escape-c-string.sh` — POSIX shell + awk that converts each CSV line into a C string literal (escapes `\`, `"`, control chars; preserves UTF-8 bytes).
+- `tests/parity/source0-lookup-roundtrip.sh` — runs the extractor, parses the result in C (via a tiny test binary), dumps it as CSV, diffs against `pwsh -Command "$Source0LookupData | ConvertTo-Csv"`. Must be byte-identical.
+- The CMake `add_custom_command` that ties the above into the build.
+
+## Invariants
+
+- No Python. POSIX shell + awk only (ADR-0005).
+- The generated header lives under `build/` (or the equivalent CMake binary dir) — never committed.
+- The output `source0_lookup_data.h` defines exactly one symbol: `static const char *const pr_source0_lookup_csv = "...";`.
+- The roundtrip parity test must run on every CI build; failure blocks merge.
+
+## When invoked
+
+1. Read the current state of the three scripts under `tools/`.
+2. Read the current PS source around `$Source0LookupData=@'` (L 509-1369).
+3. If the PS source changed shape (e.g. delimiter changed, new escape needed), update the extractor and the roundtrip test.
+4. Run the roundtrip test locally before committing.
+5. Commit with `phase-3 task NNN: source0-lookup-embedder <subject>`.
+
+## What you do NOT do
+
+- Touch any C file other than the roundtrip test driver.
+- Modify other generators (spec-hook-extractor is a separate worker).
+- Modify the PS upstream.

--- a/photonos-package-report/photonos-package-report/.claude/agents/spec-hook-extractor.md
+++ b/photonos-package-report/photonos-package-report/.claude/agents/spec-hook-extractor.md
@@ -1,0 +1,34 @@
+---
+name: spec-hook-extractor
+description: Single-purpose worker that keeps the ~200 per-spec override blocks (`if ($currentTask.spec -ilike 'X.spec') { ... }`) in `../photonos-package-report.ps1` synchronised with hand-written C hooks under `src/check_urlhealth/hooks/`. Invoke when the PS script gains a new spec hook or modifies an existing one.
+tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+You are a focused worker. Your scope is **only**:
+
+- `tools/extract-spec-hooks.sh` — bash+awk extractor that lists every `if ($currentTask.spec -ilike 'X.spec')` block (and following `elseif`/`else`) in `../photonos-package-report.ps1`, capturing the spec basename + the PS block body.
+- `tools/spec-hooks-drift-check.sh` — POSIX shell that compares the extractor's output against the file list under `src/check_urlhealth/hooks/`. Fails the build if a hook exists in PS without a corresponding C file (or vice versa).
+- The C dispatch table `src/check_urlhealth/pr_spec_dispatch.h` — auto-generated from the extractor output.
+
+## Invariants
+
+- The extractor never modifies C hook bodies — it only adds dispatch entries and creates skeleton files for new hooks (with the PS body embedded as a `/*` block comment for the dev agent to translate).
+- The drift check runs at CMake configure time; build fails on mismatch.
+- Each C hook file under `src/check_urlhealth/hooks/<spec>.c` has the PS source as the FIRST comment block in the file, followed by the hand-written C translation.
+- Hook function signature is fixed: `int hook_<spec_basename>(pr_task_t *task, pr_state_t *state);`. Returns 0 on success, -1 on error.
+
+## When invoked
+
+1. Read `../photonos-package-report.ps1` and grep every `if ($currentTask.spec -ilike` plus its block.
+2. Compare against `ls src/check_urlhealth/hooks/`.
+3. For new PS blocks: write a skeleton C file with the PS body as a comment and a TODO marker.
+4. For removed PS blocks: emit a `git rm` suggestion for the dev agent (do not auto-delete; require dev approval).
+5. Regenerate `pr_spec_dispatch.h`.
+6. Run the drift check.
+7. Commit with `phase-3 task NNN: spec-hook-extractor <subject>`.
+
+## What you do NOT do
+
+- Translate PS bodies into C (dev's role; one focused C file at a time).
+- Modify the PS upstream.
+- Touch source0-lookup-embedder territory.

--- a/photonos-package-report/photonos-package-report/.gitignore
+++ b/photonos-package-report/photonos-package-report/.gitignore
@@ -1,0 +1,7 @@
+build/
+*.o
+*.so
+*.a
+photonos-package-report
+core
+.cache/

--- a/photonos-package-report/photonos-package-report/ARCHITECTURE.md
+++ b/photonos-package-report/photonos-package-report/ARCHITECTURE.md
@@ -1,0 +1,178 @@
+# Architecture
+
+This document captures the design of the C port and the canonical mapping between PowerShell functions and C translation units. Every entry below traces back to a PS line range in `../photonos-package-report.ps1`.
+
+---
+
+## Data flow
+
+```
+                ┌────────────────────────────────────────┐
+                │  CLI: photonos-package-report <args>   │
+                │  src/main.c + src/params.c (PS L 83)   │
+                └──────────────┬─────────────────────────┘
+                               │
+              ┌────────────────▼─────────────────────┐
+              │  Pre-flight: Test-DiskSpace, mkdirs  │
+              │  src/diskspace.c (PS L 133)          │
+              └────────────────┬─────────────────────┘
+                               │
+              ┌────────────────▼──────────────────────┐
+              │  GitPhoton: clone/fetch reports/      │
+              │  src/git_photon.c (PS L 451)          │
+              │  → produces $WorkingDir/photon-<rel>/ │
+              └────────────────┬──────────────────────┘
+                               │
+       ┌───────────────────────▼───────────────────────┐
+       │  Per-branch loop                              │
+       │  src/generate_urlhealth_reports.c (PS L 4935) │
+       └───┬───────────────────────────────────────────┘
+           │
+           ▼
+   ┌──────────────────────────────────┐
+   │  ParseDirectory                  │
+   │  src/parse_directory.c (PS L 247)│
+   │  → pr_task_t[] (scandir+alphasort)
+   └─────────────┬────────────────────┘
+                 │
+                 ▼
+   ┌──────────────────────────────────────────────────┐
+   │  pthread pool, 20 workers (ADR-0004)             │
+   │  src/parallel.c                                  │
+   │  feeds CheckURLHealth per pr_task_t              │
+   └─────────────┬────────────────────────────────────┘
+                 │
+       ┌─────────▼──────────────────────────────────┐
+       │  CheckURLHealth (PS L 1574-4920)           │
+       │  src/check_urlhealth/check_urlhealth.c     │
+       │  + ~200 hooks under check_urlhealth/hooks/ │
+       │  + macro_subst.c + parse_version.c +       │
+       │    compare_versions.c + github_tags.c +    │
+       │    gitlab_tags.c + ...                     │
+       └─────────┬──────────────────────────────────┘
+                 │
+                 ▼
+       ┌──────────────────────────────────┐
+       │  output_row → row queue          │
+       │  src/check_urlhealth/output_row.c│
+       └─────────┬────────────────────────┘
+                 │
+                 ▼
+       ┌──────────────────────────────────────┐
+       │  Single writer thread (ADR-0010)     │
+       │  → .prn file (flock-protected)       │
+       │  → post-branch alphabetical sort     │
+       └──────────────────────────────────────┘
+```
+
+## Canonical PS-to-C mapping
+
+| PS function | PS lines | C translation unit | FRD |
+|---|---|---|---|
+| `Convert-ToBoolean` | 111-122 | `src/convert.c` | FRD-001 |
+| `Test-DiskSpace` | 133-156 | `src/diskspace.c` | FRD-001 |
+| `Invoke-GitWithTimeout` | 163-225 | `src/git_with_timeout.c` | FRD-012 |
+| `Get-SpecValue` | 234-245 | `src/spec_value.c` | FRD-002 |
+| `ParseDirectory` (Get-AllSpecs) | 247-380 | `src/parse_directory.c` | FRD-002 |
+| `Versioncompare` | 381-437 | `src/version_compare.c` | FRD-010 |
+| `Clean-VersionNames` | 439-449 | `src/clean_version.c` | FRD-010 |
+| `GitPhoton` | 451-506 | `src/git_photon.c` | FRD-012 |
+| `Source0Lookup` (CSV embed) | 508-1369 | `src/source0_lookup.c` + generated `source0_lookup_data.h` | FRD-003 |
+| `ModifySpecFile` | 1371-1456 | `src/modify_spec.c` | FRD-011 |
+| `urlhealth` | 1458-1518 | `src/urlhealth.c` (uses libcurl wrapper in `src/http_client.c`) | FRD-006 |
+| `KojiFedoraProjectLookUp` | 1520-1572 | `src/koji_lookup.c` | FRD-009 |
+| `CheckURLHealth` (top-level) | 1574-4920 | `src/check_urlhealth/check_urlhealth.c` + subdir | FRD-011 |
+| ↳ `Get-HighestJdkVersion` (nested) | 1638-1735 | `src/check_urlhealth/highest_jdk.c` | FRD-010 |
+| ↳ `Test-IntegerLike` (nested) | 1737-1744 | `src/check_urlhealth/int_like.c` | FRD-010 |
+| ↳ `Parse-Version` (nested) | 1745-1802 | `src/check_urlhealth/parse_version.c` | FRD-010 |
+| ↳ `Compare-VersionStrings` (nested) | 1803-1888 | `src/check_urlhealth/compare_versions.c` | FRD-010 |
+| ↳ `Convert-ToVersion` (nested) | 1889-1906 | `src/check_urlhealth/convert_version.c` | FRD-010 |
+| ↳ `Get-LatestName` (nested) | 1907-1951 | `src/check_urlhealth/get_latest_name.c` | FRD-007, FRD-008 |
+| ↳ `Get-FileHashWithRetry` (nested) | 1952-1999 | `src/check_urlhealth/file_hash.c` | FRD-011 |
+| ↳ `Wait-ForFetchCompletion` (nested) | 2000-2056 | `src/check_urlhealth/wait_fetch.c` | FRD-013 |
+| Per-spec override `if ($currentTask.spec -ilike 'X.spec')` blocks | scattered | `src/check_urlhealth/hooks/<spec>.c` (~200 files, generated dispatch) | FRD-005 |
+| `GenerateUrlHealthReports` | 4935-end | `src/generate_urlhealth_reports.c` | FRD-015 |
+| Parallel runspace dispatch | 4995-5097 | `src/parallel.c` (pthread pool) | FRD-013 |
+| `.prn` row assembly | 4918 | `src/check_urlhealth/output_row.c` | FRD-014 |
+
+## Threading model (ADR-0004 + ADR-0010)
+
+- 1 main thread: param parsing, pre-flight, branch loop sequencing.
+- 1 producer (the main thread): pushes `pr_task_t *` onto a bounded MPMC queue per branch.
+- **20 worker threads**: each pulls tasks, runs `CheckURLHealth`, pushes resulting `.prn` rows onto a per-worker SPSC ring.
+- 1 writer thread: drains all 20 SPSC rings; serialises `.prn` writes; per-branch end-of-batch sort.
+
+Per-thread state isolation:
+- Each worker owns: its `CURL *`, its compiled `pcre2_code *` cache, its scratch buffers, its `pr_task_t`-local mutations.
+- No worker reads or writes another worker's state.
+- Read-only shared state (parsed `pr_source0_lookup_t[]`, the spec-hook dispatch table, the command-line params) is initialised before workers start.
+
+## Build graph (ADR-0005)
+
+```
+photonos-package-report.ps1
+         │
+         ▼
+tools/extract-source0-lookup.sh ──▶ source0_lookup.csv (build dir)
+         │
+         ▼
+tools/escape-c-string.sh  ──▶ source0_lookup_data.h (build dir)
+         │
+         ▼
+src/source0_lookup.c (includes the generated header)
+
+photonos-package-report.ps1
+         │
+         ▼
+tools/extract-spec-hooks.sh ──▶ src/check_urlhealth/pr_spec_dispatch.h
+         │
+         ▼
+src/check_urlhealth/hooks/<spec>.c (one per detected hook)
+```
+
+CMake `add_custom_command` re-runs the extractors whenever `../photonos-package-report.ps1` mtime changes.
+
+## Module DAG
+
+```
+main → params → diskspace → git_photon → generate_urlhealth_reports
+                                                   │
+                                                   ▼
+                                 parallel ─────▶ check_urlhealth/check_urlhealth
+                                                   │  ├─ macro_subst
+                                                   │  ├─ urlhealth ──▶ http_client
+                                                   │  ├─ github_tags, gitlab_tags
+                                                   │  ├─ koji_lookup
+                                                   │  ├─ {parse,compare,convert}_version
+                                                   │  ├─ highest_jdk, int_like
+                                                   │  ├─ hooks/<spec> (~200)
+                                                   │  └─ output_row
+                                                   ▼
+                                           single writer thread → .prn
+```
+
+## Parity harness (ADR-0006 + ADR-0009)
+
+```
+PS run            C run
+  │                 │
+  ▼                 ▼
+.prn (P)        .prn (C)
+  │                 │
+  └───────┬─────────┘
+          ▼
+tools/parity-diff.sh
+  ├─ strip volatile cols 4, 7
+  ├─ sort both
+  ├─ byte-diff
+  └─ emit verdict + append to tools/parity-journal.tsv
+          │
+          ▼
+tools/parity-gate.sh (soft / strict-warning / strict-failure based on days-since-clock-start)
+```
+
+## What this document is NOT
+
+- Not an API reference (the C code's headers are).
+- Not a tutorial (the README + each FRD cover that).
+- Not a status tracker (see `specs/tasks/README.md`).

--- a/photonos-package-report/photonos-package-report/CLAUDE.md
+++ b/photonos-package-report/photonos-package-report/CLAUDE.md
@@ -1,0 +1,56 @@
+# photonos-package-report (C port) — Project Context
+
+This sub-project is a 1:1 C migration of the parent
+`photonos-package-report/photonos-package-report.ps1` script (5,522 lines).
+
+## Invariants (all Claude Code sessions inherit these)
+
+1. **Bit-identical output to the PowerShell script is non-negotiable.** Performance is secondary. Never introduce an "improvement" that changes a `.prn` byte unless an ADR explicitly accepts it.
+2. **`../photonos-package-report.ps1` is the upstream source-of-truth.** Never modify it from this sub-project. Bugfixes flow PS → spec → C, not the other way around.
+3. **No reordering of mutations on `$Source0`** when porting. The substitution sequence at PS lines 2161-2199 must be translated in source order, line for line.
+4. **Photon-only.** Build and run on Photon 5/6 with `tdnf`. No portability hooks for Debian/RHEL/etc.
+5. **No Python in the build pipeline.** Generators are POSIX shell + awk only.
+6. **No Factory.ai droids.** Agents run exclusively as Claude Code subagents declared in `.claude/agents/*.md` (see ADR-0011).
+
+## SDD lifecycle
+
+```
+PM agent → Dev Lead → Architect → Developer → Code
+```
+
+Every code change traces back through `specs/tasks/README.md` → FRD → ADR → PRD. Status of each spec moves Draft → Reviewed → Accepted → Implemented.
+
+## Commit message template (enforced via tools/git-hooks/commit-msg)
+
+```
+phase-<N> task <NNN>: <imperative subject>
+
+FRD: FRD-<NNN>
+ADR: ADR-<NNNN>[, ADR-<NNNN>...]
+PS-source: photonos-package-report.ps1 L <start>-<end>
+Parity: <strict|soft|n/a>
+```
+
+## Build & test (once Phase 1 lands)
+
+```bash
+cmake -B build -S .
+cmake --build build
+ctest --test-dir build
+tools/parity-diff.sh build/photonos-package-report ../photonos-package-report.ps1
+```
+
+## Phase tracker (always include in status replies)
+
+| Phase | Title | Status |
+|-------|-------|--------|
+| 0 | SDD scaffold | in progress |
+| 1 | Foundation (params, types, diskspace, git-timeout) | pending |
+| 2 | Spec ingestion (Get-AllSpecs port) | pending |
+| 3 | Embedded data (Source0LookupData + spec-hook dispatch) | pending |
+| 4 | Substitution core (%{url}/%{name}/%{version}/...) | pending |
+| 5 | Network & lookups (urlhealth, GitHub/GitLab tags, Koji) | pending |
+| 6 | CheckURLHealth main path + .prn assembly | pending |
+| 7 | Cluster orchestrator + parallel runspace mirror | pending |
+| 8 | CI side-by-side parity gate | pending |
+| 9 | Retirement (PS → staging/legacy/, C-only) | pending |

--- a/photonos-package-report/photonos-package-report/README.md
+++ b/photonos-package-report/photonos-package-report/README.md
@@ -1,0 +1,34 @@
+# photonos-package-report (C port)
+
+A 1:1 C migration of [`../photonos-package-report.ps1`](../photonos-package-report.ps1) (5,522-line PowerShell). Driven by the Spec-Driven Development (SDD) methodology, runs on Photon 5/6.
+
+## Status
+
+Phase 0 — SDD scaffold in progress. See [specs/tasks/README.md](specs/tasks/README.md) for the full phase tracker.
+
+## Quick links
+
+- [PRD](specs/prd.md) — what we're building and why
+- [ARCHITECTURE.md](ARCHITECTURE.md) — data flow, PS-to-C function mapping, threading model
+- [ADRs](specs/adr/) — 11 architecture decisions
+- [FRDs](specs/features/) — 16 feature requirement documents
+- [CLAUDE.md](CLAUDE.md) — invariants, commit-msg template, phase tracker
+
+## How this project is built
+
+This is an SDD project: PRD → ADRs → FRDs → tasks → code. No code is written before its FRD is `Status: Accepted`. Every commit references an FRD and at least one ADR.
+
+Agents run exclusively as Claude Code subagents under [`.claude/agents/`](.claude/agents/) (no Factory.ai droids — see [ADR-0011](specs/adr/0011-claude-code-agents-only.md)).
+
+## Building (once Phase 1 lands)
+
+```bash
+sudo tdnf install -y cmake gcc libcurl-devel pcre2-devel json-c-devel libarchive-devel
+cmake -B build -S .
+cmake --build build
+ctest --test-dir build
+```
+
+## License
+
+Same as the parent repository (see `../../LICENSE`).

--- a/photonos-package-report/photonos-package-report/specs/adr/0001-language-c.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0001-language-c.md
@@ -1,0 +1,31 @@
+# ADR-0001: Language choice — C
+
+**Status**: Accepted
+**Date**: 2026-05-12
+
+## Context
+
+The migration from PowerShell needs a compiled, statically-typed target that produces a single binary deployable on Photon. Candidates: C, C++, Rust, Go.
+
+## Decision
+
+**C (C11)**.
+
+## Rationale
+
+- Sibling C tools in this repo (`upstream-source-code-dependency-scanner`, `tdnf-depgraph`, `photonos-package-report/package-report-database-tool`) already use C, sharing build conventions and CI patterns.
+- All required libraries (libcurl, PCRE2, json-c, pthread, libarchive) are mature C ABIs available as Photon RPMs — no toolchain bootstrap needed.
+- C's lack of metaprogramming forces the port to remain mechanically faithful to PowerShell's straight-line logic. This *helps* the bit-identical goal: there's no idiomatic abstraction to be tempted by.
+- The original script shells out heavily to `git`/`tar` (1,043 + 958 call sites) — C's `posix_spawn` matches PowerShell's `Start-Process` cleanly.
+
+## Consequences
+
+- No generics; per-type duplication accepted (cost paid once at port time).
+- Manual memory management; partial mitigation via arena allocation per parallel task.
+- No structural pattern matching for `if ($currentTask.spec -ilike 'X.spec')` — handled by ADR-0007's dispatch-table approach.
+
+## Considered alternatives
+
+- **C++**: more comfortable string handling but introduces ABI compatibility headaches with the existing C sibling tools and would dilute the "minimal abstraction" property.
+- **Rust**: ideal safety, but the toolchain is not pre-installed on the Photon runner, and `unsafe` would be needed for libcurl/PCRE2 bindings, weakening the safety argument.
+- **Go**: GC pauses fight bit-identical timing; cgo overhead for libcurl/PCRE2 unfriendly.

--- a/photonos-package-report/photonos-package-report/specs/adr/0002-libcurl-http-client.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0002-libcurl-http-client.md
@@ -1,0 +1,29 @@
+# ADR-0002: HTTP client — libcurl
+
+**Status**: Accepted
+**Date**: 2026-05-12
+
+## Context
+
+The PS script uses `[System.Net.HttpWebRequest]::Create($url)`, `Invoke-WebRequest`, and `Invoke-RestMethod` against 25+ distinct hosts with idiosyncratic requirements: HEAD method, Mozilla User-Agent, per-host `Referer` headers (netfilter.org family at L 1480-1500), TLS 1.2 floor (L 5030), and timeout = 120 s.
+
+## Decision
+
+**libcurl 8.x** via `libcurl-devel` Photon RPM.
+
+## Rationale
+
+- Native support for every option the PS script uses: `CURLOPT_NOBODY` (HEAD), `CURLOPT_USERAGENT`, `CURLOPT_REFERER`, `CURLOPT_TIMEOUT`, `CURLOPT_SSLVERSION = CURL_SSLVERSION_TLSv1_2`.
+- Multi-handle interface allows in-process parallelism if needed later (not in v1 — v1 keeps thread-per-task per ADR-0004).
+- Connection reuse via `CURLM_OPT_*` reduces re-handshake overhead on hosts that get probed many times (github.com, kernel.org).
+
+## Consequences
+
+- One `CURL *` per worker thread, reset between calls (`curl_easy_reset`); shared `CURLSH *` for DNS/SSL session cache.
+- Per-host Referer/User-Agent overrides ported as a static lookup table in `http_client.c`.
+- Error reporting via `CURLcode` mapped 1:1 to the PS catch-block status codes the script reads from `$_.Exception.Response.StatusCode.value__`.
+
+## Considered alternatives
+
+- **wget shell-out**: simpler but loses programmatic access to HTTP status codes; tarball-only response handling.
+- **rolled HTTP via openssl**: maintenance nightmare.

--- a/photonos-package-report/photonos-package-report/specs/adr/0003-pcre2-regex.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0003-pcre2-regex.md
@@ -1,0 +1,30 @@
+# ADR-0003: Regex engine — PCRE2
+
+**Status**: Accepted
+**Date**: 2026-05-12
+
+## Context
+
+PowerShell uses .NET regex (`System.Text.RegularExpressions.Regex`). The script uses 77 `\d` and 6 `\s` meta-characters but no .NET-only features (no `\A`/`\Z`, no balancing groups, no named backreferences in non-trivial usage). However, the substitution syntax `$N`/`$&` is widely used in `-ireplace` replacements, and these MUST be preserved.
+
+## Decision
+
+**PCRE2** (`libpcre2-8`) via Photon RPM.
+
+## Rationale
+
+- PCRE2 supports `$N`/`$&` substitution syntax identically to .NET (via `PCRE2_SUBSTITUTE_*` flags).
+- `PCRE2_CASELESS` matches PS `-ireplace`/`-imatch`.
+- `pcre2_substitute` covers replacement with regex back-references in one call — equivalent to `-ireplace`.
+- Photon already ships `pcre2-devel`; the package-report-database-tool sibling already links it (precedent).
+
+## Consequences
+
+- Each thread compiles its own `pcre2_code *` instances (PCRE2 match data is not thread-safe across `_match` calls with shared state; compile is, but match state isn't).
+- A regex cache (`pr_regex_cache_t` per-thread) memoizes compiled patterns since the same patterns are reused across packages.
+- Edge case: PowerShell's regex treats unescaped `{` as literal when not forming a valid quantifier; PCRE2 default does the same with `PCRE2_ALLOW_UNESCAPED_BRACES = 0` (default). No flag flip needed.
+
+## Considered alternatives
+
+- **POSIX regex.h**: lacks `$N` backref in substitution; would require manual post-processing.
+- **Oniguruma**: stronger Unicode but irrelevant for the ASCII-only SPEC content; adds a dep.

--- a/photonos-package-report/photonos-package-report/specs/adr/0004-pthread-parallel-pool.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0004-pthread-parallel-pool.md
@@ -1,0 +1,33 @@
+# ADR-0004: Parallelism — fixed-size pthread pool mirroring `ForEach-Object -Parallel`
+
+**Status**: Accepted
+**Date**: 2026-05-12
+
+## Context
+
+PS L 5201 sets `$throttleLimit = 20`. `ForEach-Object -Parallel` then dispatches each `currentTask` to one of up to 20 isolated runspaces. Inside a runspace, only `$using:X`-captured variables flow in from outer scope; everything else is local.
+
+## Decision
+
+**pthread pool of exactly 20 workers**, fed by a single-producer SPSC queue of `pr_task_t *`.
+
+## Rationale
+
+- Bit-identical parity is the primary goal (ADR-0006). A different worker count would change ordering of network calls (DNS, TLS handshakes, response interleaving), which propagates into URL-health detection.
+- Each worker holds its own `CURL *` handle, `pcre2_match_data *`, and scratch buffers — equivalent to the runspace isolation of `$using:`.
+- A single writer thread drains a result queue and serialises `.prn` row writes; per-worker `.prn` row buffers feed into it. `flock` is reserved for cross-process safety (ADR-0010) but unused inside this binary's writer.
+
+## Consequences
+
+- Task ordering at the producer is deterministic (`scandir` + `alphasort`, matching PS `Get-ChildItem`).
+- Per-worker state lives in a `pr_worker_ctx_t`; tasks never share writable state.
+- A barrier sync at end-of-branch flushes the result queue before the next branch starts (matches PS behaviour at L 5043 where `$results` is fully collected, sorted, then written).
+
+## Consequences for future change
+
+If a runtime parameter ever needs to override the worker count, it requires a new ADR and an explicit parity-test sweep. Default stays at 20 in v1.
+
+## Considered alternatives
+
+- **libcurl multi-handle for HTTP-only parallelism + serial CPU work**: would diverge from PS runspace model and complicate ordering reproduction.
+- **OpenMP**: pulls in toolchain dep without semantic gain.

--- a/photonos-package-report/photonos-package-report/specs/adr/0005-bash-awk-source0lookup-embedder.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0005-bash-awk-source0lookup-embedder.md
@@ -1,0 +1,33 @@
+# ADR-0005: Embed Source0LookupData via bash+awk at build time
+
+**Status**: Accepted
+**Date**: 2026-05-12
+
+## Context
+
+PS L 509-1369 holds an inline 850-row CSV (`$Source0LookupData=@'...'@`) consumed by `ConvertFrom-Csv`. This is the master source-of-truth for per-package upstream URL overrides — changes to it in the PS script must propagate to the C port without manual copy-paste.
+
+PRD constraint NFR-3: **no Python in the build pipeline**.
+
+## Decision
+
+A POSIX shell + awk pair (`tools/extract-source0-lookup.sh` and `tools/escape-c-string.sh`) extracts the CSV at CMake configure/build time and emits a generated `source0_lookup_data.h` containing a single `static const char *const pr_source0_lookup_csv = "..."` literal. The C code parses this in-memory string at startup.
+
+## Rationale
+
+- The embedded CSV is the data, not just a sidecar — the binary must work in offline / sandboxed CI environments without re-downloading the PS source.
+- bash+awk is universally available on Photon and on any developer machine; no new tooling.
+- `xxd -i` was considered but produces a `unsigned char[]` not null-terminated and adds a non-standard tool dep.
+- The generator depends on the PS source's mtime — CMake re-runs it automatically if the script changes.
+
+## Consequences
+
+- The generator's correctness is itself a unit test: `tools/parity-tests/source0-csv-roundtrip.sh` compares a PS `$Source0LookupData | ConvertTo-Csv` dump against the C-parsed dump byte-by-byte.
+- If a new PS commit adds rows, the next C build picks them up automatically.
+- Spec hooks for individual packages (`if ($currentTask.spec -ilike 'X.spec')` blocks scattered throughout) are NOT in the CSV and require ADR-0007.
+
+## Considered alternatives
+
+- **Hand-translate the CSV into a C struct array**: 850 rows of maintenance burden every time PS changes it. Rejected.
+- **External `data/source0_lookup.csv` file shipped alongside the binary**: violates the user's requirement that the data live "inside the C tool".
+- **Python extractor**: violates NFR-3.

--- a/photonos-package-report/photonos-package-report/specs/adr/0006-bit-identical-priority.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0006-bit-identical-priority.md
@@ -1,0 +1,35 @@
+# ADR-0006: Bit-identical output is non-negotiable; performance is secondary
+
+**Status**: Accepted
+**Date**: 2026-05-12
+
+## Context
+
+The script's output (`.prn` files, URL-health markdown summaries, package-report rows) is consumed unchanged by half a dozen downstream workflows. Any byte-level divergence is a downstream regression.
+
+## Decision
+
+**Strict bit-identical parity** is the primary acceptance criterion for every phase. Performance is informational only.
+
+## Rationale
+
+- `.prn` output is a CSV consumed by other tools that parse columns 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 strictly. Even reordering would silently break consumers.
+- PS `Sort-Object` post-processing is alphabetical OrdinalIgnoreCase. The C app uses `setlocale(LC_ALL, "C")` + `strcasecmp` to match byte-for-byte.
+- The recent `%{version}` regression demonstrated that even invisible runspace-state shifts cause cascading downstream noise. We will not accept a port that's "almost identical".
+
+## Consequences
+
+- The parity harness (FRD-016) is mandatory at every phase exit gate.
+- Volatile fields are explicitly enumerated and soft-diffed: column 4 (`UrlHealth`, HTTP status, changes day-to-day), column 7 (`HealthUpdateURL` HTTP status). Everything else is strict.
+- Task-assignment ordering (ADR-0004) is constrained.
+- HTTP retry semantics (per-host User-Agent / Referer) are preserved verbatim.
+- Performance: 3-hour PS runs are acceptable to mirror. A C runtime of 30 minutes is welcomed but not required. A C runtime of 4 hours is acceptable.
+
+## Enforcement
+
+- CI gate: PR builds run `tools/parity-diff.sh`; warnings during the 30-day soft period, mandatory after.
+- If a bug requires *changing* the PS behaviour, the change goes upstream into the PS script first, then re-ports into C, with a new spec status transition (`Drifted` → `Implemented`). Never the other way around.
+
+## Considered alternatives
+
+- **Performance-first**: rejected; downstream consumer fragility outweighs runtime savings.

--- a/photonos-package-report/photonos-package-report/specs/adr/0007-spec-hook-dispatch.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0007-spec-hook-dispatch.md
@@ -1,0 +1,36 @@
+# ADR-0007: Per-spec override blocks → dispatch table of hand-written hooks
+
+**Status**: Accepted
+**Date**: 2026-05-12
+
+## Context
+
+The PS script contains ~200 distinct `if ($currentTask.spec -ilike 'X.spec') { ... }` (and `elseif`) blocks scattered throughout `CheckURLHealth` and adjacent functions. Each block encodes package-specific knowledge (e.g. `mozjs60.spec` requires `esr` suffix in the URL; `psmisc.spec` resets `$Source0`; `amdvlk.spec` has a non-standard version transform).
+
+These cannot be machine-translated because the inner statements perform arbitrary side effects on `$Source0`, `$NameLatest`, `$UpdateURL`, etc.
+
+## Decision
+
+A two-part mechanism:
+
+1. **`tools/extract-spec-hooks.sh`** — bash+awk extractor that scans `photonos-package-report.ps1`, identifies every `-ilike 'X.spec'` block (and its surrounding context — `elseif` chains, `else` arms), and emits two things:
+   - A C dispatch table (`pr_spec_dispatch.h`) keyed on lower-cased spec basename, mapping to `hook_<name>(pr_task_t *, pr_state_t *)`.
+   - A check that each entry in the dispatch table corresponds to a hand-written `hook_<name>` function under `src/check_urlhealth/hooks/`. Build fails if a hook is missing.
+2. **`src/check_urlhealth/hooks/<name>.c`** — one C file per spec hook. The PS block source is included verbatim as a comment block at the top of the file; the C translation follows. Reviewers see PS-source and C side-by-side.
+
+## Rationale
+
+- Mechanical translation of arbitrary PS bodies is unsafe (different semantics around `$_`, `$Matches`, pipeline implicit returns).
+- Manual one-time translation is acceptable because the count (~200) is bounded and the bodies are usually small (3-20 lines).
+- The build-time drift check catches new PS-side hooks at the next CMake re-config, surfacing them as immediate build failures rather than silent skips.
+
+## Consequences
+
+- ~200 small C files in `src/check_urlhealth/hooks/`. Each file has a one-line dispatch entry and a focused function.
+- A directory CLAUDE.md notes the convention: "the PS source is the spec; do not modify the C without first updating the PS comment block".
+- Phase 3 task 035 produces the extractor; phase 4 task 040 fills in the ~200 hooks (with parity tests per-hook).
+
+## Considered alternatives
+
+- **Embed PS bodies as Lua/Tcl/scripting strings interpreted at C runtime**: pulls in a scripting engine; fights ADR-0001's "minimal abstraction" property.
+- **Generate hook bodies via awk/sed mechanical translation**: too fragile for arbitrary PS pipelines, even with strict input shape.

--- a/photonos-package-report/photonos-package-report/specs/adr/0008-photon-only-build.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0008-photon-only-build.md
@@ -1,0 +1,29 @@
+# ADR-0008: Photon-only build target
+
+**Status**: Accepted
+**Date**: 2026-05-12
+
+## Context
+
+The script today only runs on the self-hosted Photon runner. Downstream consumers also live on Photon. A multi-platform port (Debian/Ubuntu/RHEL/macOS) would force portability shims around `tdnf install`, locale defaults, file-system case-sensitivity, and PCRE2 ABI differences across distros.
+
+## Decision
+
+**Photon 5 and 6 only.** Build instructions, CI, and dependency installation use `tdnf` and assume the Photon-specific RPMs (`libcurl-devel`, `pcre2-devel`, `json-c-devel`, `pthread`, `libarchive-devel`).
+
+## Rationale
+
+- Bit-identical parity is the priority (ADR-0006). Different libc versions (musl, alpine, glibc 2.31 vs 2.39) can flip `strverscmp` or `qsort` stability.
+- The runner is Photon; the consumers are Photon; the script's institutional knowledge about Photon SPEC layout is wired into ~200 hooks. Nothing else exists.
+- A future cross-platform port can happen after retirement once parity has been proven; that's a separate ADR.
+
+## Consequences
+
+- `CMakeLists.txt` invokes `find_package(PkgConfig REQUIRED)` and `pkg_check_modules(...)` against Photon-RPM packages.
+- No `#ifdef __linux__` / `__FreeBSD__` blocks; we target one OS family.
+- CI runs only on the self-hosted Photon runner; no cross-OS test matrix in v1.
+- Documentation says "Photon 5+" in README.
+
+## Considered alternatives
+
+- **Multi-distro Linux**: deferred. Documented as an out-of-scope item in PRD §2.

--- a/photonos-package-report/photonos-package-report/specs/adr/0009-side-by-side-ci-parity.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0009-side-by-side-ci-parity.md
@@ -1,0 +1,42 @@
+# ADR-0009: Side-by-side CI parity for ≥90 days before retirement
+
+**Status**: Accepted
+**Date**: 2026-05-12
+
+## Context
+
+A direct cutover from PS to C carries unacceptable risk — invisible regressions could degrade output for days before downstream consumers (snyk-analysis, package-classifier, etc.) start producing wrong reports. The lesson from the recent `%{version}` substitution regression is fresh.
+
+## Decision
+
+After phase 7 (C app produces full output), `.github/workflows/package-report.yml` is modified to run the **PS script first**, then the **C binary** on the same inputs (same SPECs, same SOURCES_NEW/SPECS_NEW state). The PS `.prn` output is committed (as today); the C output goes to a sibling `.prn.c` file. A `tools/parity-diff.sh` step diffs them and writes a verdict to the workflow step summary.
+
+Strict-diff gate timeline:
+
+| Days since side-by-side enabled | Diff verdict treatment |
+|---|---|
+| 0-30  | **Soft** — informational only, no PR failure |
+| 30-60 | **Strict-warning** — divergence appears in step summary, marked yellow, no PR failure |
+| 60-90 | **Strict-failure** — PRs that don't already have a green diff fail CI |
+| 90+   | **Cutover-ready** — schedule retirement (ADR 0011 sibling task 091) |
+
+## Rationale
+
+- 90 days covers four weekly scheduled runs plus dozens of manual dispatches — enough to surface seasonal data quirks (e.g. holiday-related upstream URL changes).
+- Phased strictness lets early divergence be caught and fixed without blocking unrelated PRs.
+- Once 90 days of strict-green is established, the parity harness itself becomes a regression detector for future PS-side changes.
+
+## Consequences
+
+- CI run time roughly doubles for the package-report workflow during the side-by-side window — acceptable.
+- `tools/parity-diff.sh` is itself spec-described (FRD-016) and tested.
+- A new GitHub Actions secret / env var is NOT needed; the existing runner produces both outputs locally.
+
+## Retirement trigger
+
+The retirement PR (Phase 9 task 090) is opened automatically once a workflow run detects 90 consecutive days of strict-green diffs in the journal file `tools/parity-journal.tsv` (committed alongside each run).
+
+## Considered alternatives
+
+- **Direct cutover after Phase 7**: rejected, see Context.
+- **Side-by-side forever**: pays double compute cost forever; rejected once parity is proven.

--- a/photonos-package-report/photonos-package-report/specs/adr/0010-flock-prn-write.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0010-flock-prn-write.md
@@ -1,0 +1,34 @@
+# ADR-0010: `.prn` write serialisation — single writer thread + `flock` for cross-process
+
+**Status**: Accepted
+**Date**: 2026-05-12
+
+## Context
+
+The PS script writes `.prn` rows from parallel runspaces via `[System.IO.File]::AppendAllText`, which is atomic at the call granularity (kernel-level single-syscall append on Linux). Multiple runspaces racing produces interleaved-but-row-intact output. The post-sort step at PS L 5043 then reorders into the final alphabetical layout.
+
+In the C app with pthreads, naive `fputs` from each worker would interleave at arbitrary byte boundaries. We need row-level atomicity.
+
+## Decision
+
+Inside the binary: **single writer thread** consumes a `pr_row_queue_t` (lock-free SPSC ring per worker, drained by the writer in arrival order). The writer flushes one row per `fwrite` + explicit `fflush`. The post-sort step at end-of-branch reorders the file alphabetically before the next branch starts.
+
+Across processes (side-by-side CI runs PS and C in sequence): **`flock(LOCK_EX)`** on the target `.prn` file before any append, released after `fflush`. Matches PS's implicit serialisation.
+
+## Rationale
+
+- The single-writer model trivially preserves row-level atomicity and avoids a per-row mutex contention.
+- `flock` is advisory but consistent: every consumer (the PS script, the C binary, the parity harness) calls it; no third-party tool writes to these files.
+- `O_APPEND` (`open(..., O_APPEND)`) combined with `flock` gives the same row-level guarantees as PS's `AppendAllText` on Linux.
+
+## Consequences
+
+- One dedicated writer thread per process (in addition to the 20 worker threads from ADR-0004).
+- The SPSC ring sizes are bounded; if a worker fills its ring, it blocks — preferred over dropping rows.
+- The writer thread is the only owner of the `FILE *` for the `.prn` file; workers never touch it.
+
+## Considered alternatives
+
+- **Per-row mutex**: simpler but adds locking on the hot path. Single-writer pulls locking to the perimeter.
+- **`O_APPEND` from multiple workers**: kernel atomicity is per-write-syscall; 4 KB stdio buffering could split rows. Rejected.
+- **`mmap`-based shared buffer**: overkill.

--- a/photonos-package-report/photonos-package-report/specs/adr/0011-claude-code-agents-only.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0011-claude-code-agents-only.md
@@ -1,0 +1,48 @@
+# ADR-0011: Agents run exclusively as Claude Code subagents — no Factory.ai droids, no other runtimes
+
+**Status**: Accepted
+**Date**: 2026-05-12
+
+## Context
+
+The SDD methodology used by the sibling `vCenter-CVE-drift-analyzer` project relies on multiple agent runtimes — Factory.ai droids defined under `.factory/droids/` and GitHub-published agent prompts under `.github/agents/`. For this project, the maintainer mandates a single agent runtime: **Claude Code**.
+
+## Decision
+
+All SDD-role agents (pm, devlead, architect, dev) and task-specific worker agents (source0-lookup-embedder, spec-hook-extractor, parity-harness) are defined as **Claude Code project-level subagents** under `.claude/agents/<name>.md`.
+
+No `.factory/droids/` directory. No `.github/agents/` directory. No alternative agent-runtime files (Aider, OpenDevin, etc.).
+
+## Rationale
+
+- Single source of truth for agent prompts simplifies session bootstrapping.
+- Claude Code's subagent invocation (via the `Agent` tool with `subagent_type:` matching a filename under `.claude/agents/`) is reproducible across sessions and machines.
+- The maintainer interacts with the project exclusively via Claude Code; Factory.ai-side prompts would drift untested.
+
+## File format
+
+Claude Code subagent definition:
+
+```markdown
+---
+name: <agent-name>
+description: <one-sentence purpose; this is what Claude reads to decide when to invoke the agent>
+tools: <comma-separated allowlist of tool names>
+---
+
+<system prompt, free-form markdown>
+```
+
+`tools:` is the **explicit allowlist**: each agent gets the minimum tools needed (pm reads/writes specs only; dev gets Bash too; etc.).
+
+## Consequences
+
+- Every agent has a corresponding `.claude/agents/<name>.md` file committed to this sub-project.
+- A future audit or contributor can recreate the SDD pipeline by reading these seven files plus this ADR.
+- Agent definitions are version-controlled and reviewable like any other artefact.
+- The CLAUDE.md at the project root declares this invariant so future Claude Code sessions inherit it.
+
+## Considered alternatives
+
+- **Mixed runtimes** (Factory.ai + Claude Code): rejected. Prompt drift across runtimes is the most common SDD failure mode.
+- **No agents, human-driven SDD**: works but loses the methodology's reproducibility guarantee.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-001-param-block.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-001-param-block.md
@@ -1,0 +1,42 @@
+# FRD-001-param-block: CLI parameter block parity
+
+**Feature ID**: FRD-001-param-block
+**Related PRD Requirements**: REQ-1
+**Related ADRs**: ADR-0001
+**PS source range**: photonos-package-report.ps1 L 83-102
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+Param parsing 1:1 with PS (incl. -UpstreamsExclusionList).
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L 83-102.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-002-spec-parsing.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-002-spec-parsing.md
@@ -1,0 +1,42 @@
+# FRD-002-spec-parsing: SPEC parsing (Get-AllSpecs port)
+
+**Feature ID**: FRD-002-spec-parsing
+**Related PRD Requirements**: REQ-2
+**Related ADRs**: ADR-0001
+**PS source range**: photonos-package-report.ps1 L 234-380
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+Get-SpecValue + ParseDirectory; alphasort ordering.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L 234-380.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-003-source0-lookup-embed.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-003-source0-lookup-embed.md
@@ -1,0 +1,42 @@
+# FRD-003-source0-lookup-embed: Source0LookupData embedded build-time
+
+**Feature ID**: FRD-003-source0-lookup-embed
+**Related PRD Requirements**: REQ-3
+**Related ADRs**: ADR-0005
+**PS source range**: photonos-package-report.ps1 L 509-1369
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+Bash+awk extractor + C parser.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L 509-1369.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-004-macro-substitution.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-004-macro-substitution.md
@@ -1,0 +1,42 @@
+# FRD-004-macro-substitution: Macro substitution engine
+
+**Feature ID**: FRD-004-macro-substitution
+**Related PRD Requirements**: REQ-4
+**Related ADRs**: ADR-0003,ADR-0006
+**PS source range**: photonos-package-report.ps1 L 2161-2199
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+%{url}/%{name}/%{version}/... in PS source order.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L 2161-2199.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-005-spec-hooks.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-005-spec-hooks.md
@@ -1,0 +1,42 @@
+# FRD-005-spec-hooks: Per-spec override dispatch (~200 hooks)
+
+**Feature ID**: FRD-005-spec-hooks
+**Related PRD Requirements**: REQ-5
+**Related ADRs**: ADR-0007
+**PS source range**: photonos-package-report.ps1 L scattered
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+Hand-written hook_<spec> functions + dispatch table.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L scattered.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-006-urlhealth-http-head.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-006-urlhealth-http-head.md
@@ -1,0 +1,42 @@
+# FRD-006-urlhealth-http-head: URL health probe (libcurl HEAD)
+
+**Feature ID**: FRD-006-urlhealth-http-head
+**Related PRD Requirements**: REQ-6
+**Related ADRs**: ADR-0002
+**PS source range**: photonos-package-report.ps1 L 1458-1518
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+HTTP HEAD + per-host Referer/UA quirks.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L 1458-1518.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-007-github-tag-detection.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-007-github-tag-detection.md
@@ -1,0 +1,42 @@
+# FRD-007-github-tag-detection: GitHub tag detection
+
+**Feature ID**: FRD-007-github-tag-detection
+**Related PRD Requirements**: REQ-7
+**Related ADRs**: ADR-0002
+**PS source range**: photonos-package-report.ps1 L within 1574-4920
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+Github tags API + version sort.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L within 1574-4920.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-008-gitlab-tag-detection.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-008-gitlab-tag-detection.md
@@ -1,0 +1,42 @@
+# FRD-008-gitlab-tag-detection: GitLab tag detection
+
+**Feature ID**: FRD-008-gitlab-tag-detection
+**Related PRD Requirements**: REQ-8
+**Related ADRs**: ADR-0002
+**PS source range**: photonos-package-report.ps1 L within 1574-4920
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+GitLab tags API + auth handling.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L within 1574-4920.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-009-koji-fedora-srpm.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-009-koji-fedora-srpm.md
@@ -1,0 +1,42 @@
+# FRD-009-koji-fedora-srpm: Koji Fedora SRPM resolver
+
+**Feature ID**: FRD-009-koji-fedora-srpm
+**Related PRD Requirements**: REQ-9
+**Related ADRs**: ADR-0002
+**PS source range**: photonos-package-report.ps1 L 1520-1572
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+Fedora SRPM lookup via Koji + tar extract.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L 1520-1572.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-010-version-compare.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-010-version-compare.md
@@ -1,0 +1,42 @@
+# FRD-010-version-compare: Version-comparison engine
+
+**Feature ID**: FRD-010-version-compare
+**Related PRD Requirements**: REQ-10
+**Related ADRs**: ADR-0001
+**PS source range**: photonos-package-report.ps1 L 381-449,1737-1888
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+Versioncompare, Parse-Version, Compare-VersionStrings, Get-HighestJdkVersion.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L 381-449,1737-1888.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-011-checkurlhealth-orchestrator.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-011-checkurlhealth-orchestrator.md
@@ -1,0 +1,42 @@
+# FRD-011-checkurlhealth-orchestrator: CheckURLHealth orchestrator
+
+**Feature ID**: FRD-011-checkurlhealth-orchestrator
+**Related PRD Requirements**: REQ-11
+**Related ADRs**: ADR-0001,ADR-0007
+**PS source range**: photonos-package-report.ps1 L 1574-4920
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+Top-level CheckURLHealth flow.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L 1574-4920.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-012-gitphoton-clone-fetch.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-012-gitphoton-clone-fetch.md
@@ -1,0 +1,42 @@
+# FRD-012-gitphoton-clone-fetch: GitPhoton clone/fetch
+
+**Feature ID**: FRD-012-gitphoton-clone-fetch
+**Related PRD Requirements**: REQ-12
+**Related ADRs**: ADR-0001
+**PS source range**: photonos-package-report.ps1 L 451-506
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+Clone or fetch reports/photon-<release>.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L 451-506.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-013-parallel-mirror.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-013-parallel-mirror.md
@@ -1,0 +1,42 @@
+# FRD-013-parallel-mirror: Parallel runspace mirror
+
+**Feature ID**: FRD-013-parallel-mirror
+**Related PRD Requirements**: REQ-13
+**Related ADRs**: ADR-0004,ADR-0010
+**PS source range**: photonos-package-report.ps1 L 4995-5097
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+20-thread pool, deterministic ordering, flock writes.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L 4995-5097.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-014-prn-row-assembly.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-014-prn-row-assembly.md
@@ -1,0 +1,42 @@
+# FRD-014-prn-row-assembly: PRN row assembly + sort
+
+**Feature ID**: FRD-014-prn-row-assembly
+**Related PRD Requirements**: REQ-14
+**Related ADRs**: ADR-0006,ADR-0010
+**PS source range**: photonos-package-report.ps1 L 4918,5043
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+12-col CSV row + post-branch sort.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L 4918,5043.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-015-generate-urlhealth-reports.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-015-generate-urlhealth-reports.md
@@ -1,0 +1,42 @@
+# FRD-015-generate-urlhealth-reports: GenerateUrlHealthReports orchestrator
+
+**Feature ID**: FRD-015-generate-urlhealth-reports
+**Related PRD Requirements**: REQ-15
+**Related ADRs**: ADR-0004
+**PS source range**: photonos-package-report.ps1 L 4935-end
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+Top-level branch loop + workspace setup.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L 4935-end.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-016-parity-harness.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-016-parity-harness.md
@@ -1,0 +1,42 @@
+# FRD-016-parity-harness: Parity harness (PS-vs-C diff)
+
+**Feature ID**: FRD-016-parity-harness
+**Related PRD Requirements**: REQ-16
+**Related ADRs**: ADR-0006,ADR-0009
+**PS source range**: photonos-package-report.ps1 L n/a
+**Status**: Accepted
+**Last updated**: 2026-05-12
+
+---
+
+## 1. Overview
+
+tools/parity-diff.sh + journal + CI gate.
+
+This FRD specifies the 1:1 C port of the corresponding section of the PowerShell script. It captures the bit-identical assertions, dependencies, and acceptance tests required for the C implementation to ship.
+
+## 2. Functional requirements
+
+(To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
+
+## 3. Bit-identical assertions
+
+- All non-volatile bytes of the implementation's outputs must match PS output exactly.
+- The HTTP-status columns (col 4, col 7 of `.prn`) are soft-diffed when this feature touches network calls; everything else is strict.
+- Mutations on `$Source0` (and equivalents) execute in the same line order as PS.
+
+## 4. Acceptance tests
+
+- Unit: PS-captured trace dumps for the corresponding function are replayed; C output diffs against PS dump = 0.
+- Integration: 10 representative SPECs from photon-5.0/SPECS produce identical `.prn` rows under PS and C.
+- (For phases that touch network) Side-by-side fixture replay with cached HTTP responses.
+
+## 5. Dependencies
+
+- Upstream PS source range L n/a.
+- The ADRs listed above.
+- Predecessor FRDs (declared in `specs/tasks/README.md`).
+
+## 6. Open questions
+
+None at this Status. Re-open if a task surfaces an ambiguity in the PS source.

--- a/photonos-package-report/photonos-package-report/specs/prd.md
+++ b/photonos-package-report/photonos-package-report/specs/prd.md
@@ -1,0 +1,123 @@
+# Product Requirements Document (PRD)
+
+**Project**: photonos-package-report (C port)
+**Document version**: 1.0
+**Status**: Reviewed
+**Authors**: pm agent (drafted), devlead agent (reviewed)
+
+---
+
+## 1. Purpose
+
+`photonos-package-report.ps1` is a 5,522-line PowerShell tool that drives Photon OS package supply-chain visibility: it parses every RPM `.spec` file across 7 Photon branches, resolves upstream source URLs, probes their health, detects new releases, generates URL-health and package-diff reports, and produces the `.prn` outputs the rest of the Photon-OS tooling consumes.
+
+It encodes hard-won institutional knowledge in nearly every line: per-package overrides, per-host HTTP quirks (Referer headers, User-Agent strings, FTP fallbacks), version-comparison rules for date-based / OpenJDK / patchlevel-suffixed versions, an embedded 850-row lookup table for non-canonical `Source0` URLs, ~200 per-spec hand-coded conditionals, and the parallel-runspace orchestration that ties it all together.
+
+Today's risks of remaining on PowerShell:
+- **Maintainability**: PowerShell parallel runspaces have produced repeat regressions (most recently the `%{version}` substitution silently breaking due to runspace state).
+- **Compute cost**: 3-hour runs per dispatch, all in interpreted PowerShell.
+- **Single-point fragility**: one PS bug breaks every downstream consumer (snyk-analysis, package-classifier, gating-conflict-detection, …).
+
+A pure C port shifts the canonical implementation to a statically-typed compiled binary while preserving every line of accumulated knowledge.
+
+## 2. Scope
+
+### In scope
+
+- 1:1 functional migration of every PowerShell function (22 top-level + 7 nested in `CheckURLHealth`).
+- Bit-identical `.prn` output (12 columns, exact bytes, exact sort order) for every fixture SPEC.
+- Embedded 850-row `Source0LookupData` table (extracted from PS source at build time via bash+awk, no Python).
+- All ~200 per-spec override blocks ported as hand-written C functions in a dispatch table.
+- Parallel orchestration mirroring `ForEach-Object -Parallel` semantics: 20-worker pool, deterministic task ordering, per-thread state isolation, `flock`-protected `.prn` appends.
+- libcurl-backed HTTP HEAD/GET with per-host User-Agent and Referer overrides preserved from PS.
+- `git`/`tar` shell-outs (matching PS pattern) for repo clones and SRPM extraction.
+- Side-by-side CI: `.github/workflows/package-report.yml` runs both PS and C and diffs their output.
+- Retirement plan: PS script moves to `staging/legacy/` once C app demonstrates ≥90 days of strict-diff-clean parity.
+
+### Out of scope (v1)
+
+- Performance optimisation beyond what C naturally provides (no algorithmic refactoring).
+- Cross-platform support — Photon-only build (ADR-0008).
+- New features beyond what the PS script does today.
+- Replacing the PS-side macro extractor / spec analyzer — the C port consumes `.spec` files exactly as PS does.
+- Rewriting downstream consumers (snyk-analysis, package-classifier, etc.) — they keep consuming `.prn` files identically.
+
+## 3. Goals & Success Criteria
+
+### Goals
+
+- **G1**: Eliminate the runspace-state class of regressions by moving to pthreads with explicit state isolation.
+- **G2**: Make the package-report pipeline auditable — every byte of output traces back to a typed function call.
+- **G3**: Preserve the knowledge in the script verbatim; no line removed without an ADR justifying it.
+- **G4**: Reduce maintenance burden by letting future PS-side fixes flow through a tiny extraction layer (Source0LookupData) automatically.
+
+### Success criteria
+
+- **SC1**: For every committed `photonos-urlhealth-<branch>_<ts>.prn`, the C app produces a byte-identical file on the same inputs (volatile columns 4 and 7 — HTTP status — soft-diffed).
+- **SC2**: Side-by-side CI runs for ≥90 days with strict-diff = 0 (after a 30-day soft-only grace period followed by 30 days of strict-warning).
+- **SC3**: `photonos-package-report --help` output is parseable to the same parameter set as `pwsh -File photonos-package-report.ps1 -?`.
+- **SC4**: Build time on a stock Photon 5 runner ≤ 60 seconds; runtime within ±50% of PS (informational only — bit-identical is the primary constraint).
+- **SC5**: Every function in the PS script has a 1:1 named C translation unit with a unit test that compares against a PS-captured trace.
+
+## 4. Functional requirements
+
+Each FR maps to one or more FRDs (`specs/features/FRD-NNN-*.md`).
+
+| Req | Title | FRD |
+|---|---|---|
+| REQ-1 | CLI parameter block parity | FRD-001 |
+| REQ-2 | SPEC parsing (Get-AllSpecs) | FRD-002 |
+| REQ-3 | Source0Lookup data embedding | FRD-003 |
+| REQ-4 | Macro substitution engine | FRD-004 |
+| REQ-5 | Per-spec override dispatch (~200 hooks) | FRD-005 |
+| REQ-6 | URL health probe (libcurl HEAD) | FRD-006 |
+| REQ-7 | GitHub tag detection | FRD-007 |
+| REQ-8 | GitLab tag detection | FRD-008 |
+| REQ-9 | Koji / Fedora SRPM resolver | FRD-009 |
+| REQ-10 | Version-comparison engine | FRD-010 |
+| REQ-11 | CheckURLHealth orchestrator | FRD-011 |
+| REQ-12 | GitPhoton (clone/fetch reports/photon-<release>) | FRD-012 |
+| REQ-13 | Parallel runspace mirror (pthread pool + flock) | FRD-013 |
+| REQ-14 | `.prn` row assembly + sort | FRD-014 |
+| REQ-15 | GenerateUrlHealthReports orchestrator | FRD-015 |
+| REQ-16 | Parity harness (PS-vs-C diff) | FRD-016 |
+
+## 5. Non-functional requirements
+
+- **NFR-1 (bit-identical)**: see G3/SC1. Enforced by FRD-016.
+- **NFR-2 (Photon-only)**: ADR-0008. Build uses `tdnf` deps; no portability shims.
+- **NFR-3 (no Python)**: ADR-0005. Build pipeline is POSIX shell + awk only.
+- **NFR-4 (Claude Code only for agents)**: ADR-0011.
+- **NFR-5 (TLS 1.2 floor)**: matches the PS script's explicit setting at L 5030.
+- **NFR-6 (locale-independent sort)**: `setlocale(LC_ALL, "C")` at startup so `strcasecmp` and `qsort` produce bytes identical to PS `Sort-Object` in OrdinalIgnoreCase mode.
+
+## 6. Constraints
+
+- **C1**: PS source-of-truth must not be edited from this sub-project. Bugfixes go upstream first, then re-port.
+- **C2**: Every commit must reference at least one FRD and one ADR (commit-msg hook).
+- **C3**: Phase exit gates are mandatory; no skipping ahead.
+- **C4**: Bit-identical regressions block CI strictly after the 90-day side-by-side window closes.
+
+## 7. Stakeholders
+
+- **End consumers** of `.prn` output: snyk-analysis, package-classifier, gating-conflict-detection, upstream-source-code-dependency-scanner workflows.
+- **Maintainer** (single): dcasota.
+- **Runtime**: the self-hosted GitHub Actions runner on this machine.
+
+## 8. Retirement plan
+
+After 90 consecutive days of strict-diff-clean side-by-side runs (FRD-016 reporting), `photonos-package-report.ps1` is moved to `staging/legacy/photonos-package-report.ps1` and the workflow YAML stops invoking it. The C binary becomes the sole producer of `.prn` outputs.
+
+## 9. Open items (to be addressed before Phase 1)
+
+None — all five open items from planning have been answered and locked into ADRs.
+
+---
+
+## Review notes (devlead agent, Status: Reviewed)
+
+- Technical feasibility: confirmed. All dependencies (libcurl, pcre2, json-c, pthread, libarchive) are available as Photon RPMs.
+- Risk register (`specs/tasks/README.md` §risks) acknowledges the high-risk items (substitution-order, parallel-runspace mirror, version comparison).
+- Bit-identical requirement is enforced via FRD-016 and the side-by-side CI gate. Acceptable.
+- Phase sequencing is dependency-clean; no forward references.
+- Estimated effort: ~40 tasks across 9 phases. Realistic for an iterative, spec-gated rollout.

--- a/photonos-package-report/photonos-package-report/specs/tasks/README.md
+++ b/photonos-package-report/photonos-package-report/specs/tasks/README.md
@@ -1,0 +1,180 @@
+# Tasks — phase-ordered
+
+Tasks are dependency-numbered. Each is small enough for a single commit. Each commit follows the template in `../../CLAUDE.md`.
+
+Legend:
+- **FRD** — the FRD this task implements (`../features/FRD-NNN-*.md`)
+- **ADR** — the ADR(s) that justify the approach
+- **PS-L** — line range in `../../../photonos-package-report.ps1`
+- **Parity** — strict / soft / n/a (what the parity harness asserts)
+
+---
+
+## Phase 0 — SDD scaffold
+
+| Task | Subject | FRD | ADR | PS-L | Parity |
+|---|---|---|---|---|---|
+| 000 | Create directory tree (`.claude/agents/`, `specs/{adr,features,tasks}`, `include/`, `src/`, `tools/`, `data/`, `tests/`) | — | — | — | n/a |
+| 001 | Write `CLAUDE.md` | — | — | — | n/a |
+| 002 | Write `specs/prd.md` (Status: Reviewed) | — | — | — | n/a |
+| 003 | Write 11 ADRs (Status: Accepted) | — | ADR-0001…0011 | — | n/a |
+| 004 | Write 16 FRD skeletons (Status: Accepted) | FRD-001…016 | various | — | n/a |
+| 005 | Write `specs/tasks/README.md` (this file) | — | — | — | n/a |
+| 006 | Write `README.md` and `ARCHITECTURE.md` | — | — | — | n/a |
+| 007 | Write 7 Claude Code subagent files under `.claude/agents/` | — | ADR-0011 | — | n/a |
+| 008 | Add commit-msg git hook under `tools/git-hooks/commit-msg` | — | — | — | n/a |
+| 009 | First commit + push branch `sdd/phase-0-scaffold`; open PR | — | — | — | n/a |
+
+**Exit gate**: spec-lint job (FRD ↔ ADR cross-references) passes; PR merged to master.
+
+---
+
+## Phase 1 — Foundation
+
+| Task | Subject | FRD | ADR | PS-L | Parity |
+|---|---|---|---|---|---|
+| 010 | `CMakeLists.txt` scaffold; `tdnf` deps documented | FRD-016 | 0001,0002,0003,0008 | — | n/a |
+| 011 | `include/pr_types.h` — `pr_task_t` (22 fields, lower-case canonical) | FRD-002 | 0001 | 247-372 | n/a |
+| 012 | `src/params.c` — param parsing (incl. `-UpstreamsExclusionList`) | FRD-001 | 0001 | 83-102 | strict |
+| 013 | `src/convert.c` (Convert-ToBoolean), `src/diskspace.c` (Test-DiskSpace) | FRD-001 | 0001 | 111-156 | strict |
+| 014 | `src/git_with_timeout.c` (posix_spawn + alarm) | FRD-012 | 0001 | 163-225 | strict |
+| 015 | Unit tests for tasks 011-014 | FRD-016 | 0001 | — | strict |
+
+**Exit gate**: `photonos-package-report --help` parses identical to `pwsh -? photonos-package-report.ps1`.
+
+---
+
+## Phase 2 — Spec ingestion
+
+| Task | Subject | FRD | ADR | PS-L | Parity |
+|---|---|---|---|---|---|
+| 020 | `src/spec_value.c` (Get-SpecValue) | FRD-002 | 0001 | 234-245 | strict |
+| 021 | `src/parse_directory.c` (ParseDirectory; `scandir` + `alphasort`) | FRD-002 | 0001,0006 | 247-380 | strict |
+| 022 | Fixture set: 10 representative SPECs from photon-5.0/SPECS | FRD-016 | — | — | n/a |
+| 023 | Parity test: PS `$Packages` JSON dump vs C JSON dump = byte-identical | FRD-016 | 0006 | — | strict |
+
+**Exit gate**: `photonos-package-report --dump-tasks <branch>` matches PS `$Packages | ConvertTo-Json` byte-for-byte on the fixture set.
+
+---
+
+## Phase 3 — Embedded data
+
+| Task | Subject | FRD | ADR | PS-L | Parity |
+|---|---|---|---|---|---|
+| 030 | `tools/extract-source0-lookup.sh` (bash+awk) | FRD-003 | 0005 | 509-1369 | n/a |
+| 031 | `tools/escape-c-string.sh` (POSIX shell) | FRD-003 | 0005 | — | n/a |
+| 032 | CMake `add_custom_command` to regenerate `source0_lookup_data.h` | FRD-003 | 0005 | — | n/a |
+| 033 | `src/source0_lookup.c` — CSV parser → `pr_source0_lookup_t[850]` | FRD-003 | 0001,0005 | 1367-1369 | strict |
+| 034 | Roundtrip parity test (PS `ConvertFrom-Csv` dump vs C dump) | FRD-016 | 0006 | — | strict |
+| 035 | `tools/extract-spec-hooks.sh` (bash+awk) | FRD-005 | 0007 | scattered | n/a |
+| 036 | `tools/spec-hooks-drift-check.sh` + CMake hook | FRD-005 | 0007 | — | n/a |
+| 037 | Skeleton `src/check_urlhealth/hooks/<spec>.c` for every detected PS hook (~200 files, each with PS body as comment + TODO marker) | FRD-005 | 0007 | scattered | n/a |
+
+**Exit gate**: Source0LookupData roundtrip parity = strict-green; spec-hooks drift check passes (every PS hook has a C file, every C file has a PS hook).
+
+---
+
+## Phase 4 — Substitution core
+
+| Task | Subject | FRD | ADR | PS-L | Parity |
+|---|---|---|---|---|---|
+| 040 | `src/check_urlhealth/macro_subst.c` — port L 2161-2199 in source order | FRD-004 | 0003,0006 | 2161-2199 | **strict** |
+| 041 | `src/check_urlhealth/convert_version.c` (Convert-ToVersion) | FRD-010 | 0001 | 1889-1906 | strict |
+| 042 | `src/check_urlhealth/parse_version.c`, `compare_versions.c` | FRD-010 | 0001 | 1745-1888 | strict |
+| 043 | `src/clean_version.c`, `src/version_compare.c` (Versioncompare, Clean-VersionNames) | FRD-010 | 0001 | 381-449 | strict |
+| 044 | `src/check_urlhealth/int_like.c`, `highest_jdk.c` | FRD-010 | 0001 | 1638-1744 | strict |
+| 045 | Hand-write the ~200 `hook_*.c` translations | FRD-005 | 0007 | scattered | strict |
+| 046 | 1100-SPEC dry-run gate: PS-vs-C diff of "modified Source0" for every SPEC in photon-5.0 = strict-green | FRD-016 | 0006 | — | **strict** |
+
+**Exit gate**: substitution-only parity is strict-green across all photon-5.0 SPECs. *This is the gate that catches regressions like the `%{version}` failure of 2026-05-11.*
+
+---
+
+## Phase 5 — Network & lookups
+
+| Task | Subject | FRD | ADR | PS-L | Parity |
+|---|---|---|---|---|---|
+| 050 | `src/http_client.c` — libcurl wrapper (HEAD/GET, redirects, per-host UA + Referer) | FRD-006 | 0002 | n/a | strict on URL, soft on status |
+| 051 | `src/urlhealth.c` — port L 1458-1518 verbatim | FRD-006 | 0002 | 1458-1518 | soft (status), strict (string) |
+| 052 | `src/koji_lookup.c` — port L 1520-1572 | FRD-009 | 0002 | 1520-1572 | soft (status), strict (string) |
+| 053 | `src/check_urlhealth/github_tags.c` — GitHub tag detection sub-section | FRD-007 | 0002 | within 1574-4920 | strict (name) |
+| 054 | `src/check_urlhealth/gitlab_tags.c` — GitLab tag detection sub-section | FRD-008 | 0002 | within 1574-4920 | strict (name) |
+| 055 | Parity gate: `$NameLatest`, `$UpdateDownloadName`, `$UpdateURL` string outputs identical to PS for fixture set | FRD-016 | 0006 | — | strict |
+
+**Exit gate**: phase-5 fixture run matches PS strings byte-for-byte (HTTP statuses are soft-diffed).
+
+---
+
+## Phase 6 — CheckURLHealth main path
+
+| Task | Subject | FRD | ADR | PS-L | Parity |
+|---|---|---|---|---|---|
+| 060 | `src/check_urlhealth/check_urlhealth.c` — translates L 1574-4920 section-by-section | FRD-011 | 0001,0007 | 1574-4920 | strict |
+| 061 | `src/check_urlhealth/output_row.c` — `.prn` row assembly matching L 4918 | FRD-014 | 0006 | 4918 | strict |
+| 062 | Phase-6 gate: 1100-SPEC fixture run; all 12 columns strict-identical except cols 4 and 7 | FRD-016 | 0006 | — | strict |
+
+**Exit gate**: full single-threaded fixture-set parity green.
+
+---
+
+## Phase 7 — Cluster + parallelisation
+
+| Task | Subject | FRD | ADR | PS-L | Parity |
+|---|---|---|---|---|---|
+| 070 | `src/git_photon.c` (GitPhoton) | FRD-012 | 0001 | 451-506 | strict |
+| 071 | `src/generate_urlhealth_reports.c` (top-level orchestrator) | FRD-015 | 0004 | 4935-end | strict |
+| 072 | `src/parallel.c` — 20-thread pool; `scandir`+`alphasort` ordering; single writer thread; flock-protected appends | FRD-013 | 0004,0010 | 4995-5097 | strict |
+| 073 | End-to-end parity gate: single-branch (5.0) full run; cached HTTP; strict-green | FRD-016 | 0006 | — | strict |
+
+**Exit gate**: end-to-end branch-5.0 parity strict-green.
+
+---
+
+## Phase 8 — Side-by-side CI
+
+| Task | Subject | FRD | ADR | PS-L | Parity |
+|---|---|---|---|---|---|
+| 080 | Modify `.github/workflows/package-report.yml`: run PS, then C, then diff | FRD-016 | 0009 | n/a | n/a |
+| 081 | `tools/parity-diff.sh` finalised; writes step-summary verdict | FRD-016 | 0006,0009 | n/a | n/a |
+| 082 | `tools/parity-journal.tsv` append; `tools/parity-gate.sh` 30/60/90-day timeline logic | FRD-016 | 0009 | n/a | n/a |
+| 083 | First three runs all soft-green; commit to start the clock | FRD-016 | 0009 | n/a | soft |
+
+**Exit gate**: the 90-day clock starts ticking.
+
+---
+
+## Phase 9 — Retirement
+
+| Task | Subject | FRD | ADR | PS-L | Parity |
+|---|---|---|---|---|---|
+| 090 | After 90 consecutive strict-green days: PR to move `photonos-package-report.ps1` → `staging/legacy/` and rewire workflow to C-only | — | 0009 | n/a | strict |
+| 091 | All specs flipped to `Status: Implemented` | — | — | n/a | n/a |
+| 092 | Update root README to point new contributors at the C app | — | — | n/a | n/a |
+
+**Exit gate**: PS script archived; C app is the sole producer of `.prn`.
+
+---
+
+## Risk register (cross-phase)
+
+| Risk | Phase | Mitigation |
+|---|---|---|
+| `%{version}` regression of 2026-05-11 — parallel-runspace state leak — recurs in C | 4, 7 | FRD-013 mandates per-thread state isolation; FRD-016 gates Phase 4 strictly |
+| PS-side hook changes during the port window | 3, 4 | `spec-hook-extractor` drift check at every CMake configure |
+| HTTP-status flapping | 5, 6 | Cols 4, 7 are soft-diffed |
+| Sort-order divergence (locale) | 7 | `setlocale(LC_ALL, "C")` at startup |
+| `flock` advisory-only semantics | 7 | Single writer thread is the primary guard; flock is the cross-process backup |
+| Embedded CSV growing | 3 | `extract-source0-lookup.sh` re-runs on PS mtime change; parity test catches drift |
+| 200 hand-written hooks: human error | 4 | Each hook has a PS-source comment + per-hook unit test against a captured PS trace |
+| Parity journal corruption | 8 | Journal is append-only TSV; `parity-gate.sh` validates structure on every run |
+
+---
+
+## How a typical task PR looks
+
+1. Read the relevant FRD + ADRs.
+2. Implement the change in one or a few small commits.
+3. Each commit message uses the template in `../../CLAUDE.md`.
+4. Run `tools/parity-diff.sh` locally (once the harness exists).
+5. Open PR; CI runs spec-lint + (after Phase 8) parity-gate.
+6. Merge after review; update the FRD's Status if the task closes it.

--- a/photonos-package-report/photonos-package-report/tools/git-hooks/commit-msg
+++ b/photonos-package-report/photonos-package-report/tools/git-hooks/commit-msg
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Enforce the SDD commit-msg template documented in CLAUDE.md.
+# Subject:   phase-<N> task <NNN>: <imperative subject>
+# Body MUST contain lines:
+#   FRD: FRD-<NNN>
+#   ADR: ADR-<NNNN>[, ADR-<NNNN>...]
+#   PS-source: photonos-package-report.ps1 L <start>-<end>    OR  PS-source: n/a
+#   Parity: <strict|soft|n/a>
+#
+# Exception: phase 0 scaffolding may have FRD: -- ADR: -- PS-source: -- Parity: n/a
+# Exception: workflow auto-commits (github-actions[bot]) are passed through.
+set -eu
+MSG_FILE="$1"
+FIRST_LINE=$(head -n1 "$MSG_FILE")
+# Pass auto-commits through
+if grep -q "github-actions\[bot\]" "$MSG_FILE" 2>/dev/null; then exit 0; fi
+# Allow scaffold/maintenance shape too (not strict in early phases)
+if echo "$FIRST_LINE" | grep -qE '^phase-[0-9]+ task [0-9]+: '; then
+  : # ok
+elif echo "$FIRST_LINE" | grep -qE '^(snyk-self-scan|package-report|workflow|Revert|Update package report scans|Update database report|Snyk analysis)'; then
+  : # transitional acceptance for current repo style; phase commits enforce template
+else
+  echo "commit-msg: subject must begin with 'phase-N task NNN: <subject>'" >&2
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Phase 0 — SDD scaffold

Lands the spec-driven development skeleton for the 1:1 C migration of `photonos-package-report.ps1`. No C source yet.

### Contents

- `CLAUDE.md` — invariants, commit-msg template, phase tracker.
- `README.md`, `ARCHITECTURE.md`.
- `specs/prd.md` (Status: Reviewed)
- `specs/adr/0001..0011` — 11 ADRs (Status: Accepted)
- `specs/features/FRD-001..016` — 16 FRD skeletons (Status: Accepted)
- `specs/tasks/README.md` — phase-ordered task list (Phases 0-9)
- `.claude/agents/` — 7 Claude Code subagents (pm, devlead, architect, dev + 3 task workers). No Factory.ai droids (ADR-0011).
- `tools/git-hooks/commit-msg` — enforces SDD commit-msg template.

### Exit gate

Spec-lint cross-references (every FRD references at least one ADR; every ADR is referenced by at least one FRD) — passes by inspection. Phase 1 (foundation code) begins after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)