### PR TITLE
phase-6a: CheckURLHealth scaffold + .prn writer + end-to-end pipeline

### DIFF
--- a/photonos-package-report/photonos-package-report/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/CMakeLists.txt
@@ -97,6 +97,9 @@ add_executable(photonos-package-report
     src/source0_substitute.c
     src/urlhealth.c
     src/koji.c
+    src/state.c
+    src/prn_writer.c
+    src/check_urlhealth.c
     ${PR_GEN_HOOK_DISPATCH}
     ${PR_HOOK_SOURCES}
 )

--- a/photonos-package-report/photonos-package-report/include/pr_check_urlhealth.h
+++ b/photonos-package-report/photonos-package-report/include/pr_check_urlhealth.h
@@ -1,0 +1,34 @@
+/* pr_check_urlhealth.h — CheckURLHealth orchestrator (Phase 6a scaffold).
+ *
+ * Mirrors photonos-package-report.ps1 L 1574-4934 in surface but only
+ * the minimal call chain is wired in 6a:
+ *
+ *   1. Look up the task in the Source0LookupData table (Phase 3a).
+ *   2. Apply the per-spec exception hook (Phase 3b stub).
+ *   3. Run pr_source0_substitute on the resolved Source0 (Phase 4).
+ *   4. Probe with urlhealth() (Phase 5).
+ *   5. Compose the 12-column .prn row from PS L 4933.
+ *
+ * Phase 6b-6f will progressively flesh out the columns currently
+ * stubbed to "":
+ *   - version comparison, UpdateAvailable           → Phase 6b
+ *   - git tag enumeration (HeapSort + Versioncompare)→ Phase 6c
+ *   - anomaly handlers (PS L 2205-3000)             → Phase 6d
+ *   - multi-branch diff reports                      → Phase 6e
+ *
+ * The function returns a malloc'd row string the caller frees. NULL on
+ * memory error. The row is NOT terminated by a newline — pr_prn_append_rows
+ * adds that.
+ */
+#ifndef PR_CHECK_URLHEALTH_H
+#define PR_CHECK_URLHEALTH_H
+
+#include "pr_types.h"
+#include "source0_lookup.h"
+
+/* Returns a malloc'd 12-column comma-separated row mirroring PS L 4933.
+ * Columns currently stubbed to "" are commented as such inside the body. */
+char *check_urlhealth(pr_task_t                       *task,
+                      const pr_source0_lookup_table_t *lookup_table);
+
+#endif /* PR_CHECK_URLHEALTH_H */

--- a/photonos-package-report/photonos-package-report/include/pr_prn.h
+++ b/photonos-package-report/photonos-package-report/include/pr_prn.h
@@ -1,0 +1,53 @@
+/* pr_prn.h — .prn report row schema + writer.
+ *
+ * The .prn file is a comma-separated text file with one header line
+ * (lifted verbatim from PS L 5068) followed by N row strings:
+ *
+ *   Spec,Source0 original,Modified Source0 for url health check,
+ *   UrlHealth,UpdateAvailable,UpdateURL,HealthUpdateURL,Name,SHAName,
+ *   UpdateDownloadName,warning,ArchivationDate
+ *
+ * Each row mirrors PS L 4933:
+ *
+ *   $spec, $source0, $Source0, $urlhealth, $UpdateAvailable, $UpdateURL,
+ *   $HealthUpdateURL, $Name, $SHAValue, $UpdateDownloadName, $Warning,
+ *   $ArchivationDate
+ *
+ * Rows are validated against PS L 5070 regex
+ *   ^(.*?)([a-zA-Z0-9][a-zA-Z0-9._-]*\.spec.*)$
+ * and the regex-stripped, sorted-ascending output is what reaches the
+ * .prn file. flock(LOCK_EX) guards each append so parallel runspaces
+ * (Phase 7) don't interleave (ADR-0010).
+ */
+#ifndef PR_PRN_H
+#define PR_PRN_H
+
+#include <stddef.h>
+
+/* Exact header bytes, NO trailing newline. The writer appends "\n". */
+extern const char PR_PRN_HEADER[];
+
+/* Open `path` for writing (truncate). Writes the header line. Returns
+ * a heap-allocated context that subsequent append calls use. NULL on
+ * failure. Caller must pr_prn_close(). */
+typedef struct pr_prn pr_prn_t;
+
+pr_prn_t *pr_prn_open(const char *path);
+
+/* Append a batch of row strings. Each row is:
+ *   - validated against the PS regex (rows without a `<spec>.spec`
+ *     anywhere are dropped — matches PS filter at L 5070)
+ *   - locale-C-sorted ascending
+ *   - appended under flock(LOCK_EX).
+ *
+ * Returns 0 on success, -1 on I/O error. */
+int pr_prn_append_rows(pr_prn_t *ctx, char **rows, size_t n_rows);
+
+/* Flush + close + free. */
+int pr_prn_close(pr_prn_t *ctx);
+
+/* Apply PS L 5070 stripping to a row in place. Returns the offset of
+ * the kept substring in `row`, or -1 if the row doesn't match. */
+const char *pr_prn_strip(const char *row);
+
+#endif /* PR_PRN_H */

--- a/photonos-package-report/photonos-package-report/include/pr_state.h
+++ b/photonos-package-report/photonos-package-report/include/pr_state.h
@@ -1,0 +1,47 @@
+/* pr_state.h — per-task scratch state.
+ *
+ * In PS, `CheckURLHealth` mutates a handful of local variables as it
+ * walks each task: $Source0, $version, $UpdateAvailable, $UpdateURL,
+ * $HealthUpdateURL, $UpdateDownloadName, $SHAValue, $Warning,
+ * $ArchivationDate. These are the columns the function ultimately
+ * concatenates into the .prn row at PS L 4933.
+ *
+ * In the C port these locals are wrapped in pr_state_t so they can be
+ * passed to:
+ *   - pr_source0_substitute() (Phase 4)
+ *   - urlhealth()             (Phase 5)
+ *   - pr_hooks_run()          (Phase 3b — per-spec exception bodies)
+ *
+ * The struct is the *only* concrete definition of pr_state_t. Phase 3b
+ * forward-declared it; that forward decl is now satisfied by including
+ * this header before pr_hook.h.
+ *
+ * All string fields are heap-allocated empty strings ("") by
+ * pr_state_init(). Hook bodies mutate them in-place via the strutil
+ * helpers; pr_state_free() releases everything.
+ */
+#ifndef PR_STATE_H
+#define PR_STATE_H
+
+#include <stddef.h>
+
+/* Concrete definition. Phase 3b forward-declared `struct pr_state`. */
+struct pr_state {
+    char *Source0;             /* PS local $Source0 — Source0 after substitution */
+    char *version;             /* PS local $version */
+    char *UpdateAvailable;     /* PS $UpdateAvailable: "" / "Update available" / ... */
+    char *UpdateURL;
+    char *HealthUpdateURL;
+    char *UpdateDownloadName;
+    char *SHAValue;
+    char *Warning;
+    char *ArchivationDate;
+};
+
+typedef struct pr_state pr_state_t;
+
+/* Lifecycle. Both are safe to call on a zero-initialised struct. */
+void pr_state_init(pr_state_t *s);
+void pr_state_free(pr_state_t *s);
+
+#endif /* PR_STATE_H */

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1,0 +1,123 @@
+/* check_urlhealth.c — CheckURLHealth orchestrator scaffold (Phase 6a).
+ *
+ * Mirrors photonos-package-report.ps1 L 1574-4934 in *surface* — the
+ * 12-column row layout from PS L 4933 is locked here. Body wires:
+ *
+ *   - Phase 3a Source0LookupData lookup
+ *   - Phase 3b per-spec hook dispatch
+ *   - Phase 4 substitution
+ *   - Phase 5 urlhealth probe
+ *
+ * Columns 5-7, 10 are emitted as "" until Phase 6b-6d land. Columns
+ * 11-12 (Warning, ArchivationDate) are populated from the Source0Lookup
+ * row when one exists (PS L 2145-2153). Column 9 (SHAValue) is stubbed
+ * until Phase 6d.
+ */
+/* _GNU_SOURCE for asprintf is provided via CMake; do not redefine. */
+#include "pr_check_urlhealth.h"
+#include "pr_hook.h"
+#include "pr_state.h"
+#include "pr_substitute.h"
+#include "pr_urlhealth.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Look up the Source0Lookup row whose specfile matches task->Spec.
+ * Returns NULL if the table is unset or no row matches. */
+static const pr_source0_lookup_t *
+lookup_row(const pr_source0_lookup_table_t *t, const char *spec)
+{
+    if (t == NULL || spec == NULL) return NULL;
+    for (size_t i = 0; i < t->count; i++) {
+        if (strcmp(t->rows[i].specfile, spec) == 0) {
+            return &t->rows[i];
+        }
+    }
+    return NULL;
+}
+
+/* xstrdup that returns "" on NULL input rather than NULL. */
+static char *dup_or_empty(const char *s)
+{
+    if (s == NULL) s = "";
+    size_t n = strlen(s);
+    char *p = (char *)malloc(n + 1);
+    if (p) memcpy(p, s, n + 1);
+    return p;
+}
+
+char *check_urlhealth(pr_task_t                       *task,
+                      const pr_source0_lookup_table_t *lookup_table)
+{
+    if (task == NULL || task->Spec == NULL) return NULL;
+
+    pr_state_t state;
+    pr_state_init(&state);
+
+    /* PS L 2140-2153: Source0Lookup CSV lookup. */
+    const pr_source0_lookup_t *row = lookup_row(lookup_table, task->Spec);
+    if (row && row->Source0Lookup && row->Source0Lookup[0] != '\0') {
+        free(state.Source0);
+        state.Source0 = dup_or_empty(row->Source0Lookup);
+    } else {
+        free(state.Source0);
+        state.Source0 = dup_or_empty(task->Source0);
+    }
+    /* PS L 2151-2152: pick up Warning + ArchivationDate from the
+     * lookup row when present. (Strings "" otherwise.) */
+    if (row) {
+        free(state.Warning);
+        state.Warning = dup_or_empty(row->Warning);
+        free(state.ArchivationDate);
+        state.ArchivationDate = dup_or_empty(row->ArchivationDate);
+    }
+
+    /* PS L 2108: $version cut. Phase 6b refines this; for 6a we use
+     * task->Version verbatim. */
+    free(state.version);
+    state.version = dup_or_empty(task->Version);
+
+    /* Phase 3b per-spec exception hook. */
+    pr_hooks_run(task, &state);
+
+    /* Phase 4 substitution (PS L 2172-2199). */
+    pr_source0_substitute(task, &state.Source0, state.version);
+
+    /* Phase 5 urlhealth probe. Skipped offline so ctest stays hermetic. */
+    int health = 0;
+    const char *netenv = getenv("PR_TEST_NETWORK");
+    if (netenv && strcmp(netenv, "1") == 0) {
+        health = urlhealth(state.Source0);
+    }
+
+    /* PS L 4933: assemble the 12-column row.
+     *
+     *   $currentTask.spec , $currentTask.source0 , $Source0 ,
+     *   $urlhealth , $UpdateAvailable , $UpdateURL , $HealthUpdateURL ,
+     *   $currentTask.Name , $SHAValue , $UpdateDownloadName , $Warning ,
+     *   $ArchivationDate
+     */
+    char *out = NULL;
+    if (asprintf(&out,
+                 "%s,%s,%s,%d,%s,%s,%s,%s,%s,%s,%s,%s",
+                 task->Spec,                                      /*  1 Spec */
+                 task->Source0 ? task->Source0 : "",              /*  2 Source0 original */
+                 state.Source0,                                   /*  3 Source0 (rewritten) */
+                 health,                                          /*  4 UrlHealth (0 offline) */
+                 state.UpdateAvailable,                           /*  5 — Phase 6b */
+                 state.UpdateURL,                                 /*  6 — Phase 6c */
+                 state.HealthUpdateURL,                           /*  7 — Phase 6c */
+                 task->Name,                                      /*  8 Name */
+                 state.SHAValue,                                  /*  9 — Phase 6d */
+                 state.UpdateDownloadName,                        /* 10 — Phase 6c */
+                 state.Warning,                                   /* 11 from lookup row */
+                 state.ArchivationDate                            /* 12 from lookup row */
+                 ) < 0) {
+        out = NULL;
+    }
+
+    pr_state_free(&state);
+    return out;
+}

--- a/photonos-package-report/photonos-package-report/src/main.c
+++ b/photonos-package-report/photonos-package-report/src/main.c
@@ -26,9 +26,14 @@
 #include <pwd.h>
 
 #include "pr_types.h"
+#include "pr_check_urlhealth.h"
+#include "pr_prn.h"
+#include "source0_lookup.h"
+#include <time.h>
 
-/* Forward declaration for the Phase 2 parity helper. Defined at bottom. */
+/* Forward declarations for helper subcommands. */
 static int dump_tasks_main(const char *working_dir, const char *branch);
+static int generate_urlhealth_main(const pr_params_t *params, const char *branch);
 
 /* Helper: getenv() returning const char *""  rather than NULL,
  * matching the PS implicit-empty semantics for $env:FOO when unset. */
@@ -135,9 +140,11 @@ int main(int argc, char **argv)
         OPT_GeneratePh5toPh6DiffHigherPackageVersionReport,
         OPT_GeneratePh4toPh5DiffHigherPackageVersionReport,
         OPT_GeneratePh3toPh4DiffHigherPackageVersionReport,
-        OPT_dump_tasks,  /* Phase 2 parity helper, not present in PS. */
+        OPT_dump_tasks,                /* Phase 2 parity helper, not in PS. */
+        OPT_generate_urlhealth_report, /* Phase 6a end-to-end pipeline.    */
     };
-    const char *dump_tasks_branch = NULL;
+    const char *dump_tasks_branch          = NULL;
+    const char *generate_urlhealth_branch  = NULL;
     static const struct option long_opts[] = {
         { "github_token",                                                       required_argument, 0, OPT_github_token },
         { "gitlab_freedesktop_org_username",                                    required_argument, 0, OPT_gitlab_freedesktop_org_username },
@@ -159,6 +166,7 @@ int main(int argc, char **argv)
         { "GeneratePh4toPh5DiffHigherPackageVersionReport",                     required_argument, 0, OPT_GeneratePh4toPh5DiffHigherPackageVersionReport },
         { "GeneratePh3toPh4DiffHigherPackageVersionReport",                     required_argument, 0, OPT_GeneratePh3toPh4DiffHigherPackageVersionReport },
         { "dump-tasks",                                                         required_argument, 0, OPT_dump_tasks },
+        { "generate-urlhealth-report",                                          required_argument, 0, OPT_generate_urlhealth_report },
         { "help",                                                               no_argument,       0, 'h' },
         { 0, 0, 0, 0 },
     };
@@ -192,6 +200,8 @@ int main(int argc, char **argv)
             params.GeneratePh3toPh4DiffHigherPackageVersionReport = convert_to_boolean(optarg); break;
         case OPT_dump_tasks:
             dump_tasks_branch = optarg; break;
+        case OPT_generate_urlhealth_report:
+            generate_urlhealth_branch = optarg; break;
         case 'h':
             usage(argv[0]);
             return 0;
@@ -247,6 +257,10 @@ int main(int argc, char **argv)
      * tools/dump-tasks.ps1. */
     if (dump_tasks_branch != NULL && dump_tasks_branch[0] != '\0') {
         return dump_tasks_main(params.workingDir, dump_tasks_branch);
+    }
+
+    if (generate_urlhealth_branch != NULL && generate_urlhealth_branch[0] != '\0') {
+        return generate_urlhealth_main(&params, generate_urlhealth_branch);
     }
 
     return 0;
@@ -349,5 +363,76 @@ static int dump_tasks_main(const char *working_dir, const char *branch)
     }
 
     pr_task_list_free(&list);
+    return 0;
+}
+
+/* ===== Phase 6a: --generate-urlhealth-report <branch> ===============
+ *
+ * Walks parse_directory(workingDir, branch) → for each task, calls
+ * check_urlhealth() → writes a .prn file named
+ *
+ *   photonos-urlhealth-<branch>_<yyyyMMddHHmm>.prn
+ *
+ * under scansDir (defaults to workingDir if -scansDir was not given).
+ *
+ * Sequential only. Parallel runspaces land in Phase 7. Columns past
+ * UrlHealth are stubbed until Phase 6b-6f; the row schema itself is
+ * already the final PS L 4933 layout. */
+
+static int generate_urlhealth_main(const pr_params_t *params, const char *branch)
+{
+    pr_task_list_t list;
+    pr_task_list_init(&list);
+    if (parse_directory(params->workingDir, branch, &list) != 0) {
+        pr_task_list_free(&list);
+        return 1;
+    }
+
+    /* Source0LookupData (Phase 3a). Loaded once and shared across tasks. */
+    pr_source0_lookup_table_t lut;
+    if (source0_lookup(&lut) != 0) {
+        pr_task_list_free(&list);
+        return 1;
+    }
+
+    /* Build output path. */
+    const char *scans_dir = (params->scansDir && params->scansDir[0])
+                            ? params->scansDir : params->workingDir;
+    time_t now = time(NULL);
+    struct tm tm; localtime_r(&now, &tm);
+    char ts[16];
+    strftime(ts, sizeof ts, "%Y%m%d%H%M", &tm);
+
+    char out_path[PR_MAX_PATH];
+    snprintf(out_path, sizeof out_path,
+             "%s/photonos-urlhealth-%s_%s.prn", scans_dir, branch, ts);
+
+    pr_prn_t *p = pr_prn_open(out_path);
+    if (!p) {
+        fprintf(stderr, "generate_urlhealth: cannot open %s\n", out_path);
+        pr_source0_lookup_free(&lut);
+        pr_task_list_free(&list);
+        return 1;
+    }
+
+    /* Build rows for every task. */
+    char **rows = (char **)calloc(list.count, sizeof *rows);
+    if (!rows) {
+        pr_prn_close(p); pr_source0_lookup_free(&lut); pr_task_list_free(&list);
+        return 1;
+    }
+    for (size_t i = 0; i < list.count; i++) {
+        rows[i] = check_urlhealth(&list.items[i], &lut);
+    }
+    pr_prn_append_rows(p, rows, list.count);
+
+    for (size_t i = 0; i < list.count; i++) free(rows[i]);
+    free(rows);
+
+    pr_prn_close(p);
+    pr_source0_lookup_free(&lut);
+    pr_task_list_free(&list);
+
+    fprintf(stderr, "Wrote %s\n", out_path);
     return 0;
 }

--- a/photonos-package-report/photonos-package-report/src/prn_writer.c
+++ b/photonos-package-report/photonos-package-report/src/prn_writer.c
@@ -1,0 +1,140 @@
+/* prn_writer.c — .prn report writer.
+ *
+ * Mirrors photonos-package-report.ps1 L 5048-5078 (the per-branch
+ * outer loop in GenerateUrlHealthReports). The header line, the row
+ * regex filter, the ascending sort, and the append semantics all
+ * match PS byte-for-byte.
+ *
+ * Concurrency: pr_prn_append_rows() takes flock(LOCK_EX) for the
+ * duration of the write so parallel Phase 7 workers cannot interleave.
+ */
+#include "pr_prn.h"
+
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/file.h>
+
+/* PS L 5068: header literal, verbatim. */
+const char PR_PRN_HEADER[] =
+    "Spec,Source0 original,Modified Source0 for url health check,"
+    "UrlHealth,UpdateAvailable,UpdateURL,HealthUpdateURL,Name,SHAName,"
+    "UpdateDownloadName,warning,ArchivationDate";
+
+struct pr_prn {
+    FILE       *f;
+    int         fd;
+    pcre2_code *re_filter;
+};
+
+pr_prn_t *pr_prn_open(const char *path)
+{
+    if (path == NULL) return NULL;
+    pr_prn_t *ctx = (pr_prn_t *)calloc(1, sizeof *ctx);
+    if (!ctx) return NULL;
+
+    ctx->f = fopen(path, "w");
+    if (!ctx->f) { free(ctx); return NULL; }
+    ctx->fd = fileno(ctx->f);
+
+    /* Compile the row filter once. Pattern from PS L 5070:
+     *   ^(.*?)([a-zA-Z0-9][a-zA-Z0-9._-]*\.spec.*)$
+     * We want capture group 2. */
+    int       err_code = 0;
+    PCRE2_SIZE err_off = 0;
+    ctx->re_filter = pcre2_compile(
+        (PCRE2_SPTR)"^(.*?)([a-zA-Z0-9][a-zA-Z0-9._-]*\\.spec.*)$",
+        PCRE2_ZERO_TERMINATED, 0, &err_code, &err_off, NULL);
+    if (!ctx->re_filter) {
+        fclose(ctx->f);
+        free(ctx);
+        return NULL;
+    }
+
+    /* Header. */
+    fwrite(PR_PRN_HEADER, 1, sizeof(PR_PRN_HEADER) - 1, ctx->f);
+    fputc('\n', ctx->f);
+    return ctx;
+}
+
+const char *pr_prn_strip(const char *row)
+{
+    /* Static compile of the same pattern; used by callers (and tests)
+     * that don't have a pr_prn_t in hand. */
+    static pcre2_code *re = NULL;
+    if (re == NULL) {
+        int       err_code = 0;
+        PCRE2_SIZE err_off = 0;
+        re = pcre2_compile(
+            (PCRE2_SPTR)"^(.*?)([a-zA-Z0-9][a-zA-Z0-9._-]*\\.spec.*)$",
+            PCRE2_ZERO_TERMINATED, 0, &err_code, &err_off, NULL);
+        if (!re) return NULL;
+    }
+    pcre2_match_data *md = pcre2_match_data_create_from_pattern(re, NULL);
+    int rc = pcre2_match(re, (PCRE2_SPTR)row, PCRE2_ZERO_TERMINATED, 0, 0, md, NULL);
+    const char *out = NULL;
+    if (rc >= 0) {
+        PCRE2_SIZE *ov = pcre2_get_ovector_pointer(md);
+        /* Group 2 starts at ov[4]. */
+        out = row + ov[4];
+    }
+    pcre2_match_data_free(md);
+    return out;
+}
+
+/* qsort comparator: locale-C strcmp ascending. */
+static int cmp_str_asc(const void *a, const void *b)
+{
+    const char *const *sa = (const char *const *)a;
+    const char *const *sb = (const char *const *)b;
+    return strcmp(*sa, *sb);
+}
+
+int pr_prn_append_rows(pr_prn_t *ctx, char **rows, size_t n_rows)
+{
+    if (ctx == NULL) return -1;
+    if (rows == NULL || n_rows == 0) return 0;
+
+    /* Filter. */
+    char **kept = (char **)malloc(n_rows * sizeof *kept);
+    if (!kept) return -1;
+    size_t k = 0;
+    for (size_t i = 0; i < n_rows; i++) {
+        if (rows[i] == NULL) continue;
+        const char *s = pr_prn_strip(rows[i]);
+        if (s == NULL) continue;
+        kept[k++] = (char *)s;
+    }
+    if (k == 0) { free(kept); return 0; }
+
+    /* Sort ascending. */
+    qsort(kept, k, sizeof *kept, cmp_str_asc);
+
+    /* Locked append. */
+    if (flock(ctx->fd, LOCK_EX) != 0) { free(kept); return -1; }
+    for (size_t i = 0; i < k; i++) {
+        fputs(kept[i], ctx->f);
+        fputc('\n', ctx->f);
+    }
+    fflush(ctx->f);
+    flock(ctx->fd, LOCK_UN);
+    free(kept);
+    return 0;
+}
+
+int pr_prn_close(pr_prn_t *ctx)
+{
+    if (ctx == NULL) return 0;
+    int rc = 0;
+    if (ctx->f) {
+        if (fflush(ctx->f) != 0) rc = -1;
+        if (fclose(ctx->f) != 0) rc = -1;
+    }
+    if (ctx->re_filter) pcre2_code_free(ctx->re_filter);
+    free(ctx);
+    return rc;
+}

--- a/photonos-package-report/photonos-package-report/src/state.c
+++ b/photonos-package-report/photonos-package-report/src/state.c
@@ -1,0 +1,41 @@
+/* state.c — pr_state_t lifecycle. */
+#include "pr_state.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static char *new_empty(void)
+{
+    char *s = (char *)malloc(1);
+    if (s) s[0] = '\0';
+    return s;
+}
+
+void pr_state_init(pr_state_t *s)
+{
+    if (s == NULL) return;
+    s->Source0            = new_empty();
+    s->version            = new_empty();
+    s->UpdateAvailable    = new_empty();
+    s->UpdateURL          = new_empty();
+    s->HealthUpdateURL    = new_empty();
+    s->UpdateDownloadName = new_empty();
+    s->SHAValue           = new_empty();
+    s->Warning            = new_empty();
+    s->ArchivationDate    = new_empty();
+}
+
+void pr_state_free(pr_state_t *s)
+{
+    if (s == NULL) return;
+    free(s->Source0);
+    free(s->version);
+    free(s->UpdateAvailable);
+    free(s->UpdateURL);
+    free(s->HealthUpdateURL);
+    free(s->UpdateDownloadName);
+    free(s->SHAValue);
+    free(s->Warning);
+    free(s->ArchivationDate);
+    memset(s, 0, sizeof *s);
+}

--- a/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
@@ -87,3 +87,32 @@ target_link_libraries(test_phase5 PRIVATE ${CURL_LIBRARIES})
 target_compile_options(test_phase5 PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE ${CURL_CFLAGS_OTHER})
 
 add_test(NAME test_phase5 COMMAND test_phase5)
+
+# ----- Phase 6a unit tests (pr_state + prn writer + CheckURLHealth) ---
+set_source_files_properties(${PR_GEN_HOOK_DISPATCH} PROPERTIES GENERATED TRUE)
+
+add_executable(test_phase6
+    test_phase6.c
+    ${CMAKE_SOURCE_DIR}/src/state.c
+    ${CMAKE_SOURCE_DIR}/src/strutil.c
+    ${CMAKE_SOURCE_DIR}/src/source0_substitute.c
+    ${CMAKE_SOURCE_DIR}/src/source0_lookup.c
+    ${CMAKE_SOURCE_DIR}/src/urlhealth.c
+    ${CMAKE_SOURCE_DIR}/src/prn_writer.c
+    ${CMAKE_SOURCE_DIR}/src/check_urlhealth.c
+    ${CMAKE_SOURCE_DIR}/src/hook_dispatch.c
+    ${CMAKE_SOURCE_DIR}/src/task.c
+    ${PR_GEN_HOOK_DISPATCH}
+    ${PR_HOOK_SOURCES}
+)
+add_dependencies(test_phase6 pr-source0-lookup-data pr-hook-dispatch)
+target_include_directories(test_phase6 PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${PR_GEN_DIR}
+    ${PCRE2_INCLUDE_DIRS}
+    ${CURL_INCLUDE_DIRS}
+)
+target_link_libraries(test_phase6 PRIVATE pthread ${PCRE2_LIBRARIES} ${CURL_LIBRARIES})
+target_compile_options(test_phase6 PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER} ${CURL_CFLAGS_OTHER})
+
+add_test(NAME test_phase6 COMMAND test_phase6)

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase6.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase6.c
@@ -1,0 +1,192 @@
+/* test_phase6.c — unit tests for Phase 6a.
+ *
+ * Coverage:
+ *   - pr_state_init / pr_state_free zero-cost lifecycle
+ *   - PR_PRN_HEADER bytes match the PS L 5068 literal
+ *   - pr_prn_strip drops rows that don't contain a `<spec>.spec`
+ *   - pr_prn_open writes the header, append+close round-trips, rows
+ *     are sorted ascending and filtered.
+ *   - check_urlhealth() returns a row with exactly 11 commas (12
+ *     columns) starting with the spec basename.
+ *
+ * Live HTTP is skipped unless PR_TEST_NETWORK=1.
+ */
+#include "pr_check_urlhealth.h"
+#include "pr_prn.h"
+#include "pr_state.h"
+#include "pr_types.h"
+#include "source0_lookup.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int failures = 0;
+
+#define EXPECT_STREQ(actual, expected) do {                                    \
+    const char *_a = (actual);                                                 \
+    const char *_e = (expected);                                               \
+    if (_a == NULL || strcmp(_a, _e) != 0) {                                   \
+        fprintf(stderr, "  FAIL %s:%d: expected '%s' got '%s'\n",              \
+                __FILE__, __LINE__, _e, _a ? _a : "(null)");                   \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+#define EXPECT_INT(actual, expected) do {                                      \
+    long _a = (long)(actual);                                                  \
+    long _e = (long)(expected);                                                \
+    if (_a != _e) {                                                            \
+        fprintf(stderr, "  FAIL %s:%d: expected %ld got %ld\n",                \
+                __FILE__, __LINE__, _e, _a);                                   \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+
+/* --- pr_state lifecycle --------------------------------------------- */
+static void test_state(void)
+{
+    fprintf(stderr, "[test_state]\n");
+    pr_state_t s;
+    pr_state_init(&s);
+    /* All fields point at heap "" — non-NULL, length 0. */
+    EXPECT_STREQ(s.Source0,            "");
+    EXPECT_STREQ(s.version,            "");
+    EXPECT_STREQ(s.UpdateAvailable,    "");
+    EXPECT_STREQ(s.UpdateURL,          "");
+    EXPECT_STREQ(s.HealthUpdateURL,    "");
+    EXPECT_STREQ(s.UpdateDownloadName, "");
+    EXPECT_STREQ(s.SHAValue,           "");
+    EXPECT_STREQ(s.Warning,            "");
+    EXPECT_STREQ(s.ArchivationDate,    "");
+    pr_state_free(&s);
+}
+
+/* --- header constant ------------------------------------------------- */
+static void test_header_literal(void)
+{
+    fprintf(stderr, "[test_header_literal]\n");
+    EXPECT_STREQ(PR_PRN_HEADER,
+        "Spec,Source0 original,Modified Source0 for url health check,"
+        "UrlHealth,UpdateAvailable,UpdateURL,HealthUpdateURL,Name,SHAName,"
+        "UpdateDownloadName,warning,ArchivationDate");
+}
+
+/* --- prn_strip ------------------------------------------------------- */
+static void test_strip(void)
+{
+    fprintf(stderr, "[test_strip]\n");
+    /* Row that starts with garbage and then has a spec basename. */
+    const char *r = pr_prn_strip("WARN:: hello.spec,a,b,200,...");
+    /* The PS regex strips the "WARN:: " prefix and keeps from the spec. */
+    if (r == NULL) { failures++; fprintf(stderr, "  FAIL: strip returned NULL on a valid row\n"); }
+    else if (strncmp(r, "hello.spec,", 11) != 0) {
+        fprintf(stderr, "  FAIL: strip kept '%s'\n", r); failures++;
+    }
+    /* Row with no `.spec` at all → NULL. */
+    if (pr_prn_strip("just,some,comma,data") != NULL) {
+        fprintf(stderr, "  FAIL: strip kept a row with no .spec\n"); failures++;
+    }
+}
+
+/* --- writer round-trip ---------------------------------------------- */
+static void test_writer_roundtrip(void)
+{
+    fprintf(stderr, "[test_writer_roundtrip]\n");
+    char tmpl[] = "/tmp/test_phase6_prn_XXXXXX";
+    int fd = mkstemp(tmpl);
+    if (fd < 0) { failures++; return; }
+    close(fd);
+
+    pr_prn_t *p = pr_prn_open(tmpl);
+    if (!p) { failures++; unlink(tmpl); return; }
+
+    /* Three rows, intentionally unsorted, one a non-match. */
+    char *rows[] = {
+        (char *)"zsh.spec,,,200,,,,,zsh,,,,",
+        (char *)"NOT A ROW WITH SPEC",
+        (char *)"abseil-cpp.spec,,,200,,,,,abseil-cpp,,,,",
+        (char *)"hello.spec,,,200,,,,,hello,,,,",
+    };
+    if (pr_prn_append_rows(p, rows, 4) != 0) failures++;
+    pr_prn_close(p);
+
+    /* Read back. */
+    FILE *r = fopen(tmpl, "rb");
+    if (!r) { failures++; unlink(tmpl); return; }
+    char line[1024];
+    int  lineno = 0;
+    const char *expected[] = {
+        "Spec,Source0 original,Modified Source0 for url health check,UrlHealth,UpdateAvailable,UpdateURL,HealthUpdateURL,Name,SHAName,UpdateDownloadName,warning,ArchivationDate",
+        "abseil-cpp.spec,,,200,,,,,abseil-cpp,,,,",
+        "hello.spec,,,200,,,,,hello,,,,",
+        "zsh.spec,,,200,,,,,zsh,,,,",
+    };
+    while (fgets(line, sizeof line, r)) {
+        size_t n = strlen(line);
+        while (n > 0 && (line[n - 1] == '\n' || line[n - 1] == '\r')) line[--n] = '\0';
+        if (lineno >= 4) {
+            fprintf(stderr, "  FAIL: extra line: %s\n", line); failures++;
+            break;
+        }
+        if (strcmp(line, expected[lineno]) != 0) {
+            fprintf(stderr, "  FAIL line %d: expected '%s' got '%s'\n",
+                    lineno, expected[lineno], line);
+            failures++;
+        }
+        lineno++;
+    }
+    if (lineno != 4) {
+        fprintf(stderr, "  FAIL: got %d lines, expected 4\n", lineno);
+        failures++;
+    }
+    fclose(r);
+    unlink(tmpl);
+}
+
+/* --- check_urlhealth row shape -------------------------------------- */
+static int count_commas(const char *s)
+{
+    int n = 0;
+    for (; *s; s++) if (*s == ',') n++;
+    return n;
+}
+
+static void test_check_urlhealth_shape(void)
+{
+    fprintf(stderr, "[test_check_urlhealth_shape]\n");
+
+    /* Minimal task. */
+    pr_task_t t;
+    memset(&t, 0, sizeof t);
+    t.Spec    = (char *)"hello.spec";
+    t.Source0 = (char *)"https://example.invalid/hello-%{version}.tar.gz";
+    t.Name    = (char *)"hello";
+    t.Version = (char *)"2.10";
+    t.url     = (char *)"";
+
+    char *row = check_urlhealth(&t, NULL);
+    if (!row) { failures++; fprintf(stderr, "  FAIL: NULL row\n"); return; }
+    EXPECT_INT(count_commas(row), 11);  /* 12 cols → 11 commas */
+    /* Starts with the spec basename. */
+    if (strncmp(row, "hello.spec,", 11) != 0) {
+        fprintf(stderr, "  FAIL: row prefix '%s'\n", row); failures++;
+    }
+    free(row);
+}
+
+int main(void)
+{
+    test_state();
+    test_header_literal();
+    test_strip();
+    test_writer_roundtrip();
+    test_check_urlhealth_shape();
+
+    if (failures == 0) {
+        fprintf(stderr, "test_phase6: ALL PASSED\n");
+        return 0;
+    }
+    fprintf(stderr, "test_phase6: %d failure(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Phase 6 is the largest single function in PS (`CheckURLHealth` spans L 1574-4934, ~3,360 lines). Splitting into **6a-6f**; this PR ships **6a** — the scaffold that wires Phase 2-5 into an end-to-end pipeline producing a real `.prn` file.

A C-side run against the fixture tree now emits:
```
$ ./build/photonos-package-report -workingDir tests/fixtures -scansDir /tmp \
      --generate-urlhealth-report photon-fixture
Wrote /tmp/photonos-urlhealth-photon-fixture_202605121550.prn

$ head -3 /tmp/photonos-urlhealth-photon-fixture_202605121550.prn
Spec,Source0 original,Modified Source0 for url health check,UrlHealth,UpdateAvailable,UpdateURL,HealthUpdateURL,Name,SHAName,UpdateDownloadName,warning,ArchivationDate
commit-test.spec,https://example.invalid/commit-test-%{version}.tar.gz,https://example.invalid/commit-test-0.0.1-1.tar.gz,0,,,,commit-test,,,,
dbus.spec,https://dbus.freedesktop.org/releases/dbus/dbus-%{version}.tar.xz,https://dbus.freedesktop.org/releases/dbus/dbus-1.12.20-7.tar.xz,0,,,,dbus,,,,
```
Source0LookupData hits work (e.g. `dialog.spec` rewritten from the spec's `dialog.tar.gz` to the lookup's `/archives/dialog/dialog-1.3-5.tgz`).

## Phase tracker
| Phase | Title | Status |
|-------|-------|--------|
| 0 | SDD scaffold | done (#52) |
| 1 | Foundation | done (#53) |
| 2 | Spec ingestion | done (#54) |
| 3a | Source0LookupData embed | done (#55) |
| 3b | Per-spec hook dispatch | done (#57) |
| 4 | Source0 substitution core | done (#58) |
| 5 | URL health + Koji lookup (libcurl) | done (#59) |
| 6a | **CheckURLHealth scaffold + .prn writer + e2e pipeline** | **this PR** |
| 6b | Version comparison (PS L 1736-1905) | pending |
| 6c | Git tag enumeration + HeapSort + UpdateURL/UpdateDownloadName | pending |
| 6d | Anomaly handlers + SHA computation | pending |
| 6e | Multi-branch diff reports (PS L 5440+) | pending |
| 6f | Final tidy + remaining ~1k lines | pending |
| 7 | Cluster orchestrator + worker pool | pending |
| 8 | Side-by-side CI parity gate | pending |
| 9 | PS retirement | pending |
| M | Maintainer ops & debug tooling | PR #56 still open |

## Deliverables
- **`pr_state_t`** — concrete struct replacing the Phase 3b forward decl. Carries the per-task scratch (Source0, version, UpdateAvailable, UpdateURL, HealthUpdateURL, UpdateDownloadName, SHAValue, Warning, ArchivationDate) — the exact locals PS L 4933 concatenates.
- **`.prn` writer** (`pr_prn.h` / `prn_writer.c`) — `PR_PRN_HEADER` is the verbatim PS L 5068 string. `pr_prn_append_rows` applies the PS L 5070 PCRE filter, sorts ascending under `LC_ALL=C`, and appends with `flock(LOCK_EX)` (ADR-0010).
- **`check_urlhealth()` orchestrator** (`pr_check_urlhealth.h` / `check_urlhealth.c`) — Source0Lookup → per-spec hook → substitute → urlhealth → 12-column row. Columns deferred to 6b-6f are documented inline per column.
- **`main.c --generate-urlhealth-report <branch>`** — writes `photonos-urlhealth-<branch>_<yyyyMMddHHmm>.prn` under `scansDir`.

## PS-source mapping (strict parity)
| PS lines | Operation | C site |
|----------|-----------|--------|
| L 2140-2153 | Source0Lookup CSV hit + Warning/ArchivationDate propagation | `check_urlhealth.c lookup_row` |
| L 4933 | 12-column row concatenation | `check_urlhealth.c asprintf` |
| L 5048-5050 | `.prn` filename format | `main.c generate_urlhealth_main` |
| L 5068 | Header line literal | `PR_PRN_HEADER` constant |
| L 5070 | Row filter regex | PCRE2 inside `prn_writer.c` |
| L 5072 | Ascending sort | `qsort` in `pr_prn_append_rows` |

## Test plan
- [x] `cmake -B build -S .` configures cleanly
- [x] `cmake --build build` zero warnings
- [x] `ctest --test-dir build` → 7/7 passed
  - `test_phase6` — state lifecycle, header literal, strip regex, writer round-trip (header + filter + sort + close), check_urlhealth row schema (12 cols, starts with spec basename)
- [x] End-to-end against `tests/fixtures/photon-fixture` produces a 10-line .prn (1 header + 9 sorted rows) with all columns populated where Phase 2/3/4 already provide data; stubbed columns are empty
- [x] Source0LookupData hits visible in the output (dialog, gnupg, hello redirected to lookup URLs)
- [ ] Live `urlhealth()` integration (column 4): set `PR_TEST_NETWORK=1` before running — currently emits `0` offline by design so ctest stays hermetic

## Out of scope (the rest of Phase 6)
- Version compare / UpdateAvailable (6b)
- Git tag enumeration + HeapSort + UpdateURL / UpdateDownloadName (6c)
- Anomaly handlers / SHA computation (6d)
- Multi-branch diff reports (6e)
- Remaining ~1,000 lines of PS L 2205-4934 (6f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)