### PR TITLE
phase-4: Source0 substitution core (PS L 2172-2199 line-for-line)

### DIFF
--- a/photonos-package-report/photonos-package-report/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/CMakeLists.txt
@@ -81,7 +81,7 @@ if(NOT _drift_rc EQUAL 0)
     endif()
 endif()
 
-# ----- Phase 1 + 2 + 3 + 3b executable ------------------------------
+# ----- Phase 1 + 2 + 3 + 3b + 4 executable --------------------------
 add_executable(photonos-package-report
     src/main.c
     src/convert.c
@@ -92,6 +92,8 @@ add_executable(photonos-package-report
     src/parse_directory.c
     src/source0_lookup.c
     src/hook_dispatch.c
+    src/strutil.c
+    src/source0_substitute.c
     ${PR_GEN_HOOK_DISPATCH}
     ${PR_HOOK_SOURCES}
 )

--- a/photonos-package-report/photonos-package-report/include/pr_strutil.h
+++ b/photonos-package-report/photonos-package-report/include/pr_strutil.h
@@ -1,0 +1,37 @@
+/* pr_strutil.h — small string helpers shared across the C port.
+ *
+ * The PS script leans heavily on three string idioms:
+ *   - `[string].Replace(a, b)`            : case-SENSITIVE literal replace
+ *   - `$s -ireplace pattern, replacement` : case-INSENSITIVE regex replace
+ *   - `$s -ilike '*needle*'`              : case-INSENSITIVE substring test
+ *
+ * For PS patterns that are always literal tokens (e.g. `%{url}`,
+ * `%{?dist}`, `%{name}`, the 15 secondary tokens), full regex is
+ * unnecessary — they translate to plain case-sensitive or case-
+ * insensitive literal replacement. Where the PS author exploited regex
+ * meta-characters (anchors, character classes, captures), we reach for
+ * PCRE2 via Get-SpecValue / dedicated callsites.
+ *
+ * Both functions below take ownership of `in` (free it), allocate a new
+ * heap string, and return it. They never return NULL on success.
+ * On allocation failure they leave `in` untouched and return NULL.
+ */
+#ifndef PR_STRUTIL_H
+#define PR_STRUTIL_H
+
+#include <stddef.h>
+
+/* PS [string]::Replace(a, b) — case-SENSITIVE literal replace of every
+ * non-overlapping occurrence of `a` with `b`. Used by ParseDirectory at
+ * PS L 270-275 to strip release-modifier tokens like `%{?dist}`. */
+char *str_replace_all(char *in, const char *a, const char *b);
+
+/* PS -ireplace LITERAL, replacement — case-INSENSITIVE literal replace
+ * of every non-overlapping occurrence of `a` with `b`. The PS operator
+ * is regex-aware, but the substitutions we port at PS L 2172-2199 use
+ * static `%{token}` patterns where the only regex meta-characters
+ * (`{`, `}`, `%`) have no quantifier semantics. Treating them as
+ * literals yields the same bytes as -ireplace would. */
+char *istr_replace_all(char *in, const char *a, const char *b);
+
+#endif /* PR_STRUTIL_H */

--- a/photonos-package-report/photonos-package-report/include/pr_substitute.h
+++ b/photonos-package-report/photonos-package-report/include/pr_substitute.h
@@ -1,0 +1,28 @@
+/* pr_substitute.h — Source0 substitution core.
+ *
+ * Ports the substitution sequence at photonos-package-report.ps1
+ * L 2172-2199 line-for-line.
+ *
+ * CLAUDE.md invariant #3: "No reordering of mutations on $Source0 when
+ * porting. The substitution sequence at PS lines 2161-2199 must be
+ * translated in source order, line for line."
+ */
+#ifndef PR_SUBSTITUTE_H
+#define PR_SUBSTITUTE_H
+
+#include "pr_types.h"
+
+/* In-place mutation of *source0 mirroring PS L 2172-2199.
+ *
+ * Inputs:
+ *   - task     : per-spec data (Name, url, and the 15 secondary tokens)
+ *   - source0  : owned heap pointer; replaced with a new heap pointer
+ *   - version  : the local $version string from PS context (NOT
+ *                task->Version, which already has -release appended)
+ *
+ * On error *source0 is left untouched and the function returns -1.
+ * On success returns 0.
+ */
+int pr_source0_substitute(pr_task_t *task, char **source0, const char *version);
+
+#endif /* PR_SUBSTITUTE_H */

--- a/photonos-package-report/photonos-package-report/src/parse_directory.c
+++ b/photonos-package-report/photonos-package-report/src/parse_directory.c
@@ -44,6 +44,7 @@
 /* _GNU_SOURCE is provided via target_compile_options(-D_GNU_SOURCE) in
  * CMakeLists.txt; do not redefine here. */
 #include "photonos_package_report.h"
+#include "pr_strutil.h"  /* str_replace_all */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -72,42 +73,10 @@ static char *xstrdup(const char *s)
 /* "" → malloc'd zero-length string. Used when PS coerces $null to "". */
 static char *empty_dup(void) { return xstrdup(""); }
 
-/* String.Replace(a,b) on a heap-allocated `in`. Frees `in`, returns new
- * heap string. Replaces ALL non-overlapping occurrences. Case-SENSITIVE
- * because PS [string]::Replace is case-sensitive (PS L 270-275 uses it). */
-static char *str_replace_all(char *in, const char *a, const char *b)
-{
-    if (in == NULL || a == NULL || a[0] == '\0') return in;
-    size_t alen = strlen(a);
-    size_t blen = b ? strlen(b) : 0;
-    /* Count occurrences. */
-    size_t count = 0;
-    for (const char *p = in; (p = strstr(p, a)) != NULL; p += alen) count++;
-    if (count == 0) return in;
-    size_t in_len  = strlen(in);
-    size_t out_len = in_len + count * (blen > alen ? blen - alen : 0)
-                            - count * (alen > blen ? alen - blen : 0);
-    char *out = (char *)malloc(out_len + 1);
-    if (!out) return in;
-    char *o = out;
-    const char *cur = in;
-    while (1) {
-        const char *hit = strstr(cur, a);
-        if (!hit) {
-            size_t tail = strlen(cur);
-            memcpy(o, cur, tail);
-            o += tail;
-            break;
-        }
-        memcpy(o, cur, (size_t)(hit - cur));
-        o += hit - cur;
-        if (blen) { memcpy(o, b, blen); o += blen; }
-        cur = hit + alen;
-    }
-    *o = '\0';
-    free(in);
-    return out;
-}
+/* str_replace_all now lives in src/strutil.c (shared with the Phase 4
+ * substitution module). Same semantics: case-SENSITIVE literal replace
+ * of every non-overlapping occurrence; frees `in` and returns a new
+ * heap pointer. */
 
 /* True iff line begins with `needle` after skipping leading spaces/tabs.
  * Used for PS `$content -ilike '*X*'` shortcut — but ilike is a SUBSTRING

--- a/photonos-package-report/photonos-package-report/src/source0_substitute.c
+++ b/photonos-package-report/photonos-package-report/src/source0_substitute.c
@@ -1,0 +1,253 @@
+/* source0_substitute.c — Source0 substitution core.
+ *
+ * 1:1 port of photonos-package-report.ps1 L 2172-2199. Order of
+ * mutations on $Source0 is preserved verbatim (CLAUDE.md invariant #3).
+ *
+ * PS source (verbatim, comments included):
+ *
+ *     if ($Source0 -ilike '*%{url}*') { $Source0 = $Source0 -ireplace '%{url}',$currentTask.url }
+ *     # add url path if necessary and possible
+ *     if (($Source0 -notlike '*//*') -and ($currentTask.url -ne ""))
+ *     {
+ *         if (($currentTask.url -match '.tar.gz$') -or ($currentTask.url -match '.tar.xz$') -or ($currentTask.url -match '.tar.bz2$') -or ($currentTask.url -match '.tgz$'))
+ *         {$Source0=$currentTask.url}
+ *         else
+ *         { $Source0 = [System.String]::Concat(($currentTask.url).Trimend('/'),$Source0) }
+ *     }
+ *     # replace variables
+ *     $Source0 = $Source0 -ireplace '%{name}',$currentTask.Name
+ *     $Source0 = $Source0 -ireplace '%{version}',$version
+ *
+ *     if ($Source0 -like '*{*')
+ *     {
+ *         if ($Source0 -ilike '*%{srcname}*')           { $Source0 = $Source0 -ireplace '%{srcname}',$currentTask.srcname }
+ *         if ($Source0 -ilike '*%{gem_name}*')          { $Source0 = $Source0 -ireplace '%{gem_name}',$currentTask.gem_name }
+ *         if ($Source0 -ilike '*%{extra_version}*')     { $Source0 = $Source0 -ireplace '%{extra_version}',$currentTask.extra_version }
+ *         if ($Source0 -ilike '*%{main_version}*')      { $Source0 = $Source0 -ireplace '%{main_version}',$currentTask.main_version }
+ *         if ($Source0 -ilike '*%{byaccdate}*')         { $Source0 = $Source0 -ireplace '%{byaccdate}',$currentTask.byaccdate }
+ *         if ($Source0 -ilike '*%{dialogsubversion}*')  { $Source0 = $Source0 -ireplace '%{dialogsubversion}',$currentTask.dialogsubversion }
+ *         if ($Source0 -ilike '*%{subversion}*')        { $Source0 = $Source0 -ireplace '%{subversion}',$currentTask.subversion }
+ *         if ($Source0 -ilike '*%{upstreamversion}*')   { $Source0 = $Source0 -ireplace '%{upstreamversion}',$currentTask.upstreamversion }
+ *         if ($Source0 -ilike '*%{libedit_release}*')   { $Source0 = $Source0 -ireplace '%{libedit_release}',$currentTask.libedit_release }
+ *         if ($Source0 -ilike '*%{libedit_version}*')   { $Source0 = $Source0 -ireplace '%{libedit_version}',$currentTask.libedit_version }
+ *         if ($Source0 -ilike '*%{ncursessubversion}*') { $Source0 = $Source0 -ireplace '%{ncursessubversion}',$currentTask.ncursessubversion }
+ *         if ($Source0 -ilike '*%{cpan_name}*')         { $Source0 = $Source0 -ireplace '%{cpan_name}',$currentTask.cpan_name }
+ *         if ($Source0 -ilike '*%{xproto_ver}*')        { $Source0 = $Source0 -ireplace '%{xproto_ver}',$currentTask.xproto_ver }
+ *         if ($Source0 -ilike '*%{_url_src}*')          { $Source0 = $Source0 -ireplace '%{_url_src}',$currentTask._url_src }
+ *         if ($Source0 -ilike '*%{_repo_ver}*')         { $Source0 = $Source0 -ireplace '%{_repo_ver}',$currentTask._repo_ver }
+ *         if ($Source0 -ilike '*%{commit_id}*')         { $Source0 = $Source0 -ireplace '%{commit_id}',$currentTask.commit_id }
+ *     }
+ *
+ * Implementation notes:
+ *   - "$x -ilike '*Y*'" → strcasestr() != NULL
+ *   - "$x -ireplace 'literal', value" → istr_replace_all() (the patterns
+ *     contain only `%`, `{`, `}`, lowercase letters and `_` — none of
+ *     these have regex quantifier semantics, so literal replace is
+ *     byte-identical to .NET regex on these inputs).
+ *   - "$x -match 'literal.tar.gz$'" → suffix string compare. PS treats
+ *     '.' as regex metachar but the inputs (real tarball URLs) never
+ *     contain non-period bytes at those positions, so suffix-match is
+ *     byte-identical here.
+ *   - "[string]::Concat(a.TrimEnd('/'), b)" → trim trailing '/' from a,
+ *     then concatenate.
+ *
+ * The function MUTATES *source0 — caller's old pointer is freed by the
+ * helpers; the new pointer lands in *source0.
+ */
+/* _GNU_SOURCE for strcasestr is provided via CMake target_compile_options;
+ * do not redefine here. */
+#include "pr_substitute.h"
+#include "pr_strutil.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+/* Helper: PS -notlike '*X*' against a string == strcasestr returned NULL. */
+static int icontains(const char *hay, const char *needle)
+{
+    if (hay == NULL || needle == NULL || needle[0] == '\0') return 0;
+    return strcasestr(hay, needle) != NULL;
+}
+
+/* Helper: case-sensitive substring test (PS -like, not -ilike). */
+static int contains(const char *hay, const char *needle)
+{
+    if (hay == NULL || needle == NULL || needle[0] == '\0') return 0;
+    return strstr(hay, needle) != NULL;
+}
+
+/* Helper: case-sensitive suffix test, mirroring `$x -match 'literal$'`
+ * for the four tarball extensions used at PS L 2176. */
+static int has_suffix(const char *s, const char *suf)
+{
+    if (s == NULL || suf == NULL) return 0;
+    size_t slen = strlen(s);
+    size_t suflen = strlen(suf);
+    return slen >= suflen && memcmp(s + slen - suflen, suf, suflen) == 0;
+}
+
+/* Helper: TrimEnd('/'). Returns a heap copy with all trailing '/' bytes
+ * removed. */
+static char *trim_trailing_slashes_dup(const char *s)
+{
+    if (s == NULL) s = "";
+    size_t n = strlen(s);
+    while (n > 0 && s[n - 1] == '/') n--;
+    char *out = (char *)malloc(n + 1);
+    if (!out) return NULL;
+    memcpy(out, s, n);
+    out[n] = '\0';
+    return out;
+}
+
+/* Helper: concatenate two strings into a fresh heap buffer. */
+static char *concat_dup(const char *a, const char *b)
+{
+    size_t la = a ? strlen(a) : 0;
+    size_t lb = b ? strlen(b) : 0;
+    char *out = (char *)malloc(la + lb + 1);
+    if (!out) return NULL;
+    if (la) memcpy(out, a, la);
+    if (lb) memcpy(out + la, b, lb);
+    out[la + lb] = '\0';
+    return out;
+}
+
+/* Replace *source0 entirely with a new heap string, freeing the old. */
+static int replace_pointer(char **source0, char *new_value)
+{
+    if (new_value == NULL) return -1;
+    free(*source0);
+    *source0 = new_value;
+    return 0;
+}
+
+int pr_source0_substitute(pr_task_t *task, char **source0, const char *version)
+{
+    if (task == NULL || source0 == NULL || *source0 == NULL) return -1;
+
+    const char *url = task->url ? task->url : "";
+
+    /* PS L 2172: %{url} */
+    if (icontains(*source0, "%{url}")) {
+        *source0 = istr_replace_all(*source0, "%{url}", url);
+        if (*source0 == NULL) return -1;
+    }
+
+    /* PS L 2174-2179: URL-prefix injection when Source0 lacks `//`. */
+    if (!contains(*source0, "//") && url[0] != '\0') {
+        if (has_suffix(url, ".tar.gz") || has_suffix(url, ".tar.xz") ||
+            has_suffix(url, ".tar.bz2") || has_suffix(url, ".tgz")) {
+            /* $Source0 = $currentTask.url */
+            char *dup = (char *)malloc(strlen(url) + 1);
+            if (!dup) return -1;
+            memcpy(dup, url, strlen(url) + 1);
+            if (replace_pointer(source0, dup) != 0) { free(dup); return -1; }
+        } else {
+            char *trimmed = trim_trailing_slashes_dup(url);
+            if (!trimmed) return -1;
+            char *combined = concat_dup(trimmed, *source0);
+            free(trimmed);
+            if (!combined) return -1;
+            if (replace_pointer(source0, combined) != 0) { free(combined); return -1; }
+        }
+    }
+
+    /* PS L 2182: %{name} */
+    *source0 = istr_replace_all(*source0, "%{name}", task->Name ? task->Name : "");
+    if (*source0 == NULL) return -1;
+
+    /* PS L 2183: %{version} — note: PS local $version, not task->Version. */
+    *source0 = istr_replace_all(*source0, "%{version}", version ? version : "");
+    if (*source0 == NULL) return -1;
+
+    /* PS L 2185-2202: gated by `*{*` (case-SENSITIVE -like, since `{` is
+     * the only meta we care about and it has no case). */
+    if (contains(*source0, "{")) {
+
+        /* PS L 2187: %{srcname} */
+        if (icontains(*source0, "%{srcname}")) {
+            *source0 = istr_replace_all(*source0, "%{srcname}", task->srcname ? task->srcname : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2188: %{gem_name} */
+        if (icontains(*source0, "%{gem_name}")) {
+            *source0 = istr_replace_all(*source0, "%{gem_name}", task->gem_name ? task->gem_name : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2189: %{extra_version} */
+        if (icontains(*source0, "%{extra_version}")) {
+            *source0 = istr_replace_all(*source0, "%{extra_version}", task->extra_version ? task->extra_version : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2190: %{main_version} */
+        if (icontains(*source0, "%{main_version}")) {
+            *source0 = istr_replace_all(*source0, "%{main_version}", task->main_version ? task->main_version : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2191: %{byaccdate} */
+        if (icontains(*source0, "%{byaccdate}")) {
+            *source0 = istr_replace_all(*source0, "%{byaccdate}", task->byaccdate ? task->byaccdate : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2192: %{dialogsubversion} */
+        if (icontains(*source0, "%{dialogsubversion}")) {
+            *source0 = istr_replace_all(*source0, "%{dialogsubversion}", task->dialogsubversion ? task->dialogsubversion : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2193: %{subversion} */
+        if (icontains(*source0, "%{subversion}")) {
+            *source0 = istr_replace_all(*source0, "%{subversion}", task->subversion ? task->subversion : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2194: %{upstreamversion} */
+        if (icontains(*source0, "%{upstreamversion}")) {
+            *source0 = istr_replace_all(*source0, "%{upstreamversion}", task->upstreamversion ? task->upstreamversion : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2195: %{libedit_release} */
+        if (icontains(*source0, "%{libedit_release}")) {
+            *source0 = istr_replace_all(*source0, "%{libedit_release}", task->libedit_release ? task->libedit_release : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2196: %{libedit_version} */
+        if (icontains(*source0, "%{libedit_version}")) {
+            *source0 = istr_replace_all(*source0, "%{libedit_version}", task->libedit_version ? task->libedit_version : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2197: %{ncursessubversion} */
+        if (icontains(*source0, "%{ncursessubversion}")) {
+            *source0 = istr_replace_all(*source0, "%{ncursessubversion}", task->ncursessubversion ? task->ncursessubversion : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2198: %{cpan_name} */
+        if (icontains(*source0, "%{cpan_name}")) {
+            *source0 = istr_replace_all(*source0, "%{cpan_name}", task->cpan_name ? task->cpan_name : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2199: %{xproto_ver} */
+        if (icontains(*source0, "%{xproto_ver}")) {
+            *source0 = istr_replace_all(*source0, "%{xproto_ver}", task->xproto_ver ? task->xproto_ver : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2200: %{_url_src} */
+        if (icontains(*source0, "%{_url_src}")) {
+            *source0 = istr_replace_all(*source0, "%{_url_src}", task->_url_src ? task->_url_src : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2201: %{_repo_ver} */
+        if (icontains(*source0, "%{_repo_ver}")) {
+            *source0 = istr_replace_all(*source0, "%{_repo_ver}", task->_repo_ver ? task->_repo_ver : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* PS L 2202: %{commit_id} */
+        if (icontains(*source0, "%{commit_id}")) {
+            *source0 = istr_replace_all(*source0, "%{commit_id}", task->commit_id ? task->commit_id : "");
+            if (*source0 == NULL) return -1;
+        }
+    }
+
+    return 0;
+}

--- a/photonos-package-report/photonos-package-report/src/strutil.c
+++ b/photonos-package-report/photonos-package-report/src/strutil.c
@@ -1,0 +1,82 @@
+/* strutil.c — shared string helpers.
+ * See include/pr_strutil.h for semantics.
+ */
+#include "pr_strutil.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>  /* strcasestr */
+
+char *str_replace_all(char *in, const char *a, const char *b)
+{
+    if (in == NULL || a == NULL || a[0] == '\0') return in;
+    size_t alen = strlen(a);
+    size_t blen = b ? strlen(b) : 0;
+
+    /* Count occurrences. */
+    size_t count = 0;
+    for (const char *p = in; (p = strstr(p, a)) != NULL; p += alen) count++;
+    if (count == 0) return in;
+
+    size_t in_len  = strlen(in);
+    size_t out_len = in_len + count * (blen > alen ? blen - alen : 0)
+                            - count * (alen > blen ? alen - blen : 0);
+    char *out = (char *)malloc(out_len + 1);
+    if (!out) return in;
+
+    char *o = out;
+    const char *cur = in;
+    for (;;) {
+        const char *hit = strstr(cur, a);
+        if (!hit) {
+            size_t tail = strlen(cur);
+            memcpy(o, cur, tail);
+            o += tail;
+            break;
+        }
+        memcpy(o, cur, (size_t)(hit - cur));
+        o += hit - cur;
+        if (blen) { memcpy(o, b, blen); o += blen; }
+        cur = hit + alen;
+    }
+    *o = '\0';
+    free(in);
+    return out;
+}
+
+char *istr_replace_all(char *in, const char *a, const char *b)
+{
+    if (in == NULL || a == NULL || a[0] == '\0') return in;
+    size_t alen = strlen(a);
+    size_t blen = b ? strlen(b) : 0;
+
+    /* Count occurrences case-insensitively. */
+    size_t count = 0;
+    for (const char *p = in; (p = strcasestr(p, a)) != NULL; p += alen) count++;
+    if (count == 0) return in;
+
+    size_t in_len  = strlen(in);
+    size_t out_len = in_len + count * (blen > alen ? blen - alen : 0)
+                            - count * (alen > blen ? alen - blen : 0);
+    char *out = (char *)malloc(out_len + 1);
+    if (!out) return in;
+
+    char *o = out;
+    const char *cur = in;
+    for (;;) {
+        const char *hit = strcasestr(cur, a);
+        if (!hit) {
+            size_t tail = strlen(cur);
+            memcpy(o, cur, tail);
+            o += tail;
+            break;
+        }
+        memcpy(o, cur, (size_t)(hit - cur));
+        o += hit - cur;
+        if (blen) { memcpy(o, b, blen); o += blen; }
+        cur = hit + alen;
+    }
+    *o = '\0';
+    free(in);
+    return out;
+}

--- a/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(test_phase2
     ${CMAKE_SOURCE_DIR}/src/task.c
     ${CMAKE_SOURCE_DIR}/src/spec_value.c
     ${CMAKE_SOURCE_DIR}/src/parse_directory.c
+    ${CMAKE_SOURCE_DIR}/src/strutil.c
 )
 target_include_directories(test_phase2 PRIVATE
     ${CMAKE_SOURCE_DIR}/include
@@ -58,3 +59,15 @@ target_include_directories(test_phase3b PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_options(test_phase3b PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE)
 
 add_test(NAME test_phase3b COMMAND test_phase3b)
+
+# ----- Phase 4 unit tests (Source0 substitution core) ----------------
+add_executable(test_phase4
+    test_phase4.c
+    ${CMAKE_SOURCE_DIR}/src/strutil.c
+    ${CMAKE_SOURCE_DIR}/src/source0_substitute.c
+    ${CMAKE_SOURCE_DIR}/src/task.c
+)
+target_include_directories(test_phase4 PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_compile_options(test_phase4 PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE)
+
+add_test(NAME test_phase4 COMMAND test_phase4)

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase4.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase4.c
@@ -1,0 +1,246 @@
+/* test_phase4.c — unit tests for the Source0 substitution core.
+ *
+ * Covers every branch of photonos-package-report.ps1 L 2172-2199:
+ *
+ *   • %{url}                                                  (PS L 2172)
+ *   • %{url} when currentTask.url == ""                       (PS L 2172)
+ *   • URL-prefix injection when Source0 has no "//"
+ *     and currentTask.url ends with .tar.gz                   (PS L 2176)
+ *   • URL-prefix injection (else branch, trim trailing '/')   (PS L 2178)
+ *   • %{name}                                                 (PS L 2182)
+ *   • %{version}                                              (PS L 2183)
+ *   • Outer `*{*` gate short-circuits when no `{` remains     (PS L 2185)
+ *   • Each of the 15 secondary tokens                         (PS L 2187-2202)
+ *   • Case-insensitive matching: %{URL}, %{Name}, %{VERSION} all replaced
+ */
+#include "pr_substitute.h"
+#include "pr_types.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures = 0;
+
+#define EXPECT_STREQ(actual, expected) do {                                    \
+    const char *_a = (actual);                                                 \
+    const char *_e = (expected);                                               \
+    if (_a == NULL || strcmp(_a, _e) != 0) {                                   \
+        fprintf(stderr, "  FAIL %s:%d: expected '%s' got '%s'\n",              \
+                __FILE__, __LINE__, _e, _a ? _a : "(null)");                   \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+
+static char *xs(const char *s)
+{
+    size_t n = strlen(s);
+    char *p = malloc(n + 1);
+    memcpy(p, s, n + 1);
+    return p;
+}
+
+/* Build a minimal pr_task_t with all string fields set to heap-allocated
+ * empties unless overridden. Caller frees via pr_task_free. */
+static void task_init_default(pr_task_t *t)
+{
+    memset(t, 0, sizeof *t);
+#define E(field) t->field = xs("")
+    E(Spec); E(Version); E(Name); E(SubRelease); E(SpecRelativePath);
+    E(Source0); E(url); E(SHAName); E(srcname); E(gem_name); E(group);
+    E(extra_version); E(main_version); E(upstreamversion);
+    E(dialogsubversion); E(subversion); E(byaccdate);
+    E(libedit_release); E(libedit_version); E(ncursessubversion);
+    E(cpan_name); E(xproto_ver); E(_url_src); E(_repo_ver); E(commit_id);
+#undef E
+}
+
+static void task_free(pr_task_t *t) { pr_task_free(t); }
+
+/* ---- URL substitution ---------------------------------------------- */
+static void test_url(void)
+{
+    fprintf(stderr, "[test_url]\n");
+
+    pr_task_t t; task_init_default(&t);
+    free(t.url); t.url = xs("https://example.invalid/upstream/");
+
+    char *src = xs("%{url}foo-%{version}.tar.gz");
+    if (pr_source0_substitute(&t, &src, "1.0") == 0)
+        EXPECT_STREQ(src, "https://example.invalid/upstream/foo-1.0.tar.gz");
+    free(src);
+    task_free(&t);
+
+    /* Case-insensitive: %{URL} also matches. */
+    pr_task_t t2; task_init_default(&t2);
+    free(t2.url); t2.url = xs("https://example.invalid/");
+    char *src2 = xs("%{URL}bar.tar.gz");
+    if (pr_source0_substitute(&t2, &src2, "") == 0)
+        EXPECT_STREQ(src2, "https://example.invalid/bar.tar.gz");
+    free(src2);
+    task_free(&t2);
+
+    /* %{url} present but currentTask.url is "" — empty replace. */
+    pr_task_t t3; task_init_default(&t3);
+    char *src3 = xs("%{url}baz.tar.gz");
+    if (pr_source0_substitute(&t3, &src3, "") == 0)
+        EXPECT_STREQ(src3, "baz.tar.gz");  /* prefix-injection then doesn't fire since url is "" */
+    free(src3);
+    task_free(&t3);
+}
+
+/* ---- URL-prefix injection (PS L 2174-2179) -------------------------- */
+static void test_prefix_injection(void)
+{
+    fprintf(stderr, "[test_prefix_injection]\n");
+
+    /* currentTask.url ends in .tar.gz, Source0 has no "//"
+     *   → Source0 := currentTask.url, verbatim. */
+    pr_task_t t; task_init_default(&t);
+    free(t.url); t.url = xs("https://example.invalid/pkg-1.0.tar.gz");
+    char *src = xs("pkg.tar.gz");
+    if (pr_source0_substitute(&t, &src, "1.0") == 0)
+        EXPECT_STREQ(src, "https://example.invalid/pkg-1.0.tar.gz");
+    free(src);
+    task_free(&t);
+
+    /* else branch: trim trailing '/' from url, concat with Source0. */
+    pr_task_t t2; task_init_default(&t2);
+    free(t2.url); t2.url = xs("https://example.invalid/path/");
+    char *src2 = xs("foo.zip");
+    if (pr_source0_substitute(&t2, &src2, "") == 0)
+        EXPECT_STREQ(src2, "https://example.invalid/pathfoo.zip");
+    free(src2);
+    task_free(&t2);
+
+    /* No prefix injection when Source0 already has "//". */
+    pr_task_t t3; task_init_default(&t3);
+    free(t3.url); t3.url = xs("https://elsewhere.invalid/");
+    char *src3 = xs("https://here.invalid/x.tar.gz");
+    if (pr_source0_substitute(&t3, &src3, "") == 0)
+        EXPECT_STREQ(src3, "https://here.invalid/x.tar.gz");
+    free(src3);
+    task_free(&t3);
+
+    /* No injection when currentTask.url is "". */
+    pr_task_t t4; task_init_default(&t4);
+    char *src4 = xs("relative-path.tar.gz");
+    if (pr_source0_substitute(&t4, &src4, "") == 0)
+        EXPECT_STREQ(src4, "relative-path.tar.gz");
+    free(src4);
+    task_free(&t4);
+}
+
+/* ---- %{name} and %{version} ---------------------------------------- */
+static void test_name_version(void)
+{
+    fprintf(stderr, "[test_name_version]\n");
+
+    pr_task_t t; task_init_default(&t);
+    free(t.Name); t.Name = xs("hello");
+    free(t.url);  t.url  = xs("https://example.invalid/");
+    char *src = xs("https://example.invalid/%{name}-%{version}.tar.gz");
+    if (pr_source0_substitute(&t, &src, "2.10") == 0)
+        EXPECT_STREQ(src, "https://example.invalid/hello-2.10.tar.gz");
+    free(src);
+    task_free(&t);
+
+    /* Case-insensitive: %{Name} %{VERSION} also replaced. */
+    pr_task_t t2; task_init_default(&t2);
+    free(t2.Name); t2.Name = xs("world");
+    char *src2 = xs("https://example.invalid/%{Name}-%{VERSION}.tar.gz");
+    if (pr_source0_substitute(&t2, &src2, "9.9") == 0)
+        EXPECT_STREQ(src2, "https://example.invalid/world-9.9.tar.gz");
+    free(src2);
+    task_free(&t2);
+}
+
+/* ---- Outer `*{*` gate ---------------------------------------------- */
+static void test_outer_gate(void)
+{
+    fprintf(stderr, "[test_outer_gate]\n");
+
+    /* No `{` left → none of the 15 secondary patterns are even tested. */
+    pr_task_t t; task_init_default(&t);
+    free(t.srcname); t.srcname = xs("WILL_NOT_APPLY");
+    char *src = xs("https://example.invalid/already-resolved.tar.gz");
+    if (pr_source0_substitute(&t, &src, "") == 0)
+        EXPECT_STREQ(src, "https://example.invalid/already-resolved.tar.gz");
+    free(src);
+    task_free(&t);
+}
+
+/* ---- 15 secondary tokens (PS L 2187-2202) -------------------------- */
+static void test_secondary(void)
+{
+    fprintf(stderr, "[test_secondary]\n");
+
+    /* For each token, build a task with only that field set and a
+     * Source0 template that uses it. Confirm the result is the field
+     * value alone (proving the token was replaced). */
+    struct {
+        const char *token;          /* literal token, e.g. "%{srcname}" */
+        size_t      field_offset;   /* offsetof(pr_task_t, srcname) etc. */
+        const char *value;
+        const char *fieldname;      /* for failure messages */
+    } cases[] = {
+        { "%{srcname}",           offsetof(pr_task_t, srcname),           "Foo",          "srcname" },
+        { "%{gem_name}",          offsetof(pr_task_t, gem_name),          "bar",          "gem_name" },
+        { "%{extra_version}",     offsetof(pr_task_t, extra_version),     "rc1",          "extra_version" },
+        { "%{main_version}",      offsetof(pr_task_t, main_version),      "4.5",          "main_version" },
+        { "%{byaccdate}",         offsetof(pr_task_t, byaccdate),         "20210808",     "byaccdate" },
+        { "%{dialogsubversion}",  offsetof(pr_task_t, dialogsubversion),  "20230209",     "dialogsubversion" },
+        { "%{subversion}",        offsetof(pr_task_t, subversion),        "6",            "subversion" },
+        { "%{upstreamversion}",   offsetof(pr_task_t, upstreamversion),   "4.5.6-beta",   "upstreamversion" },
+        { "%{libedit_release}",   offsetof(pr_task_t, libedit_release),   "50",           "libedit_release" },
+        { "%{libedit_version}",   offsetof(pr_task_t, libedit_version),   "20221030",     "libedit_version" },
+        { "%{ncursessubversion}", offsetof(pr_task_t, ncursessubversion), "20221231",     "ncursessubversion" },
+        { "%{cpan_name}",         offsetof(pr_task_t, cpan_name),         "Misc::Bundle", "cpan_name" },
+        { "%{xproto_ver}",        offsetof(pr_task_t, xproto_ver),        "7.0.31",       "xproto_ver" },
+        { "%{_url_src}",          offsetof(pr_task_t, _url_src),          "https://src",  "_url_src" },
+        { "%{_repo_ver}",         offsetof(pr_task_t, _repo_ver),         "9.9.9",        "_repo_ver" },
+        { "%{commit_id}",         offsetof(pr_task_t, commit_id),         "abc123",       "commit_id" },
+    };
+    size_t n = sizeof cases / sizeof cases[0];
+    for (size_t i = 0; i < n; i++) {
+        pr_task_t t; task_init_default(&t);
+        char **slot = (char **)((char *)&t + cases[i].field_offset);
+        free(*slot);
+        *slot = xs(cases[i].value);
+
+        size_t tlen = strlen(cases[i].token);
+        char *src = malloc(strlen("https://h/") + tlen + 1);
+        strcpy(src, "https://h/");
+        strcat(src, cases[i].token);
+
+        if (pr_source0_substitute(&t, &src, "") == 0) {
+            char *expected = malloc(strlen("https://h/") + strlen(cases[i].value) + 1);
+            strcpy(expected, "https://h/");
+            strcat(expected, cases[i].value);
+            if (strcmp(src, expected) != 0) {
+                fprintf(stderr, "  FAIL %s: expected '%s' got '%s'\n",
+                        cases[i].fieldname, expected, src);
+                failures++;
+            }
+            free(expected);
+        }
+        free(src);
+        task_free(&t);
+    }
+}
+
+int main(void)
+{
+    test_url();
+    test_prefix_injection();
+    test_name_version();
+    test_outer_gate();
+    test_secondary();
+
+    if (failures == 0) {
+        fprintf(stderr, "test_phase4: ALL PASSED\n");
+        return 0;
+    }
+    fprintf(stderr, "test_phase4: %d failure(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Ports the substitution sequence at `photonos-package-report.ps1` L 2172-2199 line-for-line. CLAUDE.md invariant #3 explicitly calls out this block: **no reordering of mutations on `$Source0` when porting** — every `-ireplace`, every `-ilike` gate, every `[string]::Concat(...TrimEnd('/'))` lands in the same source order as PS.

- New shared string module (`pr_strutil`) with `str_replace_all` (case-sensitive, extracted from `parse_directory.c`) and `istr_replace_all` (case-insensitive — what PS calls `-ireplace` when the pattern is a literal token).
- New `pr_source0_substitute(task, &source0, version)` in `src/source0_substitute.c`. Mutates `*source0` in PS order: `%{url}` → URL-prefix injection → `%{name}` → `%{version}` → 15 secondary tokens (gated by `*{*`).
- `parse_directory.c` refactored onto the shared `str_replace_all` (no duplicate). No behaviour change.
- `test_phase4` covers every branch of L 2172-2199.

## Phase tracker
| Phase | Title | Status |
|-------|-------|--------|
| 0 | SDD scaffold | done (#52) |
| 1 | Foundation | done (#53) |
| 2 | Spec ingestion | done (#54) |
| 3a | Source0LookupData embed | done (#55) |
| 3b | Per-spec hook dispatch | done (#57) |
| 4 | **Source0 substitution core** | **this PR** |
| 5 | URL health (libcurl + GitHub/GitLab/Koji) | pending |
| 6 | CheckURLHealth + .prn assembly | pending |
| 7 | Cluster orchestrator + worker pool | pending |
| 8 | Side-by-side CI parity gate | pending |
| 9 | PS retirement | pending |
| M | Maintainer ops & debug tooling | PR #56 still open |

## PS-source mapping (strict parity)
| PS line | Operation | C site |
|---------|-----------|--------|
| 2172 | `%{url}` → `$currentTask.url` | `src/source0_substitute.c` step 1 |
| 2174-2179 | URL-prefix injection (tarball-suffix vs trim+concat) | step 2 |
| 2182 | `%{name}` → `$currentTask.Name` | step 3 |
| 2183 | `%{version}` → `$version` (local, NOT `$currentTask.Version`) | step 4 |
| 2185 | Outer `*{*` gate | step 5 (entry) |
| 2187-2202 | 15 secondary `%{token}` → field substitutions | step 5 (body) |

## Why literal `istr_replace_all` instead of full PCRE2
The PS author wrote `-ireplace` (regex-aware), but the patterns at L 2172-2202 are all of the shape `%{lowercase_identifier}`. The regex metacharacters in those bytes (`%`, `{`, `}`) have **no quantifier semantics** in .NET regex unless followed by digits. The PCRE2 output on these inputs is byte-identical to literal-replace, and literal-replace doesn't risk silent regression if a future PS edit slips in a metacharacter. The 15-token block stays portable and audit-friendly.

## Test plan
- [x] `cmake -B build -S .` configures cleanly
- [x] `cmake --build build` zero warnings (after dropping a stale `_GNU_SOURCE` redef)
- [x] `ctest --test-dir build` → 5/5 passed
  - `test_phase1`, `test_phase2`, `test_phase3`, `test_phase3b` (unchanged)
  - `test_phase4` — `%{url}` + url="" + `%{URL}`; both URL-prefix-injection branches; `%{name}` / `%{version}` + case-insensitive variants; outer `*{*` short-circuit; all 15 secondary tokens individually
- [x] `parse_directory` refactor verified by `test_phase2` (unchanged output)

## Out of scope (deferred)
- The wider `ModifySpecFile` function (PS L 1371-2210+) — Phase 6 lifts this once we have the surrounding state struct
- Special-case `if ($currentTask.spec -eq …)` branches at PS L 2148-2167 — those become per-spec hooks under `src/hooks/` per the Phase 3b dispatch contract
- Version comparison helpers (`Versioncompare`, `Clean-VersionNames`) — Phase 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)