### PR TITLE
phase-6c: Get-LatestName + git tag-list parser

### DIFF
--- a/photonos-package-report/photonos-package-report/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/CMakeLists.txt
@@ -101,6 +101,8 @@ add_executable(photonos-package-report
     src/prn_writer.c
     src/check_urlhealth.c
     src/version.c
+    src/latest_name.c
+    src/git_tags.c
     ${PR_GEN_HOOK_DISPATCH}
     ${PR_HOOK_SOURCES}
 )

--- a/photonos-package-report/photonos-package-report/include/pr_git_tags.h
+++ b/photonos-package-report/photonos-package-report/include/pr_git_tags.h
@@ -1,0 +1,41 @@
+/* pr_git_tags.h — `git tag -l` output parser.
+ *
+ * Mirrors the parsing chain at photonos-package-report.ps1 L 2441-2444:
+ *
+ *     $tagLines = @($tagOutput -split "`r?`n"
+ *                   | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+ *     if (!([string]::IsNullOrEmpty($customRegex))) {
+ *         $Names = @($tagLines | Where-Object { $_ -match $customRegex }
+ *                              | ForEach-Object { $_.Trim() })
+ *     } else {
+ *         $Names = @($tagLines | ForEach-Object { $_.Trim() })
+ *     }
+ *
+ * The runtime call that produces $tagOutput (Invoke-GitWithTimeout
+ * "tag -l") lives in Phase 6d when we wire local-clone management
+ * into the orchestrator. This module exposes only the deterministic
+ * post-processing so it can be unit-tested without git.
+ */
+#ifndef PR_GIT_TAGS_H
+#define PR_GIT_TAGS_H
+
+#include <stddef.h>
+
+/* Parse `git tag -l` stdout into a heap array of trimmed, non-empty
+ * tag basenames. If `custom_regex` is non-NULL and non-empty, only
+ * lines matching the regex (case-sensitive, PCRE2) are kept.
+ *
+ * Sets *out_names to a malloc'd array of malloc'd strings and *out_n
+ * to its length. Caller frees with pr_git_tags_free().
+ *
+ * Returns 0 on success, -1 on memory failure, -2 on regex compile
+ * failure.
+ */
+int  pr_parse_tag_list(const char *git_output,
+                       const char *custom_regex,
+                       char     ***out_names,
+                       size_t     *out_n);
+
+void pr_git_tags_free(char **names, size_t n);
+
+#endif /* PR_GIT_TAGS_H */

--- a/photonos-package-report/photonos-package-report/include/pr_latest.h
+++ b/photonos-package-report/photonos-package-report/include/pr_latest.h
@@ -1,0 +1,25 @@
+/* pr_latest.h — Get-LatestName port.
+ *
+ * Mirrors photonos-package-report.ps1 L 1907-1949.
+ *
+ * Given a list of candidate names (typically the output of `git tag -l`
+ * trimmed and filtered), return the "latest". PS rules:
+ *   1. Filter out NULL / empty / whitespace-only entries.
+ *   2. If any entry matches the version-number pattern
+ *        ^\d+([.-]Q?\d+)*$
+ *      (e.g. "1.2", "1-2", "2024.Q1.7"), select the version-like
+ *      entries and bubble-search-by-pr_version_compare for the max.
+ *   3. Otherwise, sort all entries lexicographically (C locale,
+ *      strcmp ascending) and return the LAST one.
+ *
+ * Returns a malloc'd NUL-terminated string the caller frees. Returns
+ * an empty malloc'd string "" when input has no usable entries.
+ */
+#ifndef PR_LATEST_H
+#define PR_LATEST_H
+
+#include <stddef.h>
+
+char *pr_get_latest_name(char **names, size_t n);
+
+#endif /* PR_LATEST_H */

--- a/photonos-package-report/photonos-package-report/src/git_tags.c
+++ b/photonos-package-report/photonos-package-report/src/git_tags.c
@@ -1,0 +1,112 @@
+/* git_tags.c — `git tag -l` output parser.
+ * Mirrors photonos-package-report.ps1 L 2441-2444 verbatim.
+ */
+#include "pr_git_tags.h"
+
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void pr_git_tags_free(char **names, size_t n)
+{
+    if (!names) return;
+    for (size_t i = 0; i < n; i++) free(names[i]);
+    free(names);
+}
+
+/* trim ASCII whitespace from both ends, return malloc'd copy. */
+static char *trim_dup(const char *s, size_t len)
+{
+    size_t a = 0, b = len;
+    while (a < b && isspace((unsigned char)s[a])) a++;
+    while (b > a && isspace((unsigned char)s[b - 1])) b--;
+    char *out = (char *)malloc(b - a + 1);
+    if (!out) return NULL;
+    memcpy(out, s + a, b - a);
+    out[b - a] = '\0';
+    return out;
+}
+
+int pr_parse_tag_list(const char *git_output,
+                      const char *custom_regex,
+                      char     ***out_names,
+                      size_t     *out_n)
+{
+    if (out_names == NULL || out_n == NULL) return -1;
+    *out_names = NULL;
+    *out_n     = 0;
+    if (git_output == NULL) return 0;
+
+    /* Optional regex compile. */
+    pcre2_code *re = NULL;
+    if (custom_regex != NULL && custom_regex[0] != '\0') {
+        int        err_code = 0;
+        PCRE2_SIZE err_off  = 0;
+        re = pcre2_compile((PCRE2_SPTR)custom_regex, PCRE2_ZERO_TERMINATED,
+                            0, &err_code, &err_off, NULL);
+        if (re == NULL) {
+            PCRE2_UCHAR ebuf[256];
+            pcre2_get_error_message(err_code, ebuf, sizeof ebuf);
+            fprintf(stderr, "pr_parse_tag_list: compile('%s') failed at %zu: %s\n",
+                    custom_regex, (size_t)err_off, (char *)ebuf);
+            return -2;
+        }
+    }
+    pcre2_match_data *md = re ? pcre2_match_data_create_from_pattern(re, NULL) : NULL;
+
+    /* Split on \r?\n. Walk the buffer once, emit one trimmed copy per
+     * non-blank line (optionally regex-filtered). */
+    size_t cap = 64;
+    char **arr = (char **)malloc(cap * sizeof *arr);
+    if (!arr) { if (md) pcre2_match_data_free(md); if (re) pcre2_code_free(re); return -1; }
+    size_t count = 0;
+
+    const char *p = git_output;
+    while (*p) {
+        const char *line_start = p;
+        while (*p && *p != '\n' && *p != '\r') p++;
+        size_t llen = (size_t)(p - line_start);
+        /* skip the line terminator. */
+        if (*p == '\r') p++;
+        if (*p == '\n') p++;
+
+        if (llen == 0) continue;
+
+        /* trim + non-blank gate. */
+        char *trimmed = trim_dup(line_start, llen);
+        if (!trimmed) goto fail;
+        if (trimmed[0] == '\0') { free(trimmed); continue; }
+
+        /* regex gate. */
+        if (re) {
+            int rc = pcre2_match(re, (PCRE2_SPTR)trimmed, PCRE2_ZERO_TERMINATED,
+                                  0, 0, md, NULL);
+            if (rc < 0) { free(trimmed); continue; }
+        }
+
+        if (count == cap) {
+            cap *= 2;
+            char **np = (char **)realloc(arr, cap * sizeof *arr);
+            if (!np) { free(trimmed); goto fail; }
+            arr = np;
+        }
+        arr[count++] = trimmed;
+    }
+
+    if (md) pcre2_match_data_free(md);
+    if (re) pcre2_code_free(re);
+    *out_names = arr;
+    *out_n     = count;
+    return 0;
+
+fail:
+    for (size_t i = 0; i < count; i++) free(arr[i]);
+    free(arr);
+    if (md) pcre2_match_data_free(md);
+    if (re) pcre2_code_free(re);
+    return -1;
+}

--- a/photonos-package-report/photonos-package-report/src/latest_name.c
+++ b/photonos-package-report/photonos-package-report/src/latest_name.c
@@ -1,0 +1,138 @@
+/* latest_name.c — Get-LatestName port.
+ * Mirrors photonos-package-report.ps1 L 1907-1949 line-for-line.
+ *
+ * PS source:
+ *
+ *   function Get-LatestName {
+ *       param([Parameter(Mandatory=$false)]
+ *             [AllowEmptyString()][AllowNull()][string[]]$Names)
+ *       if ($Names) { $Names = @($Names | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) }
+ *       if (-not $Names -or $Names.Count -eq 0) { return "" }
+ *
+ *       $versionNames = @($Names | Where-Object { $_ -match '^\d+([.-]Q?\d+)*$' })
+ *
+ *       if ($versionNames -and $versionNames.Count -gt 0) {
+ *           $latest = $versionNames[0]
+ *           foreach ($name in $versionNames) {
+ *               $result = Compare-VersionStrings -Namelatest $name -Version $latest
+ *               if ($result -eq 1) { $latest = $name }
+ *           }
+ *           return $latest
+ *       } else {
+ *           try { ConvertFrom-Json $Names | Sort-Object | Select-Object -Last 1 }
+ *           catch { $Names | Sort-Object | Select-Object -Last 1 }
+ *       }
+ *   }
+ *
+ * Notes:
+ *   - The "ConvertFrom-Json" branch fires only when the entire $Names
+ *     array is valid JSON — vanishingly rare for `git tag -l` output.
+ *     We always take the lexicographic fallback (PS catch{} arm). If a
+ *     real-world tag list ever turns out to be JSON we can add the
+ *     parse later; the parity gate at Phase 8 will surface the gap.
+ *   - "Whitespace-only" follows PS IsNullOrWhiteSpace: chars in
+ *     " \t\r\n\v\f" only. UTF-8 multi-byte whitespace is not handled
+ *     because PS Get-Content / git tag -l never produces such bytes.
+ */
+#include "pr_latest.h"
+#include "pr_version.h"
+
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
+#include <ctype.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Compile the version-name detector regex once. */
+static pcre2_code     *RE_VERSION_NAME;
+static pthread_once_t  g_re_once = PTHREAD_ONCE_INIT;
+
+static void init_re(void)
+{
+    int        err_code = 0;
+    PCRE2_SIZE err_off  = 0;
+    RE_VERSION_NAME = pcre2_compile(
+        (PCRE2_SPTR)"^\\d+([.-]Q?\\d+)*$",
+        PCRE2_ZERO_TERMINATED, 0, &err_code, &err_off, NULL);
+    if (!RE_VERSION_NAME) {
+        PCRE2_UCHAR ebuf[256];
+        pcre2_get_error_message(err_code, ebuf, sizeof ebuf);
+        fprintf(stderr, "latest_name.c: re_compile failed: %s\n", (char *)ebuf);
+        abort();
+    }
+}
+
+static int is_version_name(const char *s)
+{
+    pthread_once(&g_re_once, init_re);
+    pcre2_match_data *md = pcre2_match_data_create_from_pattern(RE_VERSION_NAME, NULL);
+    int rc = pcre2_match(RE_VERSION_NAME, (PCRE2_SPTR)s, PCRE2_ZERO_TERMINATED,
+                          0, 0, md, NULL);
+    pcre2_match_data_free(md);
+    return rc >= 0;
+}
+
+static int is_blank(const char *s)
+{
+    if (s == NULL) return 1;
+    for (; *s; s++) {
+        if (!isspace((unsigned char)*s)) return 0;
+    }
+    return 1;
+}
+
+static char *xstrdup(const char *s)
+{
+    size_t n = strlen(s);
+    char *p = (char *)malloc(n + 1);
+    if (p) memcpy(p, s, n + 1);
+    return p;
+}
+
+static int cmp_strcmp(const void *a, const void *b)
+{
+    return strcmp(*(const char *const *)a, *(const char *const *)b);
+}
+
+char *pr_get_latest_name(char **names, size_t n)
+{
+    /* PS: filter out null/whitespace-only entries. */
+    char **kept = (char **)malloc((n + 1) * sizeof *kept);
+    if (!kept) return xstrdup("");
+    size_t k = 0;
+    for (size_t i = 0; i < n; i++) {
+        if (is_blank(names[i])) continue;
+        kept[k++] = names[i];
+    }
+    if (k == 0) { free(kept); return xstrdup(""); }
+
+    /* PS: select version-like entries. */
+    char **vers = (char **)malloc(k * sizeof *vers);
+    if (!vers) { free(kept); return xstrdup(""); }
+    size_t v = 0;
+    for (size_t i = 0; i < k; i++) {
+        if (is_version_name(kept[i])) vers[v++] = kept[i];
+    }
+
+    char *out = NULL;
+    if (v > 0) {
+        /* Bubble-search-by-compare for the max (PS L 1928-1935). */
+        const char *latest = vers[0];
+        for (size_t i = 0; i < v; i++) {
+            int rc = pr_version_compare(vers[i], latest);
+            if (rc == 1) latest = vers[i];
+        }
+        out = xstrdup(latest);
+    } else {
+        /* Lexicographic sort, take last (PS L 1944 catch{} arm). */
+        qsort(kept, k, sizeof *kept, cmp_strcmp);
+        out = xstrdup(kept[k - 1]);
+    }
+
+    free(vers);
+    free(kept);
+    return out ? out : xstrdup("");
+}

--- a/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
@@ -130,3 +130,19 @@ target_link_libraries(test_phase6b PRIVATE pthread ${PCRE2_LIBRARIES})
 target_compile_options(test_phase6b PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER})
 
 add_test(NAME test_phase6b COMMAND test_phase6b)
+
+# ----- Phase 6c unit tests (Get-LatestName + git_tags parser) --------
+add_executable(test_phase6c
+    test_phase6c.c
+    ${CMAKE_SOURCE_DIR}/src/latest_name.c
+    ${CMAKE_SOURCE_DIR}/src/git_tags.c
+    ${CMAKE_SOURCE_DIR}/src/version.c
+)
+target_include_directories(test_phase6c PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${PCRE2_INCLUDE_DIRS}
+)
+target_link_libraries(test_phase6c PRIVATE pthread ${PCRE2_LIBRARIES})
+target_compile_options(test_phase6c PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER})
+
+add_test(NAME test_phase6c COMMAND test_phase6c)

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase6c.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase6c.c
@@ -1,0 +1,180 @@
+/* test_phase6c.c — unit tests for Get-LatestName + git_tags parser.
+ *
+ * Covers PS L 1907-1949 (Get-LatestName) and PS L 2441-2444 (tag-list
+ * post-processing).
+ */
+#include "pr_latest.h"
+#include "pr_git_tags.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures = 0;
+
+#define EXPECT_STREQ(actual, expected) do {                                    \
+    const char *_a = (actual);                                                 \
+    const char *_e = (expected);                                               \
+    if (_a == NULL || strcmp(_a, _e) != 0) {                                   \
+        fprintf(stderr, "  FAIL %s:%d: expected '%s' got '%s'\n",              \
+                __FILE__, __LINE__, _e, _a ? _a : "(null)");                   \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+#define EXPECT_SZ(actual, expected) do {                                       \
+    long _a = (long)(actual); long _e = (long)(expected);                      \
+    if (_a != _e) {                                                            \
+        fprintf(stderr, "  FAIL %s:%d: expected %ld got %ld\n",                \
+                __FILE__, __LINE__, _e, _a);                                   \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+
+/* --- Get-LatestName -------------------------------------------------- */
+
+static void test_latest_empty(void)
+{
+    fprintf(stderr, "[test_latest_empty]\n");
+    char *out = pr_get_latest_name(NULL, 0);
+    EXPECT_STREQ(out, "");
+    free(out);
+
+    /* all-blank input. */
+    char *blanks[] = { (char *)"", (char *)"   ", (char *)"\t\n" };
+    out = pr_get_latest_name(blanks, 3);
+    EXPECT_STREQ(out, "");
+    free(out);
+}
+
+static void test_latest_version_like(void)
+{
+    fprintf(stderr, "[test_latest_version_like]\n");
+    char *names[] = {
+        (char *)"1.2.3",
+        (char *)"1.10.0",  /* numeric > 1.2.* */
+        (char *)"1.9",
+    };
+    char *out = pr_get_latest_name(names, 3);
+    EXPECT_STREQ(out, "1.10.0");
+    free(out);
+
+    /* hyphen-separated still matches `^\d+([.-]Q?\d+)*$`. */
+    char *names2[] = {
+        (char *)"2-10",
+        (char *)"3-1",
+        (char *)"1-5",
+    };
+    out = pr_get_latest_name(names2, 3);
+    EXPECT_STREQ(out, "3-1");
+    free(out);
+
+    /* Quarterly. */
+    char *names3[] = {
+        (char *)"2023.Q4.5",
+        (char *)"2024.Q1.0",
+        (char *)"2023.Q1.99",
+    };
+    out = pr_get_latest_name(names3, 3);
+    EXPECT_STREQ(out, "2024.Q1.0");
+    free(out);
+}
+
+static void test_latest_non_version(void)
+{
+    fprintf(stderr, "[test_latest_non_version]\n");
+    /* No name matches `^\d+([.-]Q?\d+)*$`. PS falls back to lex sort
+     * + Select-Object -Last 1. */
+    char *names[] = {
+        (char *)"v1.0",
+        (char *)"release-2023",
+        (char *)"abc",
+    };
+    char *out = pr_get_latest_name(names, 3);
+    /* lex order: "abc" < "release-2023" < "v1.0" → last is "v1.0". */
+    EXPECT_STREQ(out, "v1.0");
+    free(out);
+}
+
+static void test_latest_mixed(void)
+{
+    fprintf(stderr, "[test_latest_mixed]\n");
+    /* When ANY version-like name exists, only those are considered. */
+    char *names[] = {
+        (char *)"v1.99",   /* skipped — has 'v' */
+        (char *)"1.2.3",   /* selected */
+        (char *)"release", /* skipped */
+        (char *)"1.10",    /* selected — winner */
+    };
+    char *out = pr_get_latest_name(names, 4);
+    EXPECT_STREQ(out, "1.10");
+    free(out);
+}
+
+/* --- pr_parse_tag_list ----------------------------------------------- */
+
+static void test_parse_basic(void)
+{
+    fprintf(stderr, "[test_parse_basic]\n");
+    const char *git = "v1.0\nv1.1\n\n  v1.2  \r\nrelease-2023\n";
+    char **names = NULL; size_t n = 0;
+    int rc = pr_parse_tag_list(git, NULL, &names, &n);
+    EXPECT_SZ(rc, 0);
+    EXPECT_SZ(n, 4);
+    if (n == 4) {
+        EXPECT_STREQ(names[0], "v1.0");
+        EXPECT_STREQ(names[1], "v1.1");
+        EXPECT_STREQ(names[2], "v1.2");          /* spaces stripped */
+        EXPECT_STREQ(names[3], "release-2023");
+    }
+    pr_git_tags_free(names, n);
+}
+
+static void test_parse_regex_filter(void)
+{
+    fprintf(stderr, "[test_parse_regex_filter]\n");
+    const char *git = "v1.0\nfoo\nv2.0\nbar\n";
+    char **names = NULL; size_t n = 0;
+    int rc = pr_parse_tag_list(git, "^v\\d", &names, &n);
+    EXPECT_SZ(rc, 0);
+    EXPECT_SZ(n, 2);
+    if (n == 2) {
+        EXPECT_STREQ(names[0], "v1.0");
+        EXPECT_STREQ(names[1], "v2.0");
+    }
+    pr_git_tags_free(names, n);
+}
+
+static void test_parse_empty_input(void)
+{
+    fprintf(stderr, "[test_parse_empty_input]\n");
+    char **names = (char **)0x1; size_t n = 42;
+    int rc = pr_parse_tag_list("", NULL, &names, &n);
+    EXPECT_SZ(rc, 0);
+    EXPECT_SZ(n, 0);
+    pr_git_tags_free(names, n);
+
+    /* NULL input. */
+    char **n2 = (char **)0x1; size_t cnt2 = 42;
+    rc = pr_parse_tag_list(NULL, NULL, &n2, &cnt2);
+    EXPECT_SZ(rc, 0);
+    EXPECT_SZ(cnt2, 0);
+    /* names is NULL on empty/null input */
+}
+
+int main(void)
+{
+    test_latest_empty();
+    test_latest_version_like();
+    test_latest_non_version();
+    test_latest_mixed();
+    test_parse_basic();
+    test_parse_regex_filter();
+    test_parse_empty_input();
+
+    if (failures == 0) {
+        fprintf(stderr, "test_phase6c: ALL PASSED\n");
+        return 0;
+    }
+    fprintf(stderr, "test_phase6c: %d failure(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Two pure functions that Phase 6d needs to wire UpdateAvailable / UpdateDownloadName population:

- **`pr_get_latest_name`** — PS L 1907-1949 verbatim. Filters null/whitespace, selects version-like names via `^\d+([.-]Q?\d+)*$`, bubble-searches for max via `pr_version_compare`; lex-sort fallback otherwise.
- **`pr_parse_tag_list`** — PS L 2441-2444 verbatim. Splits `git tag -l` stdout on `\r?\n`, drops blanks, optional PCRE2 regex filter, trims each survivor.

The runtime call (`Invoke-GitWithTimeout "tag -l"` against a local clone) ships in Phase 6d when local-clone management lands. Keeping the parser pure means it's unit-testable without git.

## Phase tracker
| Phase | Title | Status |
|-------|-------|--------|
| 0–6b | (all merged) | ✅ |
| 6c | **Get-LatestName + git tag-list parser** | **this PR** |
| 6d | Local-clone manager + integration into check_urlhealth | pending |
| 6e | HeapSort + Get-HighestJdkVersion + openjdk special cases | pending |
| 6f | Anomaly handlers + multi-branch diff reports + remaining ~1k lines | pending |
| 7 | Cluster orchestrator + worker pool | pending |
| 8 | Side-by-side CI parity gate | pending |
| 9 | PS retirement | pending |
| M | Maintainer ops & debug tooling | PR #56 still open |

## PS-source mapping (strict parity)
| PS lines | Operation | C site |
|----------|-----------|--------|
| 1907-1923 | Null/whitespace filter | `pr_get_latest_name` |
| 1925 | `^\d+([.-]Q?\d+)*$` version-like detection | `is_version_name` |
| 1928-1935 | Bubble-search-by-`Compare-VersionStrings` | inner loop |
| 1944 | Lexicographic sort + `Select-Object -Last 1` fallback | `qsort` + last |
| 2441 | split + IsNullOrWhiteSpace filter | line walk + `is_blank` |
| 2442-2443 | optional `customRegex` filter | PCRE2 + match gate |
| 2442-2443 | `.Trim()` | `trim_dup` |

## PS quirk skipped (with rationale)
PS L 1941 has a `ConvertFrom-Json | Sort-Object | Select-Object -Last 1` branch inside the non-version-name path. This fires only if the *entire* `$Names` array is valid JSON — vanishingly rare for `git tag -l` output. The C port always takes the lex-sort fallback (PS catch{} arm). The Phase 8 parity gate will surface any drift if a real-world tag list ever turns out to be JSON.

## Test plan
- [x] `cmake -B build -S .` configures cleanly
- [x] `cmake --build build` zero warnings
- [x] `ctest --test-dir build` → 9/9 passed
  - `test_phase6c` — Get-LatestName (empty / numeric / hyphen / quarterly / non-version / mixed) + tag-list parser (basic / regex filter / empty / NULL input)

## Reshuffled scope (6d/6e split)
Was originally "Git tag enumeration + HeapSort + UpdateURL/UpdateDownloadName". The actual wiring needs local-clone management to test properly, so:
- **6c** (this PR): pure functions, fully unit-tested
- **6d**: local-clone manager + `invoke_git_with_timeout` integration + column 5/6/7/10 population in `check_urlhealth.c`
- **6e**: HeapSort + Get-HighestJdkVersion + openjdk special cases (used only at PS L 4252 and L 2460-2462)

🤖 Generated with [Claude Code](https://claude.com/claude-code)