### PR TITLE
phase-5: urlhealth() + KojiFedoraProjectLookUp() via libcurl

### DIFF
--- a/photonos-package-report/photonos-package-report/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # bash+awk Source0LookupData generator (no extra runtime deps).
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PCRE2 REQUIRED libpcre2-8)
+pkg_check_modules(CURL  REQUIRED libcurl)
 
 # ----- Phase 3 generator: embedded Source0LookupData CSV -------------
 # Runs at build time. Output lives under ${CMAKE_BINARY_DIR}/generated
@@ -94,6 +95,8 @@ add_executable(photonos-package-report
     src/hook_dispatch.c
     src/strutil.c
     src/source0_substitute.c
+    src/urlhealth.c
+    src/koji.c
     ${PR_GEN_HOOK_DISPATCH}
     ${PR_HOOK_SOURCES}
 )
@@ -104,9 +107,10 @@ target_include_directories(photonos-package-report PRIVATE
     include
     ${PR_GEN_DIR}
     ${PCRE2_INCLUDE_DIRS}
+    ${CURL_INCLUDE_DIRS}
 )
-target_link_libraries(photonos-package-report PRIVATE pthread ${PCRE2_LIBRARIES})
-target_compile_options(photonos-package-report PRIVATE -Wall -Wextra -O2 -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER})
+target_link_libraries(photonos-package-report PRIVATE pthread ${PCRE2_LIBRARIES} ${CURL_LIBRARIES})
+target_compile_options(photonos-package-report PRIVATE -Wall -Wextra -O2 -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER} ${CURL_CFLAGS_OTHER})
 
 # ----- Tests --------------------------------------------------------
 enable_testing()

--- a/photonos-package-report/photonos-package-report/include/pr_koji.h
+++ b/photonos-package-report/photonos-package-report/include/pr_koji.h
@@ -1,0 +1,45 @@
+/* pr_koji.h — KojiFedoraProjectLookUp port.
+ *
+ * Mirrors photonos-package-report.ps1 L 1520-1572.
+ *
+ * Given a package name (e.g. "libaio") the function walks:
+ *   1. https://src.fedoraproject.org/rpms/<name>/blob/main/f/sources
+ *      → extract upstream tarball name from the embedded `<code>...(...)</code>`
+ *   2. The tarball name → upstream version (strip leading "<name>-" / "v" / ".tar.gz")
+ *      Special cases: "connect-proxy" strips "ssh-connect-"; "python-pbr" strips "pbr-".
+ *   3. https://kojipkgs.fedoraproject.org/packages/<name>/<version>
+ *      → list build-release subdirs; pick the highest numeric prefix.
+ *   4. https://kojipkgs.fedoraproject.org/packages/<name>/<version>/<release>/src/
+ *      → list .src.rpm files; pick the highest numeric prefix.
+ *   5. Return the final .src.rpm URL.
+ *
+ * Returns 0 on success (writes a malloc'd URL into *out_url; caller frees).
+ * Returns 0 with *out_url = strdup("") if any step missed (mirrors PS
+ * silent-catch at L 1571).
+ * Returns -1 on memory failure.
+ */
+#ifndef PR_KOJI_H
+#define PR_KOJI_H
+
+int koji_fedora_lookup(const char *artefact_name, char **out_url);
+
+/* --- Parsing helpers exposed for unit tests ----------------------- */
+
+/* Step 1 parser: extract the tarball filename inside the FIRST
+ *   <code class...>...</code>(...)
+ * pair on the page. Returns malloc'd string or NULL on miss. */
+char *pr_koji_parse_artefact_download_name(const char *html);
+
+/* Step 2 helper: given (artefact_name, download_name) return the
+ * upstream version with PS L 1545-1547 strippings applied. malloc'd. */
+char *pr_koji_derive_version(const char *artefact_name, const char *download_name);
+
+/* Step 3 parser: from the directory listing HTML, return the highest-
+ * numbered release name. Returns malloc'd string or NULL. */
+char *pr_koji_pick_latest_release(const char *html);
+
+/* Step 4 parser: from the src/ listing HTML, return the highest-
+ * numbered .src.rpm filename. Returns malloc'd string or NULL. */
+char *pr_koji_pick_latest_srpm(const char *html);
+
+#endif /* PR_KOJI_H */

--- a/photonos-package-report/photonos-package-report/include/pr_urlhealth.h
+++ b/photonos-package-report/photonos-package-report/include/pr_urlhealth.h
@@ -1,0 +1,20 @@
+/* pr_urlhealth.h — urlhealth() port.
+ *
+ * Mirrors photonos-package-report.ps1 L 1458-1518.
+ *
+ * The PS function probes a URL with a HEAD request, returns the HTTP
+ * status code, and falls back to a full browser-mimic GET for known-
+ * stubborn hosts (netfilter.org/ftp URLs that 403 on plain HEAD).
+ *
+ * Return values:
+ *   200..599  : HTTP status (success or HTTP-level failure both surface)
+ *   0         : libcurl/transport-level error (timeout, DNS, TLS, ...)
+ *
+ * Timeout: 120 seconds, matching PS L 1469 ($request.Timeout = 120000).
+ */
+#ifndef PR_URLHEALTH_H
+#define PR_URLHEALTH_H
+
+int urlhealth(const char *checkurl);
+
+#endif /* PR_URLHEALTH_H */

--- a/photonos-package-report/photonos-package-report/src/koji.c
+++ b/photonos-package-report/photonos-package-report/src/koji.c
@@ -1,0 +1,416 @@
+/* koji.c — KojiFedoraProjectLookUp port.
+ * Mirrors photonos-package-report.ps1 L 1520-1572.
+ *
+ * PS source (verbatim, condensed):
+ *
+ *     function KojiFedoraProjectLookUp {
+ *         param([parameter(Mandatory=$true)][string]$ArtefactName)
+ *         $SourceRPMFileURL=""
+ *         $SourceTagURL="https://src.fedoraproject.org/rpms/$ArtefactName/blob/main/f/sources"
+ *         try {
+ *             $ArtefactDownloadName=((((((invoke-restmethod -uri $SourceTagURL ...)
+ *                 -split '<code class') -split '</code>')[1]) -split '\(') -split '\)')[1]
+ *             $ArtefactVersion=$ArtefactDownloadName -ireplace "${ArtefactName}-",""
+ *             if ($ArtefactName -ieq "connect-proxy") {$ArtefactVersion=$ArtefactDownloadName -ireplace "ssh-connect-",""}
+ *             if ($ArtefactName -ieq "python-pbr")    {$ArtefactVersion=$ArtefactDownloadName -ireplace "pbr-",""}
+ *             $ArtefactVersion=$ArtefactVersion -ireplace ".tar.gz",""
+ *             $ArtefactVersion=$ArtefactVersion -ireplace "v",""
+ *
+ *             $SourceTagURL="https://kojipkgs.fedoraproject.org/packages/$ArtefactName/$ArtefactVersion"
+ *             $Names = ((invoke-restmethod ...) -split '/">') -split '/</a>'
+ *             $Names = $Names | foreach-object { if (!($_ | select-string '<' -simplematch)) {$_}}
+ *             $Names = $Names | foreach-object { if ($_ -match '\d') {$_}}
+ *             $lastItem = $Names | Sort-Object {...} | select-object -last 1
+ *
+ *             $SourceTagURL="https://kojipkgs.fedoraproject.org/packages/$ArtefactName/$ArtefactVersion/$NameLatest/src/"
+ *             $Names = ((invoke-restmethod ...) -split '<a href="') -split '"'
+ *             $Names = $Names | where {!($_ -match '<') -and ($_ -match '.src.rpm')}
+ *             $lastItem = $Names | Sort-Object {...} | select-object -last 1
+ *
+ *             $SourceRPMFileURL = "https://kojipkgs.fedoraproject.org/packages/$ArtefactName/$ArtefactVersion/$NameLatest/src/$SourceRPMFileName"
+ *         } catch { ... silent ... }
+ *         return $SourceRPMFileURL
+ *     }
+ *
+ * The HTML parsing logic is factored into four pr_koji_* helpers so we
+ * can unit-test them deterministically against canned input without
+ * touching the network.
+ */
+#include "pr_koji.h"
+#include "pr_strutil.h"
+
+#include <curl/curl.h>
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+/* ----- libcurl GET into heap buffer --------------------------------- */
+
+typedef struct { char *buf; size_t len; size_t cap; } httpbuf_t;
+
+static size_t collect_cb(char *p, size_t s, size_t n, void *u)
+{
+    httpbuf_t *b = (httpbuf_t *)u;
+    size_t add = s * n;
+    if (b->len + add + 1 > b->cap) {
+        size_t nc = b->cap == 0 ? 4096 : b->cap;
+        while (nc < b->len + add + 1) nc *= 2;
+        char *np = (char *)realloc(b->buf, nc);
+        if (!np) return 0;
+        b->buf = np; b->cap = nc;
+    }
+    memcpy(b->buf + b->len, p, add);
+    b->len += add;
+    b->buf[b->len] = '\0';
+    return add;
+}
+
+static int http_get(const char *url, long timeout_ms, char **out_body)
+{
+    *out_body = NULL;
+    CURL *c = curl_easy_init();
+    if (!c) return -1;
+    httpbuf_t b = {0};
+    curl_easy_setopt(c, CURLOPT_URL,            url);
+    curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(c, CURLOPT_TIMEOUT_MS,     timeout_ms);
+    curl_easy_setopt(c, CURLOPT_USERAGENT,      "photonos-package-report/C");
+    curl_easy_setopt(c, CURLOPT_WRITEFUNCTION,  collect_cb);
+    curl_easy_setopt(c, CURLOPT_WRITEDATA,      &b);
+    CURLcode rc = curl_easy_perform(c);
+    long status = 0;
+    curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &status);
+    curl_easy_cleanup(c);
+    if (rc != CURLE_OK || status < 200 || status >= 300) {
+        free(b.buf);
+        return -1;
+    }
+    *out_body = b.buf;
+    return 0;
+}
+
+/* ----- Pure parsers ------------------------------------------------- */
+
+/* Step 1: find the FIRST `<code class...>...</code>` block, then
+ * inside that block find the substring between '(' and ')'.
+ *
+ * PS:
+ *   ((((((html -split '<code class') -split '</code>')[1]) -split '\(') -split '\)')[1]
+ *
+ * Breakdown:
+ *   - split on '<code class' → take element [1] (everything after the
+ *     first `<code class`)
+ *   - split on '</code>'    → take element [1] -- BUT PS array indexing
+ *     after two -splits gets confusing. Inspecting the chain again:
+ *
+ *     "$html -split '<code class'" returns an array; element [1] is the
+ *     text after the first opener. Then "-split '</code>'" splits that;
+ *     element [0] is what's inside the <code> tag, [1] is what comes
+ *     after `</code>`. The PS author wrote `[1]` here meaning the
+ *     text BETWEEN the first `<code class>` and the corresponding
+ *     `</code>` — except it's actually `[0]` of the inner split. Real
+ *     Fedora pages always have a single `(` after `</code>` outside the
+ *     tag, like `<code class>X</code> (filename.tar.gz)`. The PS chain
+ *     ultimately extracts whatever sits between the `(` and `)` AFTER
+ *     `</code>`. We honour that.
+ *
+ * The C parser implements this:
+ *   1. Find "<code class" anchor.
+ *   2. From there, find "</code>".
+ *   3. From there, find next '('.
+ *   4. From there, find next ')'.
+ *   5. Return the bytes between '(' and ')'.
+ */
+char *pr_koji_parse_artefact_download_name(const char *html)
+{
+    if (html == NULL) return NULL;
+    const char *p = strstr(html, "<code class");
+    if (!p) return NULL;
+    p = strstr(p, "</code>");
+    if (!p) return NULL;
+    p += 7; /* past "</code>" */
+    p = strchr(p, '(');
+    if (!p) return NULL;
+    p++;
+    const char *q = strchr(p, ')');
+    if (!q) return NULL;
+    size_t n = (size_t)(q - p);
+    char *out = (char *)malloc(n + 1);
+    if (!out) return NULL;
+    memcpy(out, p, n);
+    out[n] = '\0';
+    return out;
+}
+
+/* Step 2: derive version. PS L 1543-1547 chain:
+ *   $v = $download_name -ireplace "<name>-",""
+ *   if name == "connect-proxy"  : $v = $download_name -ireplace "ssh-connect-",""
+ *   if name == "python-pbr"     : $v = $download_name -ireplace "pbr-",""
+ *   $v = $v -ireplace ".tar.gz",""
+ *   $v = $v -ireplace "v",""
+ *
+ * Note: the special-case branches REPLACE $v entirely (off $download_name),
+ * not on top of the previous $v. We preserve that.
+ *
+ * Note: the final ireplace "v","" strips *every* occurrence of 'v',
+ * case-insensitively — a quirk of the PS author that we must keep
+ * (CLAUDE.md invariant #2: bug-fixes flow PS → spec → C, not vice versa).
+ */
+char *pr_koji_derive_version(const char *artefact_name, const char *download_name)
+{
+    if (artefact_name == NULL || download_name == NULL) return NULL;
+
+    char *v = NULL;
+    /* default: strip "<name>-" */
+    size_t nlen = strlen(artefact_name);
+    char *needle = (char *)malloc(nlen + 2);
+    if (!needle) return NULL;
+    memcpy(needle, artefact_name, nlen);
+    needle[nlen] = '-';
+    needle[nlen + 1] = '\0';
+    /* duplicate download_name into a heap copy first (istr_replace_all
+     * takes ownership). */
+    v = (char *)malloc(strlen(download_name) + 1);
+    if (!v) { free(needle); return NULL; }
+    memcpy(v, download_name, strlen(download_name) + 1);
+    v = istr_replace_all(v, needle, "");
+    free(needle);
+
+    /* Special cases override `v` from `download_name`. */
+    if (strcasecmp(artefact_name, "connect-proxy") == 0) {
+        free(v);
+        v = (char *)malloc(strlen(download_name) + 1);
+        if (!v) return NULL;
+        memcpy(v, download_name, strlen(download_name) + 1);
+        v = istr_replace_all(v, "ssh-connect-", "");
+    } else if (strcasecmp(artefact_name, "python-pbr") == 0) {
+        free(v);
+        v = (char *)malloc(strlen(download_name) + 1);
+        if (!v) return NULL;
+        memcpy(v, download_name, strlen(download_name) + 1);
+        v = istr_replace_all(v, "pbr-", "");
+    }
+
+    v = istr_replace_all(v, ".tar.gz", "");
+    v = istr_replace_all(v, "v", "");
+    return v;
+}
+
+/* PS Sort-Object {$_ -notlike '<*'},{($_ -replace '^.*?(\d+).*$','$1') -as [int]}
+ *   | select-object -last 1
+ *
+ * Translates to: among entries that DO NOT start with '<', pick the one
+ * whose first run-of-digits parses to the largest integer. Ties broken
+ * by stable insertion order (PS Sort-Object is stable).
+ *
+ * Returns a malloc'd copy of the winner, or NULL if no candidate exists.
+ */
+static long first_int_in(const char *s)
+{
+    long v = -1;
+    const char *p = s;
+    while (*p && !isdigit((unsigned char)*p)) p++;
+    if (!*p) return -1;
+    v = 0;
+    while (*p && isdigit((unsigned char)*p)) {
+        v = v * 10 + (*p - '0');
+        p++;
+    }
+    return v;
+}
+
+static char *pick_largest_numeric(char **cands, size_t n)
+{
+    long best = -1;
+    int  best_idx = -1;
+    for (size_t i = 0; i < n; i++) {
+        const char *c = cands[i];
+        if (c == NULL || c[0] == '\0') continue;
+        if (c[0] == '<') continue;
+        long v = first_int_in(c);
+        if (v < 0) continue;
+        if (v > best || best_idx < 0) {
+            best = v;
+            best_idx = (int)i;
+        } else if (v == best) {
+            /* PS stable sort: keep the EARLIER one when ties? No —
+             * PS `select-object -last 1` after stable sort keeps the
+             * LATER one of equal keys (since stable sort preserves
+             * input order and -last 1 takes the tail). */
+            best_idx = (int)i;
+        }
+    }
+    if (best_idx < 0) return NULL;
+    return strdup(cands[best_idx]);
+}
+
+/* PS:
+ *   $Names = (html -split '/">') -split '/</a>'
+ *   $Names = $Names | where { !($_ -match '<') -and ($_ -match '\d') }
+ *   pick the one with the largest leading int.
+ *
+ * "Split on A, then split each result on B" — concatenate the two split
+ * passes by splitting on either delimiter.
+ */
+char *pr_koji_pick_latest_release(const char *html)
+{
+    if (html == NULL) return NULL;
+    /* Tokenise on either '/">' or '/</a>' boundaries. */
+    char *copy = strdup(html);
+    if (!copy) return NULL;
+
+    size_t cap = 64, count = 0;
+    char **toks = (char **)malloc(cap * sizeof *toks);
+    if (!toks) { free(copy); return NULL; }
+
+    char *cur = copy;
+    while (*cur) {
+        char *next = NULL;
+        char *a = strstr(cur, "/\">");
+        char *b = strstr(cur, "/</a>");
+        char *hit = NULL;
+        size_t hit_len = 0;
+        if (a && (!b || a < b)) { hit = a; hit_len = 3; }
+        else if (b)             { hit = b; hit_len = 5; }
+        if (hit) {
+            *hit = '\0';
+            next = hit + hit_len;
+        }
+        /* PS where: skip if line contains '<' or has no digit. */
+        int has_lt = strchr(cur, '<') != NULL;
+        int has_dg = 0;
+        for (const char *p = cur; *p; p++) {
+            if (isdigit((unsigned char)*p)) { has_dg = 1; break; }
+        }
+        if (!has_lt && has_dg) {
+            if (count == cap) {
+                cap *= 2;
+                char **np = (char **)realloc(toks, cap * sizeof *toks);
+                if (!np) { free(copy); free(toks); return NULL; }
+                toks = np;
+            }
+            toks[count++] = cur;
+        }
+        if (!next) break;
+        cur = next;
+    }
+
+    char *winner = pick_largest_numeric(toks, count);
+    free(toks);
+    free(copy);
+    return winner;
+}
+
+/* PS:
+ *   $Names = (html -split '<a href="') -split '"'
+ *   $Names = $Names | where { !($_ -match '<') -and ($_ -match '.src.rpm') }
+ *   pick largest-numeric
+ */
+char *pr_koji_pick_latest_srpm(const char *html)
+{
+    if (html == NULL) return NULL;
+    char *copy = strdup(html);
+    if (!copy) return NULL;
+
+    size_t cap = 64, count = 0;
+    char **toks = (char **)malloc(cap * sizeof *toks);
+    if (!toks) { free(copy); return NULL; }
+
+    /* Tokenise on either '<a href="' or '"'. */
+    char *cur = copy;
+    while (*cur) {
+        char *next = NULL;
+        char *a = strstr(cur, "<a href=\"");
+        char *b = strchr(cur, '"');
+        char *hit = NULL;
+        size_t hit_len = 0;
+        if (a && (!b || a < b)) { hit = a; hit_len = 9; }
+        else if (b)             { hit = b; hit_len = 1; }
+        if (hit) {
+            *hit = '\0';
+            next = hit + hit_len;
+        }
+        int has_lt = strchr(cur, '<') != NULL;
+        int has_srpm = strstr(cur, ".src.rpm") != NULL;
+        if (!has_lt && has_srpm) {
+            if (count == cap) {
+                cap *= 2;
+                char **np = (char **)realloc(toks, cap * sizeof *toks);
+                if (!np) { free(copy); free(toks); return NULL; }
+                toks = np;
+            }
+            toks[count++] = cur;
+        }
+        if (!next) break;
+        cur = next;
+    }
+    char *winner = pick_largest_numeric(toks, count);
+    free(toks);
+    free(copy);
+    return winner;
+}
+
+/* ----- Public entry point ------------------------------------------- */
+
+int koji_fedora_lookup(const char *artefact_name, char **out_url)
+{
+    if (out_url == NULL) return -1;
+    *out_url = strdup("");
+    if (*out_url == NULL) return -1;
+    if (artefact_name == NULL || artefact_name[0] == '\0') return 0;
+
+    /* Step 1: GET src.fedoraproject.org sources page. */
+    char url1[1024];
+    snprintf(url1, sizeof url1,
+             "https://src.fedoraproject.org/rpms/%s/blob/main/f/sources",
+             artefact_name);
+
+    char *body1 = NULL;
+    if (http_get(url1, 10000, &body1) != 0) return 0;  /* silent miss */
+    char *dlname = pr_koji_parse_artefact_download_name(body1);
+    free(body1);
+    if (!dlname) return 0;
+
+    /* Step 2: derive version. */
+    char *version = pr_koji_derive_version(artefact_name, dlname);
+    free(dlname);
+    if (!version || version[0] == '\0') { free(version); return 0; }
+
+    /* Step 3: list release subdirs. */
+    char url2[1024];
+    snprintf(url2, sizeof url2,
+             "https://kojipkgs.fedoraproject.org/packages/%s/%s",
+             artefact_name, version);
+    char *body2 = NULL;
+    if (http_get(url2, 10000, &body2) != 0) { free(version); return 0; }
+    char *release = pr_koji_pick_latest_release(body2);
+    free(body2);
+    if (!release) { free(version); return 0; }
+
+    /* Step 4: list .src.rpm files. */
+    char url3[1024];
+    snprintf(url3, sizeof url3,
+             "https://kojipkgs.fedoraproject.org/packages/%s/%s/%s/src/",
+             artefact_name, version, release);
+    char *body3 = NULL;
+    if (http_get(url3, 10000, &body3) != 0) {
+        free(version); free(release); return 0;
+    }
+    char *srpm = pr_koji_pick_latest_srpm(body3);
+    free(body3);
+    if (!srpm) { free(version); free(release); return 0; }
+
+    /* Step 5: assemble final URL. */
+    char final_url[2048];
+    snprintf(final_url, sizeof final_url,
+             "https://kojipkgs.fedoraproject.org/packages/%s/%s/%s/src/%s",
+             artefact_name, version, release, srpm);
+    free(version); free(release); free(srpm);
+
+    free(*out_url);
+    *out_url = strdup(final_url);
+    return *out_url ? 0 : -1;
+}

--- a/photonos-package-report/photonos-package-report/src/urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/urlhealth.c
@@ -1,0 +1,175 @@
+/* urlhealth.c — urlhealth() port.
+ * Mirrors photonos-package-report.ps1 L 1458-1518 line-by-line.
+ *
+ * PS source (verbatim, condensed):
+ *
+ *   function urlhealth {
+ *       param([parameter(Mandatory=$true)]$checkurl)
+ *       $urlhealthrc = ""
+ *       try {
+ *           $request = [System.Net.HttpWebRequest]::Create($checkurl)
+ *           $request.Method  = "HEAD"
+ *           $request.Timeout = 120000
+ *           $rc = $request.GetResponse()
+ *           $urlhealthrc = [int]$rc.StatusCode
+ *           $rc.Close()
+ *       } catch {
+ *           $urlhealthrc = [int]$_.Exception.Response.StatusCode.value__
+ *           if (($checkurl -ilike '*netfilter.org*') -or
+ *               ($checkurl -ilike 'https://ftp.*')) {
+ *               # browser-mimic fallback: build a WebSession with
+ *               # User-Agent + Referer + Sec-Fetch-* headers, retry HEAD.
+ *           }
+ *       }
+ *       return $urlhealthrc
+ *   }
+ *
+ * Implementation notes:
+ *   - libcurl handles "HEAD" via CURLOPT_NOBODY=1 + CURLOPT_CUSTOMREQUEST.
+ *   - PS catches the WebException and reads .Response.StatusCode. libcurl
+ *     surfaces both layers in the same call: CURLINFO_RESPONSE_CODE is
+ *     the HTTP status (any value), and the curl_easy_perform return code
+ *     tells us whether the transport itself succeeded.
+ *   - For the netfilter/ftp fallback we re-run with full Chrome-mimic
+ *     headers, lifting the same User-Agent and Sec-Fetch-* string PS uses.
+ */
+#include "pr_urlhealth.h"
+
+#include <curl/curl.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+static const char *PR_UA_CHROME =
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36";
+
+/* Discard any response body from curl. */
+static size_t discard_cb(char *p, size_t s, size_t n, void *u)
+{
+    (void)p; (void)u;
+    return s * n;
+}
+
+/* Look up the netfilter Referer for a given checkurl by case-insensitive
+ * substring match. Mirrors PS L 1485-1494. Returns NULL when checkurl is
+ * outside the netfilter family. */
+static const char *netfilter_referer(const char *url)
+{
+    struct { const char *needle; const char *referer; } map[] = {
+        { "libnetfilter_conntrack",  "https://www.netfilter.org/projects/libnetfilter_conntrack/downloads.html" },
+        { "libmnl",                  "https://www.netfilter.org/projects/libmnl/downloads.html" },
+        { "libnetfilter_cthelper",   "https://www.netfilter.org/projects/libnetfilter_cthelper/downloads.html" },
+        { "libnetfilter_cttimeout",  "https://www.netfilter.org/projects/libnetfilter_cttimeout/downloads.html" },
+        { "libnetfilter_queue",      "https://www.netfilter.org/projects/libnetfilter_queue/downloads.html" },
+        { "libnfnetlink",            "https://www.netfilter.org/projects/libnfnetlink/downloads.html" },
+        { "libnftnl",                "https://www.netfilter.org/projects/libnftnl/downloads.html" },
+        { "nftables",                "https://www.netfilter.org/projects/nftables/downloads.html" },
+        { "conntrack-tools",         "https://www.netfilter.org/projects/conntrack-tools/downloads.html" },
+        { "iptables",                "https://www.netfilter.org/projects/iptables/downloads.html" },
+    };
+    size_t n = sizeof map / sizeof map[0];
+    for (size_t i = 0; i < n; i++) {
+        if (strcasestr(url, map[i].needle) != NULL) return map[i].referer;
+    }
+    return NULL;
+}
+
+/* True iff the URL qualifies for the browser-mimic fallback (PS L 1480). */
+static int needs_browser_fallback(const char *url)
+{
+    if (url == NULL) return 0;
+    if (strcasestr(url, "netfilter.org") != NULL) return 1;
+    if (strncasecmp(url, "https://ftp.", 12) == 0) return 1;
+    return 0;
+}
+
+static int curl_head(const char *url, long timeout_ms,
+                     struct curl_slist *headers, long *out_status)
+{
+    CURL *c = curl_easy_init();
+    if (!c) return -1;
+    curl_easy_setopt(c, CURLOPT_URL,           url);
+    curl_easy_setopt(c, CURLOPT_NOBODY,        1L);          /* HEAD */
+    curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION,1L);
+    curl_easy_setopt(c, CURLOPT_TIMEOUT_MS,    timeout_ms);
+    curl_easy_setopt(c, CURLOPT_USERAGENT,     "photonos-package-report/C");
+    curl_easy_setopt(c, CURLOPT_WRITEFUNCTION, discard_cb);
+    if (headers) curl_easy_setopt(c, CURLOPT_HTTPHEADER, headers);
+
+    long status = 0;
+    CURLcode rc = curl_easy_perform(c);
+    if (rc == CURLE_OK || rc == CURLE_HTTP_RETURNED_ERROR) {
+        curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &status);
+    }
+    curl_easy_cleanup(c);
+    *out_status = status;
+    return rc == CURLE_OK ? 0 : -1;
+}
+
+int urlhealth(const char *checkurl)
+{
+    if (checkurl == NULL || checkurl[0] == '\0') return 0;
+
+    long status = 0;
+    int  rc     = curl_head(checkurl, 120000, NULL, &status);
+    if (rc == 0 && status >= 200 && status < 400) {
+        return (int)status;
+    }
+
+    /* PS L 1480: fallback for netfilter/ftp URLs. */
+    if (!needs_browser_fallback(checkurl)) {
+        return (int)status;  /* HTTP-level error surfaces directly */
+    }
+
+    /* Build the Chrome-mimic header set, mirroring PS L 1497-1513. */
+    struct curl_slist *h = NULL;
+    h = curl_slist_append(h, "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7");
+    h = curl_slist_append(h, "Accept-Encoding: gzip, deflate, br");
+    h = curl_slist_append(h, "Accept-Language: en-US,en;q=0.9");
+    const char *ref = netfilter_referer(checkurl);
+    if (ref) {
+        char tmp[1024];
+        snprintf(tmp, sizeof tmp, "Referer: %s", ref);
+        h = curl_slist_append(h, tmp);
+    } else {
+        h = curl_slist_append(h, "Referer: ");
+    }
+    h = curl_slist_append(h, "Sec-Fetch-Dest: document");
+    h = curl_slist_append(h, "Sec-Fetch-Mode: navigate");
+    h = curl_slist_append(h, "Sec-Fetch-Site: same-origin");
+    h = curl_slist_append(h, "Sec-Fetch-User: ?1");
+    h = curl_slist_append(h, "Upgrade-Insecure-Requests: 1");
+    h = curl_slist_append(h, "sec-ch-ua: \"Google Chrome\";v=\"113\", \"Chromium\";v=\"113\", \"Not-A.Brand\";v=\"24\"");
+    h = curl_slist_append(h, "sec-ch-ua-mobile: ?0");
+    h = curl_slist_append(h, "sec-ch-ua-platform: \"Windows\"");
+
+    /* PS L 1497: -UseBasicParsing means "no DOM parsing"; in curl-land
+     * we just don't follow any meta refresh and use NOBODY for HEAD. */
+    /* PS L 1497: TimeoutSec 10 — PS uses 10s on the fallback path,
+     * NOT 120s. Preserve this exactly. */
+    CURL *c = curl_easy_init();
+    if (!c) { curl_slist_free_all(h); return (int)status; }
+    curl_easy_setopt(c, CURLOPT_URL,            checkurl);
+    curl_easy_setopt(c, CURLOPT_NOBODY,         1L);
+    curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(c, CURLOPT_TIMEOUT_MS,     10000);
+    curl_easy_setopt(c, CURLOPT_USERAGENT,      PR_UA_CHROME);
+    curl_easy_setopt(c, CURLOPT_WRITEFUNCTION,  discard_cb);
+    curl_easy_setopt(c, CURLOPT_HTTPHEADER,     h);
+    curl_easy_setopt(c, CURLOPT_ACCEPT_ENCODING,"");  /* "Accept-Encoding: gzip,deflate" + auto-decode */
+    long fb_status = 0;
+    CURLcode fb_rc = curl_easy_perform(c);
+    if (fb_rc == CURLE_OK || fb_rc == CURLE_HTTP_RETURNED_ERROR) {
+        curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &fb_status);
+    }
+    curl_easy_cleanup(c);
+    curl_slist_free_all(h);
+
+    /* PS L 1515: on success the fallback status wins; on inner-catch
+     * we keep whatever .Exception.Response.StatusCode reported. */
+    if (fb_rc == CURLE_OK || fb_status > 0) return (int)fb_status;
+    return (int)status;
+}

--- a/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
@@ -71,3 +71,19 @@ target_include_directories(test_phase4 PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_options(test_phase4 PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE)
 
 add_test(NAME test_phase4 COMMAND test_phase4)
+
+# ----- Phase 5 unit tests (urlhealth + Koji parsers) ------------------
+add_executable(test_phase5
+    test_phase5.c
+    ${CMAKE_SOURCE_DIR}/src/strutil.c
+    ${CMAKE_SOURCE_DIR}/src/urlhealth.c
+    ${CMAKE_SOURCE_DIR}/src/koji.c
+)
+target_include_directories(test_phase5 PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CURL_INCLUDE_DIRS}
+)
+target_link_libraries(test_phase5 PRIVATE ${CURL_LIBRARIES})
+target_compile_options(test_phase5 PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE ${CURL_CFLAGS_OTHER})
+
+add_test(NAME test_phase5 COMMAND test_phase5)

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase5.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase5.c
@@ -1,0 +1,149 @@
+/* test_phase5.c — unit tests for Phase 5 helpers.
+ *
+ * The live HTTP entry points (urlhealth(), koji_fedora_lookup()) are
+ * exercised only when PR_TEST_NETWORK=1 is set in the environment, so
+ * ctest stays offline-friendly. The pure HTML-parse helpers run
+ * unconditionally against canned input.
+ */
+#include "pr_urlhealth.h"
+#include "pr_koji.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures = 0;
+
+#define EXPECT_STREQ(actual, expected) do {                                    \
+    const char *_a = (actual);                                                 \
+    const char *_e = (expected);                                               \
+    if (_a == NULL || strcmp(_a, _e) != 0) {                                   \
+        fprintf(stderr, "  FAIL %s:%d: expected '%s' got '%s'\n",              \
+                __FILE__, __LINE__, _e, _a ? _a : "(null)");                   \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+#define EXPECT_NULL(actual) do {                                               \
+    if ((actual) != NULL) {                                                    \
+        fprintf(stderr, "  FAIL %s:%d: expected NULL\n", __FILE__, __LINE__);  \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+
+static void test_parse_artefact_download_name(void)
+{
+    fprintf(stderr, "[test_parse_artefact_download_name]\n");
+
+    /* Realistic shape of the src.fedoraproject.org sources page. */
+    const char *html =
+        "<html><body>\n"
+        "<pre><code class=\"hash\">SHA512\n"
+        "abc123</code> (libaio-0.3.111.tar.gz)\n"
+        "</pre></body></html>";
+    char *v = pr_koji_parse_artefact_download_name(html);
+    EXPECT_STREQ(v, "libaio-0.3.111.tar.gz");
+    free(v);
+
+    /* No <code> block at all → NULL. */
+    EXPECT_NULL(pr_koji_parse_artefact_download_name("no code here"));
+
+    /* <code> but no ()/) after it → NULL. */
+    EXPECT_NULL(pr_koji_parse_artefact_download_name(
+        "<code class=\"x\">abc</code> no parens"));
+}
+
+static void test_derive_version(void)
+{
+    fprintf(stderr, "[test_derive_version]\n");
+
+    /* Default: strip "<name>-" + ".tar.gz" + "v" (everywhere).
+     * NOTE the trailing "v" wildcard-strip — every 'v' in the string
+     * is removed by the PS author's final ireplace. */
+    char *v = pr_koji_derive_version("libaio", "libaio-0.3.111.tar.gz");
+    /* libaio-0.3.111.tar.gz → "0.3.111.tar.gz" → "0.3.111" → "0.3.111" */
+    EXPECT_STREQ(v, "0.3.111");
+    free(v);
+
+    /* The 'v'-strip eats letters too. */
+    v = pr_koji_derive_version("dummy", "dummy-v1.2.3.tar.gz");
+    EXPECT_STREQ(v, "1.2.3");
+    free(v);
+
+    /* connect-proxy special case: strip "ssh-connect-" instead of "<name>-". */
+    v = pr_koji_derive_version("connect-proxy", "ssh-connect-1.103.tar.gz");
+    EXPECT_STREQ(v, "1.103");
+    free(v);
+
+    /* python-pbr special case: strip "pbr-" instead. */
+    v = pr_koji_derive_version("python-pbr", "pbr-5.11.1.tar.gz");
+    EXPECT_STREQ(v, "5.11.1");
+    free(v);
+}
+
+static void test_pick_latest_release(void)
+{
+    fprintf(stderr, "[test_pick_latest_release]\n");
+
+    /* PS splits on '/">' and '/</a>'. After tokenisation the surviving
+     * candidates are the directory names embedded between `<a href=".../">`
+     * and `/</a>`. */
+    const char *html =
+        "<a href=\"19.fc41/\">19.fc41/</a>\n"
+        "<a href=\"20.fc42/\">20.fc42/</a>\n"
+        "<a href=\"21.fc42/\">21.fc42/</a>\n";
+    char *w = pr_koji_pick_latest_release(html);
+    /* 21 > 20 > 19 → "21.fc42" wins. */
+    EXPECT_STREQ(w, "21.fc42");
+    free(w);
+
+    /* Empty input → NULL. */
+    EXPECT_NULL(pr_koji_pick_latest_release(""));
+}
+
+static void test_pick_latest_srpm(void)
+{
+    fprintf(stderr, "[test_pick_latest_srpm]\n");
+
+    /* Real Koji src/ listings: bare .src.rpm files only, no .asc
+     * signatures. (When the listing does include a .asc, PS L 1551 keeps
+     * it because `-simplematch '.src.rpm'` is a substring test, and PS
+     * subsequently picks the last entry — known PS quirk preserved
+     * per CLAUDE.md invariant #2; we mirror, not fix.) */
+    const char *html =
+        "<a href=\"libaio-0.3.111-19.fc41.src.rpm\">libaio-0.3.111-19.fc41.src.rpm</a>\n"
+        "<a href=\"libaio-0.3.111-21.fc42.src.rpm\">libaio-0.3.111-21.fc42.src.rpm</a>\n";
+    char *w = pr_koji_pick_latest_srpm(html);
+    EXPECT_STREQ(w, "libaio-0.3.111-21.fc42.src.rpm");
+    free(w);
+}
+
+static void test_urlhealth_live(void)
+{
+    const char *enable = getenv("PR_TEST_NETWORK");
+    if (enable == NULL || strcmp(enable, "1") != 0) {
+        fprintf(stderr, "[test_urlhealth_live] SKIP (set PR_TEST_NETWORK=1 to run)\n");
+        return;
+    }
+    fprintf(stderr, "[test_urlhealth_live]\n");
+    int s = urlhealth("https://www.gnu.org/");
+    if (s != 200 && s != 301 && s != 302) {
+        fprintf(stderr, "  FAIL: expected 2xx/3xx from gnu.org, got %d\n", s);
+        failures++;
+    }
+}
+
+int main(void)
+{
+    test_parse_artefact_download_name();
+    test_derive_version();
+    test_pick_latest_release();
+    test_pick_latest_srpm();
+    test_urlhealth_live();
+
+    if (failures == 0) {
+        fprintf(stderr, "test_phase5: ALL PASSED\n");
+        return 0;
+    }
+    fprintf(stderr, "test_phase5: %d failure(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Ports the two network-aware helpers the per-task workflow needs:

- **`urlhealth(checkurl)`** — `libcurl` HEAD with 120s timeout. Returns the HTTP status code, with the PS L 1480 fallback path for `*netfilter.org*` and `https://ftp.*` URLs that 403 on plain HEAD: retry with the full Chrome-mimic header set (`User-Agent` + `Accept` + `Accept-Encoding` + `Accept-Language` + `Referer` + `Sec-Fetch-*` + `sec-ch-ua-*`) and a project-specific `Referer` map.
- **`koji_fedora_lookup(name, &out_url)`** — four-step HTML scrape of `src.fedoraproject.org` + `kojipkgs.fedoraproject.org` to find the latest `.src.rpm` for a Fedora package name. Mirrors PS L 1520-1572 byte-for-byte including known quirks (e.g. the final `-ireplace 'v',""` that strips every 'v' in the version string).

`pkg-config` confirms libcurl 8.19.0 on Photon. Wired into CMake as a hard dependency. `test_phase5` covers the deterministic HTML-parse helpers; live HTTP HEAD is opt-in via `PR_TEST_NETWORK=1` so ctest stays offline-friendly.

## Phase tracker
| Phase | Title | Status |
|-------|-------|--------|
| 0 | SDD scaffold | done (#52) |
| 1 | Foundation | done (#53) |
| 2 | Spec ingestion | done (#54) |
| 3a | Source0LookupData embed | done (#55) |
| 3b | Per-spec hook dispatch | done (#57) |
| 4 | Source0 substitution core | done (#58) |
| 5 | **URL health + Koji lookup (libcurl)** | **this PR** |
| 6 | CheckURLHealth main path + .prn assembly | pending |
| 7 | Cluster orchestrator + worker pool | pending |
| 8 | Side-by-side CI parity gate | pending |
| 9 | PS retirement | pending |
| M | Maintainer ops & debug tooling | PR #56 still open |

## PS-source mapping (strict parity)
| PS lines | Operation | C site |
|----------|-----------|--------|
| 1458-1469 | HEAD with 120s timeout | `src/urlhealth.c` curl_head |
| 1480 | Fallback gate: `*netfilter.org*` or `https://ftp.*` | `needs_browser_fallback` |
| 1485-1494 | Per-project `Referer` map | `netfilter_referer` |
| 1497-1513 | Chrome-mimic header bundle | `urlhealth()` second curl handle |
| 1520-1539 | Step 1: extract download name from `<code>(...)` | `pr_koji_parse_artefact_download_name` |
| 1543-1547 | Step 2: derive version + 2 special cases | `pr_koji_derive_version` |
| 1550-1556 | Step 3: pick highest-numbered release dir | `pr_koji_pick_latest_release` |
| 1558-1564 | Step 4: pick highest-numbered `.src.rpm` | `pr_koji_pick_latest_srpm` |
| 1566 | Step 5: assemble final URL | `koji_fedora_lookup` |
| 1571 | Silent-catch on miss | top-level `0` returns with `out_url=""` |

## Quirks preserved (CLAUDE.md invariant #2)
- **Trailing `-ireplace 'v',""`** (PS L 1547): strips every `'v'` from the version string, not just a leading one. Documented in `pr_koji_derive_version`.
- **`-simplematch '.src.rpm'`** (PS L 1551): substring-matches `.src.rpm.asc` too. When a real Koji listing exposes both a `.src.rpm` and a `.src.rpm.asc`, PS picks the last-sorted-by-leading-int (often the `.asc`). Mirrored, not fixed. The fixture intentionally uses a `.asc`-free listing to avoid muddying assertions; a `// quirk preserved` comment flags the behaviour in the test file.

## Test plan
- [x] `cmake -B build -S .` configures cleanly; libcurl detected via `pkg_check_modules`
- [x] `cmake --build build` zero warnings
- [x] `ctest --test-dir build` → 6/6 passed
  - `test_phase5` — 4 parser cases (download-name, derive-version + 2 special cases, pick-latest-release, pick-latest-srpm); live HEAD skipped offline
- [x] `PR_TEST_NETWORK=1 ctest -R test_phase5 --test-dir build --output-on-failure` — opt-in live HEAD to gnu.org

## Out of scope (deferred)
- The full `CheckURLHealth` orchestrator (PS L 1574+) — Phase 6, glues urlhealth/Koji/git-tag together and emits `.prn` rows
- Runbook section on urlhealth/koji debugging — depends on PR #56 (Phase M) being merged; will land in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)