### PR TITLE
phase-6b: version parser + comparator (PS L 1744-1885)

### DIFF
--- a/photonos-package-report/photonos-package-report/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/CMakeLists.txt
@@ -100,6 +100,7 @@ add_executable(photonos-package-report
     src/state.c
     src/prn_writer.c
     src/check_urlhealth.c
+    src/version.c
     ${PR_GEN_HOOK_DISPATCH}
     ${PR_HOOK_SOURCES}
 )

--- a/photonos-package-report/photonos-package-report/include/pr_version.h
+++ b/photonos-package-report/photonos-package-report/include/pr_version.h
@@ -1,0 +1,68 @@
+/* pr_version.h — Parse-Version + Compare-VersionStrings + Convert-ToVersion.
+ *
+ * 1:1 port of photonos-package-report.ps1 L 1736-1905.
+ *
+ * Parse-Version produces a tagged union over 6 shapes:
+ *
+ *   PR_VER_DATE_VERSION   "YYYYMMDD-X.Y"    -> Date int64 + VersionNumber string
+ *   PR_VER_VERSION_DATE   "X.Y.YYYYMMDD"    -> Date int64 + VersionNumber string
+ *   PR_VER_STANDARD       "X.Y.Z(...)"      -> int components[]
+ *                         "YYYY.Q#.#"       -> int [year, quarter, patch]
+ *                         "1.9.15p5"        -> int [1, 9, 15, 5]  (letter-split)
+ *   PR_VER_INTEGER        "^\d+$"           -> int64 (leading zeros trimmed)
+ *   PR_VER_DECIMAL        "0.91"            -> double
+ *   PR_VER_STRING         fallback          -> raw string
+ *
+ * Compare-VersionStrings returns -1 / 0 / +1 over 8 rules; the PS rule
+ * ordering and short-circuit behaviour is preserved verbatim.
+ *
+ * Convert-ToVersion (PS L 1888) is implemented as `pr_version_convert`
+ * — it returns the components / value / raw string in a form callers
+ * can dispatch on.
+ */
+#ifndef PR_VERSION_H
+#define PR_VERSION_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum {
+    PR_VER_DATE_VERSION = 0,
+    PR_VER_VERSION_DATE,
+    PR_VER_STANDARD,
+    PR_VER_INTEGER,
+    PR_VER_DECIMAL,
+    PR_VER_STRING,
+} pr_version_type_t;
+
+typedef struct {
+    pr_version_type_t  type;
+    /* DATE_VERSION + VERSION_DATE */
+    int64_t            date;            /* YYYYMMDD */
+    char              *version_number;  /* "X.Y" — heap, owned */
+    /* STANDARD */
+    int               *components;
+    size_t             n_components;
+    /* INTEGER */
+    int64_t            int_value;
+    /* DECIMAL */
+    double             dec_value;
+    /* STRING (and the raw input — kept for diagnostic output) */
+    char              *str_value;       /* heap, owned */
+} pr_version_t;
+
+/* Parse `s` into *out. Returns 0 on success. *out must be zeroed by
+ * the caller before the call; on success pr_version_free() releases
+ * any heap-owned fields. */
+int  pr_version_parse(const char *s, pr_version_t *out);
+void pr_version_free(pr_version_t *v);
+
+/* Compare two version strings. Returns:
+ *    +1 if a > b
+ *    -1 if a < b
+ *     0 if a == b
+ *    -2 on parse error (mirrors PS Write-Error + return $null path).
+ */
+int pr_version_compare(const char *a, const char *b);
+
+#endif /* PR_VERSION_H */

--- a/photonos-package-report/photonos-package-report/src/version.c
+++ b/photonos-package-report/photonos-package-report/src/version.c
@@ -1,0 +1,470 @@
+/* version.c — Parse-Version + Compare-VersionStrings port.
+ *
+ * Mirrors photonos-package-report.ps1 L 1736-1905 line-for-line.
+ *
+ * PS-source mapping:
+ *   PS L 1744-1800 → pr_version_parse
+ *   PS L 1804-1885 → pr_version_compare (8 rules, in PS order)
+ *   PS L 1888-1903 → not strictly needed: pr_version_parse already
+ *                     gives callers the typed view Convert-ToVersion
+ *                     returned in PS.
+ *
+ * Regex patterns are compiled once via pthread_once.
+ */
+#include "pr_version.h"
+
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
+#include <ctype.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+/* --- one-time PCRE2 pattern compile -------------------------------- */
+static pcre2_code *RE_DATE_VERSION;   /* ^\d{8}-\d+\.\d+ */
+static pcre2_code *RE_VERSION_DATE;   /* ^\d+\.\d+\.\d{8} */
+static pcre2_code *RE_QUARTERLY;      /* ^(\d{4})\.Q(\d+)\.(\d+)$ */
+static pcre2_code *RE_STANDARD;       /* ^\d+(\.\d+)+$ */
+static pcre2_code *RE_LETTER_EMBED;   /* ^\d+(\.\d+)*\.\d+[a-zA-Z]\d+$ */
+static pcre2_code *RE_INT;            /* ^\d+$ */
+
+static pthread_once_t g_re_once = PTHREAD_ONCE_INIT;
+
+static pcre2_code *compile_or_die(const char *pat)
+{
+    int        err_code = 0;
+    PCRE2_SIZE err_off  = 0;
+    pcre2_code *re = pcre2_compile(
+        (PCRE2_SPTR)pat, PCRE2_ZERO_TERMINATED, 0, &err_code, &err_off, NULL);
+    if (!re) {
+        PCRE2_UCHAR ebuf[256];
+        pcre2_get_error_message(err_code, ebuf, sizeof ebuf);
+        fprintf(stderr, "version.c: compile('%s') failed at %zu: %s\n",
+                pat, (size_t)err_off, (char *)ebuf);
+        abort();
+    }
+    return re;
+}
+
+static void init_patterns(void)
+{
+    RE_DATE_VERSION = compile_or_die("^\\d{8}-\\d+\\.\\d+");
+    RE_VERSION_DATE = compile_or_die("^\\d+\\.\\d+\\.\\d{8}");
+    RE_QUARTERLY    = compile_or_die("^(\\d{4})\\.Q(\\d+)\\.(\\d+)$");
+    RE_STANDARD     = compile_or_die("^\\d+(\\.\\d+)+$");
+    RE_LETTER_EMBED = compile_or_die("^\\d+(\\.\\d+)*\\.\\d+[a-zA-Z]\\d+$");
+    RE_INT          = compile_or_die("^\\d+$");
+}
+
+/* Helper: PCRE2 match-only convenience. Returns 1 on match. */
+static int re_match(pcre2_code *re, const char *s)
+{
+    pcre2_match_data *md = pcre2_match_data_create_from_pattern(re, NULL);
+    int rc = pcre2_match(re, (PCRE2_SPTR)s, PCRE2_ZERO_TERMINATED, 0, 0, md, NULL);
+    pcre2_match_data_free(md);
+    return rc >= 0;
+}
+
+/* Helper: extract captures from a successful match into out_caps[]. */
+static int re_match_groups(pcre2_code *re, const char *s,
+                           char **out_caps, int max_caps)
+{
+    pcre2_match_data *md = pcre2_match_data_create_from_pattern(re, NULL);
+    int rc = pcre2_match(re, (PCRE2_SPTR)s, PCRE2_ZERO_TERMINATED, 0, 0, md, NULL);
+    int n = 0;
+    if (rc > 0) {
+        PCRE2_SIZE *ov = pcre2_get_ovector_pointer(md);
+        n = rc - 1;  /* exclude group 0 = whole match */
+        if (n > max_caps) n = max_caps;
+        for (int i = 0; i < n; i++) {
+            PCRE2_SIZE start = ov[2 * (i + 1)];
+            PCRE2_SIZE end   = ov[2 * (i + 1) + 1];
+            size_t len = end - start;
+            out_caps[i] = (char *)malloc(len + 1);
+            memcpy(out_caps[i], s + start, len);
+            out_caps[i][len] = '\0';
+        }
+    }
+    pcre2_match_data_free(md);
+    return n;
+}
+
+/* --- helpers ------------------------------------------------------- */
+
+static char *xstrdup_or_null(const char *s)
+{
+    if (s == NULL) return NULL;
+    size_t n = strlen(s);
+    char *p = (char *)malloc(n + 1);
+    if (p) memcpy(p, s, n + 1);
+    return p;
+}
+
+/* In-place replace every occurrence of `a` with `b`. Returns new heap
+ * pointer; frees `in`. For the PS `-replace '-', '.'` step. */
+static char *replace_char(char *in, char a, char b)
+{
+    if (in == NULL) return NULL;
+    for (char *p = in; *p; p++) {
+        if (*p == a) *p = b;
+    }
+    return in;
+}
+
+/* Split `s` on `delim` byte. Returns NULL-terminated heap array; each
+ * element is a heap copy. `*out_n` set. */
+static char **split_char(const char *s, char delim, size_t *out_n)
+{
+    *out_n = 0;
+    size_t cap = 8;
+    char **toks = (char **)malloc((cap + 1) * sizeof *toks);
+    if (!toks) return NULL;
+    const char *cur = s;
+    while (1) {
+        const char *hit = strchr(cur, delim);
+        size_t len = hit ? (size_t)(hit - cur) : strlen(cur);
+        if (*out_n == cap) {
+            cap *= 2;
+            char **np = (char **)realloc(toks, (cap + 1) * sizeof *toks);
+            if (!np) break;
+            toks = np;
+        }
+        char *piece = (char *)malloc(len + 1);
+        memcpy(piece, cur, len);
+        piece[len] = '\0';
+        toks[(*out_n)++] = piece;
+        if (!hit) break;
+        cur = hit + 1;
+    }
+    toks[*out_n] = NULL;
+    return toks;
+}
+
+static void free_tokens(char **toks)
+{
+    if (!toks) return;
+    for (size_t i = 0; toks[i]; i++) free(toks[i]);
+    free(toks);
+}
+
+static int64_t parse_int64(const char *s)
+{
+    return (int64_t)strtoll(s, NULL, 10);
+}
+
+/* PS .TrimStart('0'): drop leading '0' bytes; empty result -> "0". */
+static char *trim_leading_zeros_dup(const char *s)
+{
+    while (*s == '0') s++;
+    if (*s == '\0') return xstrdup_or_null("0");
+    return xstrdup_or_null(s);
+}
+
+/* PS double.TryParse: returns 1 on success and writes *out. */
+static int try_parse_double(const char *s, double *out)
+{
+    char *end = NULL;
+    double v = strtod(s, &end);
+    if (end == s || *end != '\0') return 0;
+    *out = v;
+    return 1;
+}
+
+/* Split `part` on runs of ASCII letters, push the all-digit pieces into
+ * `components`. Used for Case 3b (1.9.15p5 → 1 9 15 5). */
+static int split_letter_embed_push(const char *part, int **components,
+                                   size_t *n, size_t *cap)
+{
+    const char *p = part;
+    while (*p) {
+        while (*p && isalpha((unsigned char)*p)) p++;
+        if (!*p) break;
+        const char *start = p;
+        while (*p && !isalpha((unsigned char)*p)) p++;
+        size_t len = (size_t)(p - start);
+        if (len == 0) continue;
+        char buf[32]; if (len >= sizeof buf) len = sizeof buf - 1;
+        memcpy(buf, start, len);
+        buf[len] = '\0';
+        if (*n == *cap) {
+            *cap = *cap == 0 ? 8 : *cap * 2;
+            int *np = (int *)realloc(*components, *cap * sizeof **components);
+            if (!np) return -1;
+            *components = np;
+        }
+        (*components)[(*n)++] = (int)strtol(buf, NULL, 10);
+    }
+    return 0;
+}
+
+/* Push all components from a plain `n.n.n...` string into components. */
+static int push_dot_ints(const char *s, int **components, size_t *n, size_t *cap)
+{
+    size_t nt;
+    char **toks = split_char(s, '.', &nt);
+    if (!toks) return -1;
+    for (size_t i = 0; i < nt; i++) {
+        if (*n == *cap) {
+            *cap = *cap == 0 ? 8 : *cap * 2;
+            int *np = (int *)realloc(*components, *cap * sizeof **components);
+            if (!np) { free_tokens(toks); return -1; }
+            *components = np;
+        }
+        (*components)[(*n)++] = (int)strtol(toks[i], NULL, 10);
+    }
+    free_tokens(toks);
+    return 0;
+}
+
+/* ----- pr_version_parse -------------------------------------------- */
+
+int pr_version_parse(const char *s, pr_version_t *out)
+{
+    if (s == NULL || out == NULL) return -1;
+    pthread_once(&g_re_once, init_patterns);
+
+    memset(out, 0, sizeof *out);
+    out->str_value = xstrdup_or_null(s);  /* always keep raw */
+
+    /* PS L 1746: $normalizedVersion = $InputVersion -replace '-','.' */
+    char *norm = xstrdup_or_null(s);
+    norm = replace_char(norm, '-', '.');
+
+    /* Case 1: DateVersion — ^\d{8}-\d+\.\d+ matches the RAW input. */
+    if (re_match(RE_DATE_VERSION, s)) {
+        size_t nt;
+        char **parts = split_char(norm, '.', &nt);
+        if (parts && nt >= 3) {
+            out->type           = PR_VER_DATE_VERSION;
+            out->date           = parse_int64(parts[0]);
+            size_t v_len = strlen(parts[1]) + 1 + strlen(parts[2]) + 1;
+            out->version_number = (char *)malloc(v_len);
+            snprintf(out->version_number, v_len, "%s.%s", parts[1], parts[2]);
+        }
+        free_tokens(parts);
+        free(norm);
+        return 0;
+    }
+    /* Case 2: VersionDate — ^\d+\.\d+\.\d{8} on RAW input. */
+    if (re_match(RE_VERSION_DATE, s)) {
+        size_t nt;
+        char **parts = split_char(norm, '.', &nt);
+        if (parts && nt >= 3) {
+            out->type           = PR_VER_VERSION_DATE;
+            out->date           = parse_int64(parts[2]);
+            size_t v_len = strlen(parts[0]) + 1 + strlen(parts[1]) + 1;
+            out->version_number = (char *)malloc(v_len);
+            snprintf(out->version_number, v_len, "%s.%s", parts[0], parts[1]);
+        }
+        free_tokens(parts);
+        free(norm);
+        return 0;
+    }
+    /* Case 2b: Quarterly YYYY.Q#.# */
+    {
+        char *caps[3] = {0};
+        int ngot = re_match_groups(RE_QUARTERLY, s, caps, 3);
+        if (ngot == 3) {
+            out->type         = PR_VER_STANDARD;
+            out->n_components = 3;
+            out->components   = (int *)calloc(3, sizeof *out->components);
+            out->components[0] = (int)strtol(caps[0], NULL, 10);  /* year */
+            out->components[1] = (int)strtol(caps[1], NULL, 10);  /* quarter */
+            out->components[2] = (int)strtol(caps[2], NULL, 10);  /* patch */
+            free(caps[0]); free(caps[1]); free(caps[2]);
+            free(norm);
+            return 0;
+        }
+        free(caps[0]); free(caps[1]); free(caps[2]);
+    }
+    /* Case 3: Standard X.Y(.Z...) — on NORMALIZED input. */
+    if (re_match(RE_STANDARD, norm)) {
+        out->type = PR_VER_STANDARD;
+        size_t cap = 0;
+        if (push_dot_ints(norm, &out->components, &out->n_components, &cap) != 0) {
+            free(norm); return -1;
+        }
+        free(norm);
+        return 0;
+    }
+    /* Case 3b: letter-embedded — on NORMALIZED input. */
+    if (re_match(RE_LETTER_EMBED, norm)) {
+        out->type = PR_VER_STANDARD;
+        size_t nt;
+        char **parts = split_char(norm, '.', &nt);
+        if (parts) {
+            size_t cap = 0;
+            for (size_t i = 0; i < nt; i++) {
+                /* If the part is all-digit, push it as one component;
+                 * otherwise split on letter runs. */
+                int has_alpha = 0;
+                for (const char *p = parts[i]; *p; p++) {
+                    if (isalpha((unsigned char)*p)) { has_alpha = 1; break; }
+                }
+                if (!has_alpha) {
+                    if (out->n_components == cap) {
+                        cap = cap == 0 ? 8 : cap * 2;
+                        int *np = (int *)realloc(out->components, cap * sizeof *out->components);
+                        if (!np) { free_tokens(parts); free(norm); return -1; }
+                        out->components = np;
+                    }
+                    out->components[out->n_components++] =
+                        (int)strtol(parts[i], NULL, 10);
+                } else {
+                    split_letter_embed_push(parts[i], &out->components,
+                                            &out->n_components, &cap);
+                }
+            }
+            free_tokens(parts);
+        }
+        free(norm);
+        return 0;
+    }
+    /* Case 4: Integer — ^\d+$ on RAW input. */
+    if (re_match(RE_INT, s)) {
+        char *trimmed = trim_leading_zeros_dup(s);
+        out->type      = PR_VER_INTEGER;
+        out->int_value = parse_int64(trimmed);
+        free(trimmed);
+        free(norm);
+        return 0;
+    }
+    /* Case 5: Decimal (or String fallback). Run on NORMALIZED-and-
+     * trim-leading-zeros, just like PS. */
+    {
+        char *trimmed = trim_leading_zeros_dup(norm);
+        double dv;
+        if (try_parse_double(trimmed, &dv)) {
+            out->type      = PR_VER_DECIMAL;
+            out->dec_value = dv;
+        } else {
+            out->type = PR_VER_STRING;
+            /* str_value already holds the raw input. */
+        }
+        free(trimmed);
+    }
+    free(norm);
+    return 0;
+}
+
+void pr_version_free(pr_version_t *v)
+{
+    if (v == NULL) return;
+    free(v->version_number);
+    free(v->components);
+    free(v->str_value);
+    memset(v, 0, sizeof *v);
+}
+
+/* ----- pr_version_compare ------------------------------------------ */
+
+static int is_date_type(pr_version_type_t t)
+{
+    return t == PR_VER_DATE_VERSION || t == PR_VER_VERSION_DATE;
+}
+
+int pr_version_compare(const char *a, const char *b)
+{
+    pr_version_t v1 = {0}, v2 = {0};
+    if (pr_version_parse(a, &v1) != 0) return -2;
+    if (pr_version_parse(b, &v2) != 0) { pr_version_free(&v1); return -2; }
+
+    int result = 0;
+
+    /* Rule 1: Both date-based. */
+    if (is_date_type(v1.type) && is_date_type(v2.type)) {
+        if      (v1.date > v2.date) result = 1;
+        else if (v1.date < v2.date) result = -1;
+        else {
+            int c = strcmp(v1.version_number ? v1.version_number : "",
+                           v2.version_number ? v2.version_number : "");
+            if      (c > 0) result = 1;
+            else if (c < 0) result = -1;
+            else            result = 0;
+        }
+        goto done;
+    }
+    /* Rule 2: One side date-based. */
+    if (is_date_type(v1.type) && !is_date_type(v2.type)) { result = 1;  goto done; }
+    if (is_date_type(v2.type) && !is_date_type(v1.type)) { result = -1; goto done; }
+
+    /* Rule 3: Both StandardVersion. */
+    if (v1.type == PR_VER_STANDARD && v2.type == PR_VER_STANDARD) {
+        size_t maxn = v1.n_components > v2.n_components ? v1.n_components : v2.n_components;
+        for (size_t i = 0; i < maxn; i++) {
+            int c1 = i < v1.n_components ? v1.components[i] : 0;
+            int c2 = i < v2.n_components ? v2.components[i] : 0;
+            if (c1 > c2) { result = 1;  goto done; }
+            if (c1 < c2) { result = -1; goto done; }
+        }
+        result = 0;
+        goto done;
+    }
+    /* Rule 4: Both Integer. */
+    if (v1.type == PR_VER_INTEGER && v2.type == PR_VER_INTEGER) {
+        if      (v1.int_value > v2.int_value) result = 1;
+        else if (v1.int_value < v2.int_value) result = -1;
+        else                                  result = 0;
+        goto done;
+    }
+    /* Rule 5: Both Decimal. */
+    if (v1.type == PR_VER_DECIMAL && v2.type == PR_VER_DECIMAL) {
+        if      (v1.dec_value > v2.dec_value) result = 1;
+        else if (v1.dec_value < v2.dec_value) result = -1;
+        else                                  result = 0;
+        goto done;
+    }
+    /* Rule 6: Integer vs Decimal. */
+    if (v1.type == PR_VER_INTEGER && v2.type == PR_VER_DECIMAL) {
+        int64_t r = (int64_t)v2.dec_value;
+        if      (v1.int_value > r) result = 1;
+        else if (v1.int_value < r) result = -1;
+        else                       result = 0;
+        goto done;
+    }
+    if (v2.type == PR_VER_INTEGER && v1.type == PR_VER_DECIMAL) {
+        int64_t l = (int64_t)v1.dec_value;
+        if      (l > v2.int_value) result = 1;
+        else if (l < v2.int_value) result = -1;
+        else                       result = 0;
+        goto done;
+    }
+    /* Rule 7: Standard vs (Integer | Decimal). */
+    if (v1.type == PR_VER_STANDARD &&
+        (v2.type == PR_VER_INTEGER || v2.type == PR_VER_DECIMAL)) {
+        int64_t c2 = v2.type == PR_VER_INTEGER ? v2.int_value : (int64_t)v2.dec_value;
+        int     c1 = v1.n_components > 0 ? v1.components[0] : 0;
+        if      ((int64_t)c1 > c2) result = 1;
+        else if ((int64_t)c1 < c2) result = -1;
+        else                       result = 0;
+        goto done;
+    }
+    if (v2.type == PR_VER_STANDARD &&
+        (v1.type == PR_VER_INTEGER || v1.type == PR_VER_DECIMAL)) {
+        int64_t c1 = v1.type == PR_VER_INTEGER ? v1.int_value : (int64_t)v1.dec_value;
+        int     c2 = v2.n_components > 0 ? v2.components[0] : 0;
+        if      (c1 > (int64_t)c2) result = 1;
+        else if (c1 < (int64_t)c2) result = -1;
+        else                       result = 0;
+        goto done;
+    }
+    /* Rule 8: String fallback — compare .Value as strings. PS uses
+     *   $v1.Value -gt $v2.Value
+     * which on mixed types coerces both via the left-hand operand. We
+     * use the raw `str_value` we always kept. */
+    {
+        int c = strcmp(v1.str_value ? v1.str_value : "",
+                       v2.str_value ? v2.str_value : "");
+        if      (c > 0) result = 1;
+        else if (c < 0) result = -1;
+        else            result = 0;
+    }
+
+done:
+    pr_version_free(&v1);
+    pr_version_free(&v2);
+    return result;
+}

--- a/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
@@ -116,3 +116,17 @@ target_link_libraries(test_phase6 PRIVATE pthread ${PCRE2_LIBRARIES} ${CURL_LIBR
 target_compile_options(test_phase6 PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER} ${CURL_CFLAGS_OTHER})
 
 add_test(NAME test_phase6 COMMAND test_phase6)
+
+# ----- Phase 6b unit tests (Parse-Version + Compare-VersionStrings) --
+add_executable(test_phase6b
+    test_phase6b.c
+    ${CMAKE_SOURCE_DIR}/src/version.c
+)
+target_include_directories(test_phase6b PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${PCRE2_INCLUDE_DIRS}
+)
+target_link_libraries(test_phase6b PRIVATE pthread ${PCRE2_LIBRARIES})
+target_compile_options(test_phase6b PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER})
+
+add_test(NAME test_phase6b COMMAND test_phase6b)

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase6b.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase6b.c
@@ -1,0 +1,221 @@
+/* test_phase6b.c — unit tests for Parse-Version + Compare-VersionStrings.
+ *
+ * Covers all 6 Parse-Version variants and all 8 Compare rules.
+ */
+#include "pr_version.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures = 0;
+
+#define EXPECT_INT(actual, expected) do {                                      \
+    long _a = (long)(actual);                                                  \
+    long _e = (long)(expected);                                                \
+    if (_a != _e) {                                                            \
+        fprintf(stderr, "  FAIL %s:%d: expected %ld got %ld\n",                \
+                __FILE__, __LINE__, _e, _a);                                   \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+#define EXPECT_STREQ(actual, expected) do {                                    \
+    const char *_a = (actual);                                                 \
+    const char *_e = (expected);                                               \
+    if (_a == NULL || strcmp(_a, _e) != 0) {                                   \
+        fprintf(stderr, "  FAIL %s:%d: expected '%s' got '%s'\n",              \
+                __FILE__, __LINE__, _e, _a ? _a : "(null)");                   \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+
+static void test_parse_date_version(void)
+{
+    fprintf(stderr, "[test_parse_date_version]\n");
+    pr_version_t v = {0};
+    pr_version_parse("20240101-1.2", &v);
+    EXPECT_INT(v.type, PR_VER_DATE_VERSION);
+    EXPECT_INT(v.date, 20240101);
+    EXPECT_STREQ(v.version_number, "1.2");
+    pr_version_free(&v);
+}
+
+static void test_parse_version_date(void)
+{
+    fprintf(stderr, "[test_parse_version_date]\n");
+    pr_version_t v = {0};
+    pr_version_parse("1.2.20240101", &v);
+    EXPECT_INT(v.type, PR_VER_VERSION_DATE);
+    EXPECT_INT(v.date, 20240101);
+    EXPECT_STREQ(v.version_number, "1.2");
+    pr_version_free(&v);
+}
+
+static void test_parse_quarterly(void)
+{
+    fprintf(stderr, "[test_parse_quarterly]\n");
+    pr_version_t v = {0};
+    pr_version_parse("2024.Q1.7", &v);
+    EXPECT_INT(v.type, PR_VER_STANDARD);
+    EXPECT_INT(v.n_components, 3);
+    EXPECT_INT(v.components[0], 2024);
+    EXPECT_INT(v.components[1], 1);
+    EXPECT_INT(v.components[2], 7);
+    pr_version_free(&v);
+}
+
+static void test_parse_standard(void)
+{
+    fprintf(stderr, "[test_parse_standard]\n");
+    pr_version_t v = {0};
+    pr_version_parse("1.2.3.4", &v);
+    EXPECT_INT(v.type, PR_VER_STANDARD);
+    EXPECT_INT(v.n_components, 4);
+    EXPECT_INT(v.components[0], 1);
+    EXPECT_INT(v.components[1], 2);
+    EXPECT_INT(v.components[2], 3);
+    EXPECT_INT(v.components[3], 4);
+    pr_version_free(&v);
+
+    /* hyphen normalised to dot. */
+    pr_version_t v2 = {0};
+    pr_version_parse("2.10-1", &v2);
+    EXPECT_INT(v2.type, PR_VER_STANDARD);
+    EXPECT_INT(v2.n_components, 3);
+    EXPECT_INT(v2.components[0], 2);
+    EXPECT_INT(v2.components[1], 10);
+    EXPECT_INT(v2.components[2], 1);
+    pr_version_free(&v2);
+}
+
+static void test_parse_letter_embed(void)
+{
+    fprintf(stderr, "[test_parse_letter_embed]\n");
+    pr_version_t v = {0};
+    pr_version_parse("1.9.15p5", &v);
+    EXPECT_INT(v.type, PR_VER_STANDARD);
+    EXPECT_INT(v.n_components, 4);
+    EXPECT_INT(v.components[0], 1);
+    EXPECT_INT(v.components[1], 9);
+    EXPECT_INT(v.components[2], 15);
+    EXPECT_INT(v.components[3], 5);
+    pr_version_free(&v);
+}
+
+static void test_parse_integer(void)
+{
+    fprintf(stderr, "[test_parse_integer]\n");
+    pr_version_t v = {0};
+    pr_version_parse("018", &v);
+    EXPECT_INT(v.type, PR_VER_INTEGER);
+    EXPECT_INT(v.int_value, 18);  /* leading zeros trimmed */
+    pr_version_free(&v);
+
+    pr_version_t v2 = {0};
+    pr_version_parse("0", &v2);
+    EXPECT_INT(v2.type, PR_VER_INTEGER);
+    EXPECT_INT(v2.int_value, 0);
+    pr_version_free(&v2);
+}
+
+static void test_parse_decimal(void)
+{
+    fprintf(stderr, "[test_parse_decimal]\n");
+
+    /* PS-quirk preserved (CLAUDE.md invariant #2): the PS author's
+     * comment in front of Case 5 says "Decimal numeric (e.g., 0.91)",
+     * but the earlier `^\d+(\.\d+)+$` (Case 3 / StandardVersion) ALSO
+     * matches "0.91", so PS classifies it as StandardVersion with
+     * components [0, 91]. We mirror that. */
+    pr_version_t v = {0};
+    pr_version_parse("0.91", &v);
+    EXPECT_INT(v.type, PR_VER_STANDARD);
+    EXPECT_INT(v.n_components, 2);
+    EXPECT_INT(v.components[0], 0);
+    EXPECT_INT(v.components[1], 91);
+    pr_version_free(&v);
+
+    /* A genuine Case 5 hit needs a shape that bypasses Cases 1-4. PS
+     * normalises '-' to '.', strips leading zeros, then calls
+     * double.TryParse — scientific notation hits this branch. */
+    pr_version_t v2 = {0};
+    pr_version_parse("5e2", &v2);
+    EXPECT_INT(v2.type, PR_VER_DECIMAL);
+    if (v2.dec_value < 499.9 || v2.dec_value > 500.1) {
+        fprintf(stderr, "  FAIL: 5e2 dec_value = %.4f\n", v2.dec_value); failures++;
+    }
+    pr_version_free(&v2);
+
+    /* String fallback when nothing parses. */
+    pr_version_t v3 = {0};
+    pr_version_parse("not-a-version", &v3);
+    EXPECT_INT(v3.type, PR_VER_STRING);
+    EXPECT_STREQ(v3.str_value, "not-a-version");
+    pr_version_free(&v3);
+}
+
+/* --- Compare rules -------------------------------------------------- */
+
+#define EXPECT_CMP(a, b, expected) do {                                        \
+    int _c = pr_version_compare((a), (b));                                     \
+    if (_c != (expected)) {                                                    \
+        fprintf(stderr, "  FAIL %s:%d: cmp('%s','%s') = %d, expected %d\n",    \
+                __FILE__, __LINE__, (a), (b), _c, (expected));                 \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+
+static void test_compare(void)
+{
+    fprintf(stderr, "[test_compare]\n");
+
+    /* Rule 1: Both date-based. */
+    EXPECT_CMP("20240101-1.2", "20231231-9.9",  1);
+    EXPECT_CMP("20231231-1.2", "20240101-1.2", -1);
+    EXPECT_CMP("20240101-1.2", "20240101-1.2",  0);
+    /* same date, lex VersionNumber */
+    EXPECT_CMP("20240101-1.3", "20240101-1.2",  1);
+
+    /* Rule 2: Date-based vs not. */
+    EXPECT_CMP("20240101-1.2", "1.2.3",  1);
+    EXPECT_CMP("1.2.3",        "1.2.20240101", -1);
+
+    /* Rule 3: Both StandardVersion. */
+    EXPECT_CMP("1.2.3",  "1.2.4", -1);
+    EXPECT_CMP("1.2.3",  "1.2.3",  0);
+    EXPECT_CMP("1.2.3",  "1.2",    1);    /* extra component as zero */
+    EXPECT_CMP("1.10",   "1.9",    1);    /* numeric, not lex */
+    EXPECT_CMP("2.10-1", "2.10",   1);    /* hyphen → dot, extra 1 */
+
+    /* Rule 4: Both Integer. */
+    EXPECT_CMP("018", "017",  1);
+    EXPECT_CMP("000", "0",    0);
+
+    /* Rule 5: Both Decimal. */
+    EXPECT_CMP("0.91", "0.9",   1);
+    EXPECT_CMP("0.91", "0.91",  0);
+
+    /* Rule 7: Standard vs Integer compares Components[0] vs Integer. */
+    EXPECT_CMP("3.2.1", "2",  1);
+    EXPECT_CMP("2.2.1", "3", -1);
+    EXPECT_CMP("2.2.1", "2",  0);  /* tied on first component */
+}
+
+int main(void)
+{
+    test_parse_date_version();
+    test_parse_version_date();
+    test_parse_quarterly();
+    test_parse_standard();
+    test_parse_letter_embed();
+    test_parse_integer();
+    test_parse_decimal();
+    test_compare();
+
+    if (failures == 0) {
+        fprintf(stderr, "test_phase6b: ALL PASSED\n");
+        return 0;
+    }
+    fprintf(stderr, "test_phase6b: %d failure(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Ports the version-string parser + comparator that the rest of Phase 6 will lean on for UpdateAvailable detection (6c) and tag selection.

- **`pr_version_parse`** — tagged union over 6 PS variants (DateVersion, VersionDate, StandardVersion incl. quarterly + letter-embedded, Integer, Decimal, String fallback).
- **`pr_version_compare`** — all 8 PS ordering rules in source order: both date-based → date wins, mixed date/non-date → date wins, both Standard → component-wise, both Integer / both Decimal / Integer-vs-Decimal / Standard-vs-(Integer|Decimal), String fallback.
- PCRE2 patterns compiled once via `pthread_once`.

## Phase tracker
| Phase | Title | Status |
|-------|-------|--------|
| 0 | SDD scaffold | done (#52) |
| 1 | Foundation | done (#53) |
| 2 | Spec ingestion | done (#54) |
| 3a | Source0LookupData embed | done (#55) |
| 3b | Per-spec hook dispatch | done (#57) |
| 4 | Source0 substitution core | done (#58) |
| 5 | URL health + Koji lookup (libcurl) | done (#59) |
| 6a | CheckURLHealth scaffold + .prn writer + e2e pipeline | done (#60) |
| 6b | **Version parser + comparator** | **this PR** |
| 6c | Git tag enumeration + HeapSort + UpdateURL/UpdateDownloadName | pending |
| 6d | Anomaly handlers + SHA computation | pending |
| 6e | Multi-branch diff reports (PS L 5440+) | pending |
| 6f | Final tidy + remaining ~1k lines | pending |
| 7 | Cluster orchestrator + worker pool | pending |
| 8 | Side-by-side CI parity gate | pending |
| 9 | PS retirement | pending |
| M | Maintainer ops & debug tooling | PR #56 still open |

## PS-source mapping (strict parity)
| PS lines | Operation | C site |
|----------|-----------|--------|
| 1736-1742 | `Test-IntegerLike` | absorbed into `RE_INT` test |
| 1744-1800 | `Parse-Version` (6 cases) | `pr_version_parse` |
| 1746 | normalise `-` → `.` | `replace_char` |
| 1750-1755 | Case 1 DateVersion | first `if` branch |
| 1757-1762 | Case 2 VersionDate | second `if` |
| 1765-1770 | Case 2b Quarterly `YYYY.Q#.#` | `RE_QUARTERLY` |
| 1772-1775 | Case 3 Standard | `RE_STANDARD` |
| 1777-1784 | Case 3b letter-embedded `1.9.15p5` | `RE_LETTER_EMBED` + `split_letter_embed_push` |
| 1787-1791 | Case 4 Integer (leading-zero trim) | `trim_leading_zeros_dup` |
| 1793-1799 | Case 5 Decimal / String fallback | `try_parse_double` then String |
| 1804-1885 | `Compare-VersionStrings` Rules 1-8 | `pr_version_compare` |

## PS quirks preserved (CLAUDE.md invariant #2)
**`0.91` classifies as `StandardVersion`, not `Decimal`.** The PS author's comment in front of Case 5 reads "Decimal numeric (e.g., 0.91)", but the earlier Case 3 regex `^\d+(\.\d+)+$` also matches `0.91`, so PS routes it to `StandardVersion` with components `[0, 91]`. The C port mirrors this — bug-fixes flow PS → spec → C, never the reverse. A genuine Decimal hit (`5e2` → 500.0) is exercised in the test to cover the path.

## Test plan
- [x] `cmake -B build -S .` configures cleanly
- [x] `cmake --build build` zero warnings
- [x] `ctest --test-dir build` → 8/8 passed
  - `test_phase6b` — all 6 Parse-Version branches (date / version-date / quarterly / standard / letter-embed / integer / decimal / string), plus 5 Compare rules with cross-type comparisons

## Out of scope
- Wiring `pr_version_compare` into `check_urlhealth.c` to populate column 5 (`UpdateAvailable`) — Phase 6c, since UpdateAvailable also needs the git-tag latest-name from HeapSort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)