### PR TITLE
phase-6d: local-clone manager + git tag enumeration wired into check_urlhealth

### DIFF
--- a/photonos-package-report/photonos-package-report/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/CMakeLists.txt
@@ -103,6 +103,7 @@ add_executable(photonos-package-report
     src/version.c
     src/latest_name.c
     src/git_tags.c
+    src/clone.c
     ${PR_GEN_HOOK_DISPATCH}
     ${PR_HOOK_SOURCES}
 )

--- a/photonos-package-report/photonos-package-report/include/pr_check_urlhealth.h
+++ b/photonos-package-report/photonos-package-report/include/pr_check_urlhealth.h
@@ -27,8 +27,17 @@
 #include "source0_lookup.h"
 
 /* Returns a malloc'd 12-column comma-separated row mirroring PS L 4933.
- * Columns currently stubbed to "" are commented as such inside the body. */
+ * Columns currently stubbed to "" are commented as such inside the body.
+ *
+ * `clone_root`: directory under which per-repo clones live. When set
+ * (non-NULL and non-empty) AND the Source0Lookup row exposes a
+ * gitSource, runs the Phase 6d local-clone + `git tag -l` chain to
+ * populate columns 5 (UpdateAvailable) and 10 (UpdateDownloadName).
+ *
+ * Pass NULL/"" to skip the git step entirely (used by the existing
+ * unit tests so they stay offline-hermetic). */
 char *check_urlhealth(pr_task_t                       *task,
-                      const pr_source0_lookup_table_t *lookup_table);
+                      const pr_source0_lookup_table_t *lookup_table,
+                      const char                      *clone_root);
 
 #endif /* PR_CHECK_URLHEALTH_H */

--- a/photonos-package-report/photonos-package-report/include/pr_clone.h
+++ b/photonos-package-report/photonos-package-report/include/pr_clone.h
@@ -1,0 +1,56 @@
+/* pr_clone.h — local-clone manager.
+ *
+ * Mirrors photonos-package-report.ps1 L 2358-2456 sequentially:
+ *
+ *     $repoName = regex extract `/<name>\.git$` from $GitSource
+ *     $ClonePath = "$UpstreamsDir/$photonDir/clones"
+ *     $SourceClonePath = "$ClonePath/$repoName"
+ *     if (!Test-Path $SourceClonePath)
+ *         Invoke-GitWithTimeout "clone $GitSource [-b $branch] $repoName"
+ *     else if (!Test-Path $SourceClonePath/.git)
+ *         rm -rf $SourceClonePath; retry clone
+ *     else
+ *         Invoke-GitWithTimeout "fetch --prune --prune-tags --tags --force ..."
+ *
+ *     $tagOutput = Invoke-GitWithTimeout "tag -l"
+ *     $tagLines = pr_parse_tag_list(tagOutput, customRegex)
+ *
+ * Phase 7 will wrap this with the FETCH_HEAD/mutex coordination from
+ * Wait-ForFetchCompletion (PS L 2003-2073). For 6d we run sequentially.
+ */
+#ifndef PR_CLONE_H
+#define PR_CLONE_H
+
+#include <stddef.h>
+
+/* Extract the repository name from a `git clone`-style URL.
+ *
+ * PS L 2363: `if ($SourceTagURL -match "/([^/]+)\.git$") { $Matches[1] }`
+ *
+ * Returns a malloc'd string on match. Returns NULL when the URL does
+ * not end with `/<name>.git`. */
+char *pr_extract_repo_name(const char *git_url);
+
+/* Ensure a local clone exists for `git_url` under `clone_root/repo_name`.
+ * If `git_branch` is non-empty, clones with `-b <branch>` / fetches origin <branch>.
+ *
+ * Returns 0 on success (clone exists and is healthy), -1 on failure.
+ * Mirrors the PS retry-on-broken-.git logic (max 2 attempts).
+ */
+int pr_clone_ensure(const char *clone_root,
+                    const char *git_url,
+                    const char *git_branch,
+                    const char *repo_name);
+
+/* Run `git tag -l` in the clone directory and parse the output.
+ * Optional case-sensitive PCRE2 filter via `custom_regex`.
+ *
+ * Sets *out_names + *out_n on success. Caller frees with pr_git_tags_free.
+ * Returns 0 on success, -1 on failure.
+ */
+int pr_clone_list_tags(const char *clone_path,
+                       const char *custom_regex,
+                       char     ***out_names,
+                       size_t     *out_n);
+
+#endif /* PR_CLONE_H */

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -15,10 +15,14 @@
  */
 /* _GNU_SOURCE for asprintf is provided via CMake; do not redefine. */
 #include "pr_check_urlhealth.h"
+#include "pr_clone.h"
+#include "pr_git_tags.h"
 #include "pr_hook.h"
+#include "pr_latest.h"
 #include "pr_state.h"
 #include "pr_substitute.h"
 #include "pr_urlhealth.h"
+#include "pr_version.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -49,7 +53,8 @@ static char *dup_or_empty(const char *s)
 }
 
 char *check_urlhealth(pr_task_t                       *task,
-                      const pr_source0_lookup_table_t *lookup_table)
+                      const pr_source0_lookup_table_t *lookup_table,
+                      const char                      *clone_root)
 {
     if (task == NULL || task->Spec == NULL) return NULL;
 
@@ -88,8 +93,54 @@ char *check_urlhealth(pr_task_t                       *task,
     /* Phase 5 urlhealth probe. Skipped offline so ctest stays hermetic. */
     int health = 0;
     const char *netenv = getenv("PR_TEST_NETWORK");
-    if (netenv && strcmp(netenv, "1") == 0) {
+    int allow_network = (netenv && strcmp(netenv, "1") == 0);
+    if (allow_network) {
         health = urlhealth(state.Source0);
+    }
+
+    /* Phase 6d: when the Source0Lookup row has a gitSource AND a
+     * clone_root is configured AND the network is allowed, run the
+     * clone+fetch+tag chain to populate UpdateDownloadName (col 10)
+     * and UpdateAvailable (col 5). */
+    if (allow_network && clone_root && clone_root[0] != '\0'
+        && row && row->gitSource && row->gitSource[0] != '\0') {
+
+        char *repo_name = pr_extract_repo_name(row->gitSource);
+        if (repo_name) {
+            if (pr_clone_ensure(clone_root,
+                                row->gitSource,
+                                row->gitBranch,
+                                repo_name) == 0) {
+                /* List tags. */
+                char *clone_path = NULL;
+                if (asprintf(&clone_path, "%s/%s", clone_root, repo_name) > 0) {
+                    char  **names = NULL;
+                    size_t  n     = 0;
+                    if (pr_clone_list_tags(clone_path, row->customRegex,
+                                           &names, &n) == 0 && n > 0) {
+                        char *latest = pr_get_latest_name(names, n);
+                        if (latest && latest[0]) {
+                            free(state.UpdateDownloadName);
+                            state.UpdateDownloadName = latest;
+                            latest = NULL;  /* moved */
+
+                            /* UpdateAvailable: set to NameLatest iff
+                             * pr_version_compare(NameLatest, task.version) == 1. */
+                            int rc = pr_version_compare(state.UpdateDownloadName,
+                                                        task->Version ? task->Version : "");
+                            if (rc == 1) {
+                                free(state.UpdateAvailable);
+                                state.UpdateAvailable = dup_or_empty(state.UpdateDownloadName);
+                            }
+                        }
+                        free(latest);
+                    }
+                    pr_git_tags_free(names, n);
+                    free(clone_path);
+                }
+            }
+            free(repo_name);
+        }
     }
 
     /* PS L 4933: assemble the 12-column row.

--- a/photonos-package-report/photonos-package-report/src/clone.c
+++ b/photonos-package-report/photonos-package-report/src/clone.c
@@ -1,0 +1,184 @@
+/* clone.c — local-clone manager (Phase 6d, sequential).
+ * Mirrors photonos-package-report.ps1 L 2358-2456.
+ */
+/* _GNU_SOURCE for asprintf comes from CMake; do not redefine. */
+#include "pr_clone.h"
+#include "pr_git_tags.h"
+#include "photonos_package_report.h"  /* invoke_git_with_timeout from Phase 1 */
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <ftw.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+/* --- helpers -------------------------------------------------------- */
+
+static int dir_exists(const char *path)
+{
+    struct stat st;
+    if (stat(path, &st) != 0) return 0;
+    return S_ISDIR(st.st_mode);
+}
+
+static int rm_walker(const char *fpath, const struct stat *sb,
+                     int typeflag, struct FTW *ftwbuf)
+{
+    (void)sb; (void)typeflag; (void)ftwbuf;
+    return remove(fpath);
+}
+
+/* `rm -rf path`. Returns 0 on success or if path doesn't exist. */
+static int rm_rf(const char *path)
+{
+    if (!dir_exists(path) && access(path, F_OK) != 0) return 0;
+    /* nftw post-order: deepest first. */
+    return nftw(path, rm_walker, 16, FTW_DEPTH | FTW_PHYS);
+}
+
+static int mkdir_p(const char *path)
+{
+    char *copy = strdup(path);
+    if (!copy) return -1;
+    for (char *p = copy + 1; *p; p++) {
+        if (*p == '/') {
+            *p = '\0';
+            if (mkdir(copy, 0755) != 0 && errno != EEXIST) { free(copy); return -1; }
+            *p = '/';
+        }
+    }
+    int rc = mkdir(copy, 0755);
+    if (rc != 0 && errno == EEXIST) rc = 0;
+    free(copy);
+    return rc;
+}
+
+/* --- pr_extract_repo_name ------------------------------------------ */
+
+char *pr_extract_repo_name(const char *git_url)
+{
+    /* PS L 2363: /([^/]+)\.git$ */
+    if (git_url == NULL) return NULL;
+    size_t n = strlen(git_url);
+    if (n < 5) return NULL;                              /* min: "/a.git" */
+    if (strcmp(git_url + n - 4, ".git") != 0) return NULL;
+    const char *end = git_url + n - 4;                    /* points to '.git' */
+    const char *slash = end;
+    while (slash > git_url && *(slash - 1) != '/') slash--;
+    if (slash == git_url) return NULL;                    /* no '/' found */
+    size_t len = (size_t)(end - slash);
+    if (len == 0) return NULL;
+    char *out = (char *)malloc(len + 1);
+    if (!out) return NULL;
+    memcpy(out, slash, len);
+    out[len] = '\0';
+    return out;
+}
+
+/* --- pr_clone_ensure ----------------------------------------------- */
+
+static int do_clone(const char *clone_root,
+                    const char *git_url,
+                    const char *git_branch,
+                    const char *repo_name)
+{
+    char *args = NULL;
+    if (git_branch && git_branch[0]) {
+        if (asprintf(&args, "clone %s -b %s %s", git_url, git_branch, repo_name) < 0) return -1;
+    } else {
+        if (asprintf(&args, "clone %s %s", git_url, repo_name) < 0) return -1;
+    }
+    char *stdout_buf = NULL;
+    int rc = invoke_git_with_timeout(args, clone_root, 0, &stdout_buf);
+    free(args);
+    free(stdout_buf);
+    return rc == 0 ? 0 : -1;
+}
+
+static int do_fetch(const char *clone_path, const char *git_branch)
+{
+    char *args = NULL;
+    if (git_branch && git_branch[0]) {
+        if (asprintf(&args, "fetch --prune --prune-tags --tags --force origin %s",
+                     git_branch) < 0) return -1;
+    } else {
+        if (asprintf(&args, "fetch --prune --prune-tags --tags --force") < 0) return -1;
+    }
+    char *stdout_buf = NULL;
+    int rc = invoke_git_with_timeout(args, clone_path, 0, &stdout_buf);
+    free(args);
+    free(stdout_buf);
+    return rc == 0 ? 0 : -1;
+}
+
+int pr_clone_ensure(const char *clone_root,
+                    const char *git_url,
+                    const char *git_branch,
+                    const char *repo_name)
+{
+    if (clone_root == NULL || git_url == NULL || repo_name == NULL) return -1;
+    if (mkdir_p(clone_root) != 0) {
+        fprintf(stderr, "pr_clone_ensure: mkdir_p(%s) failed\n", clone_root);
+        return -1;
+    }
+
+    char *clone_path = NULL;
+    if (asprintf(&clone_path, "%s/%s", clone_root, repo_name) < 0) return -1;
+
+    char *git_dir = NULL;
+    if (asprintf(&git_dir, "%s/.git", clone_path) < 0) { free(clone_path); return -1; }
+
+    /* PS L 2390-2421: up to 2 attempts, deleting and re-cloning on
+     * a corrupt working tree. */
+    int rc = -1;
+    for (int attempt = 1; attempt <= 2; attempt++) {
+        if (!dir_exists(clone_path)) {
+            if (do_clone(clone_root, git_url, git_branch, repo_name) != 0) {
+                fprintf(stderr, "pr_clone_ensure: clone failed (attempt %d/2)\n", attempt);
+            }
+        } else if (!dir_exists(git_dir)) {
+            fprintf(stderr, "pr_clone_ensure: %s exists but no .git; rm+retry\n", clone_path);
+            rm_rf(clone_path);
+            continue;
+        } else {
+            if (do_fetch(clone_path, git_branch) != 0) {
+                fprintf(stderr, "pr_clone_ensure: fetch failed (attempt %d/2)\n", attempt);
+            }
+        }
+        if (dir_exists(clone_path) && dir_exists(git_dir)) { rc = 0; break; }
+        if (attempt == 1) {
+            rm_rf(clone_path);
+        }
+    }
+    free(git_dir);
+    free(clone_path);
+    return rc;
+}
+
+/* --- pr_clone_list_tags -------------------------------------------- */
+
+int pr_clone_list_tags(const char *clone_path,
+                       const char *custom_regex,
+                       char     ***out_names,
+                       size_t     *out_n)
+{
+    if (out_names == NULL || out_n == NULL) return -1;
+    *out_names = NULL;
+    *out_n     = 0;
+    if (clone_path == NULL) return -1;
+
+    char *stdout_buf = NULL;
+    int rc = invoke_git_with_timeout("tag -l", clone_path, 120, &stdout_buf);
+    if (rc != 0) {
+        free(stdout_buf);
+        return -1;
+    }
+
+    int prc = pr_parse_tag_list(stdout_buf, custom_regex, out_names, out_n);
+    free(stdout_buf);
+    return prc == 0 ? 0 : -1;
+}

--- a/photonos-package-report/photonos-package-report/src/main.c
+++ b/photonos-package-report/photonos-package-report/src/main.c
@@ -421,9 +421,19 @@ static int generate_urlhealth_main(const pr_params_t *params, const char *branch
         pr_prn_close(p); pr_source0_lookup_free(&lut); pr_task_list_free(&list);
         return 1;
     }
-    for (size_t i = 0; i < list.count; i++) {
-        rows[i] = check_urlhealth(&list.items[i], &lut);
+    /* Phase 6d: pass upstreamsDir/photonDir as the clone root so the
+     * git-tag chain populates UpdateDownloadName / UpdateAvailable
+     * when PR_TEST_NETWORK=1 is set. */
+    char *clone_root = NULL;
+    const char *up_dir = (params->upstreamsDir && params->upstreamsDir[0])
+                         ? params->upstreamsDir : params->workingDir;
+    if (asprintf(&clone_root, "%s/%s/clones", up_dir, branch) < 0) {
+        clone_root = NULL;
     }
+    for (size_t i = 0; i < list.count; i++) {
+        rows[i] = check_urlhealth(&list.items[i], &lut, clone_root);
+    }
+    free(clone_root);
     pr_prn_append_rows(p, rows, list.count);
 
     for (size_t i = 0; i < list.count; i++) free(rows[i]);

--- a/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
@@ -102,6 +102,11 @@ add_executable(test_phase6
     ${CMAKE_SOURCE_DIR}/src/check_urlhealth.c
     ${CMAKE_SOURCE_DIR}/src/hook_dispatch.c
     ${CMAKE_SOURCE_DIR}/src/task.c
+    ${CMAKE_SOURCE_DIR}/src/clone.c
+    ${CMAKE_SOURCE_DIR}/src/git_tags.c
+    ${CMAKE_SOURCE_DIR}/src/git_with_timeout.c
+    ${CMAKE_SOURCE_DIR}/src/latest_name.c
+    ${CMAKE_SOURCE_DIR}/src/version.c
     ${PR_GEN_HOOK_DISPATCH}
     ${PR_HOOK_SOURCES}
 )
@@ -146,3 +151,19 @@ target_link_libraries(test_phase6c PRIVATE pthread ${PCRE2_LIBRARIES})
 target_compile_options(test_phase6c PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER})
 
 add_test(NAME test_phase6c COMMAND test_phase6c)
+
+# ----- Phase 6d unit tests (local-clone manager + git tag enumeration)
+add_executable(test_phase6d
+    test_phase6d.c
+    ${CMAKE_SOURCE_DIR}/src/clone.c
+    ${CMAKE_SOURCE_DIR}/src/git_tags.c
+    ${CMAKE_SOURCE_DIR}/src/git_with_timeout.c
+)
+target_include_directories(test_phase6d PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${PCRE2_INCLUDE_DIRS}
+)
+target_link_libraries(test_phase6d PRIVATE pthread ${PCRE2_LIBRARIES})
+target_compile_options(test_phase6d PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER})
+
+add_test(NAME test_phase6d COMMAND test_phase6d)

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase6.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase6.c
@@ -165,7 +165,7 @@ static void test_check_urlhealth_shape(void)
     t.Version = (char *)"2.10";
     t.url     = (char *)"";
 
-    char *row = check_urlhealth(&t, NULL);
+    char *row = check_urlhealth(&t, NULL, NULL);
     if (!row) { failures++; fprintf(stderr, "  FAIL: NULL row\n"); return; }
     EXPECT_INT(count_commas(row), 11);  /* 12 cols → 11 commas */
     /* Starts with the spec basename. */

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase6d.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase6d.c
@@ -1,0 +1,168 @@
+/* test_phase6d.c — unit tests for the local-clone manager.
+ *
+ * Coverage:
+ *   - pr_extract_repo_name on a range of git URL shapes
+ *   - end-to-end pr_clone_ensure + pr_clone_list_tags against a tiny
+ *     local bare repo created in /tmp (no network). Gated on whether
+ *     git is on PATH.
+ */
+#include "pr_clone.h"
+#include "pr_git_tags.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int failures = 0;
+
+#define EXPECT_STREQ(actual, expected) do {                                    \
+    const char *_a = (actual);                                                 \
+    const char *_e = (expected);                                               \
+    if (_a == NULL || strcmp(_a, _e) != 0) {                                   \
+        fprintf(stderr, "  FAIL %s:%d: expected '%s' got '%s'\n",              \
+                __FILE__, __LINE__, _e, _a ? _a : "(null)");                   \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+#define EXPECT_NULL(actual) do {                                               \
+    if ((actual) != NULL) {                                                    \
+        fprintf(stderr, "  FAIL %s:%d: expected NULL\n", __FILE__, __LINE__);  \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+
+/* --- pr_extract_repo_name ------------------------------------------ */
+static void test_extract_repo_name(void)
+{
+    fprintf(stderr, "[test_extract_repo_name]\n");
+
+    char *r;
+    r = pr_extract_repo_name("https://github.com/abseil/abseil-cpp.git");
+    EXPECT_STREQ(r, "abseil-cpp"); free(r);
+
+    r = pr_extract_repo_name("https://gitlab.freedesktop.org/cairo/cairo.git");
+    EXPECT_STREQ(r, "cairo"); free(r);
+
+    /* Multiple path segments before .git */
+    r = pr_extract_repo_name("https://gitlab.freedesktop.org/xorg/lib/libx11.git");
+    EXPECT_STREQ(r, "libx11"); free(r);
+
+    /* SSH-style. */
+    r = pr_extract_repo_name("git@github.com:user/repo.git");
+    /* Falls back: there is no '/' before "repo.git" — actually there
+     * is one in "user/repo.git"; the function looks for the last '/'. */
+    EXPECT_STREQ(r, "repo"); free(r);
+
+    /* Missing .git → NULL */
+    EXPECT_NULL(pr_extract_repo_name("https://github.com/foo/bar"));
+
+    /* Just ".git" with no slash → NULL */
+    EXPECT_NULL(pr_extract_repo_name(".git"));
+
+    /* NULL → NULL */
+    EXPECT_NULL(pr_extract_repo_name(NULL));
+}
+
+/* --- Local-bare-repo integration ----------------------------------- */
+
+static int have_git(void)
+{
+    return system("git --version >/dev/null 2>&1") == 0;
+}
+
+static int run(const char *cmd)
+{
+    int rc = system(cmd);
+    return WIFEXITED(rc) && WEXITSTATUS(rc) == 0 ? 0 : -1;
+}
+
+static void test_clone_and_tags(void)
+{
+    fprintf(stderr, "[test_clone_and_tags]\n");
+    if (!have_git()) {
+        fprintf(stderr, "  SKIP: git not on PATH\n");
+        return;
+    }
+
+    char bare_tmpl[]  = "/tmp/pr_phase6d_bare_XXXXXX";
+    char clone_tmpl[] = "/tmp/pr_phase6d_clone_XXXXXX";
+    char *bare  = mkdtemp(bare_tmpl);
+    char *clone = mkdtemp(clone_tmpl);
+    if (!bare || !clone) {
+        fprintf(stderr, "  FAIL: mkdtemp failed\n"); failures++;
+        return;
+    }
+
+    /* Build a bare repo with three tags.
+     *   workdir holds the working copy, bare is the .git that
+     *   pr_clone_ensure clones from. */
+    char workdir_tmpl[] = "/tmp/pr_phase6d_work_XXXXXX";
+    char *workdir = mkdtemp(workdir_tmpl);
+    if (!workdir) { fprintf(stderr, "  FAIL: mkdtemp workdir\n"); failures++; return; }
+
+    char cmd[1024];
+    snprintf(cmd, sizeof cmd,
+        "set -e ;"
+        "cd '%s' ;"
+        "git init -q -b main . ;"
+        "git config user.email t@t ;"
+        "git config user.name t ;"
+        "echo a > a.txt ; git add . ; git commit -q -m a ; git tag v1.0 ;"
+        "echo b > b.txt ; git add . ; git commit -q -m b ; git tag v1.1 ;"
+        "echo c > c.txt ; git add . ; git commit -q -m c ; git tag v2.0 ;"
+        "cd '%s' ; git clone -q --bare '%s/.git' . ;",
+        workdir, bare, workdir);
+    if (run(cmd) != 0) {
+        fprintf(stderr, "  FAIL: bare repo setup\n"); failures++;
+        return;
+    }
+
+    /* Clone-ensure into clone_root/repo. */
+    if (pr_clone_ensure(clone, bare, NULL, "repo") != 0) {
+        fprintf(stderr, "  FAIL: pr_clone_ensure rc != 0\n"); failures++;
+    }
+
+    /* List tags. */
+    char clone_path[1024];
+    snprintf(clone_path, sizeof clone_path, "%s/repo", clone);
+    char **names = NULL; size_t n = 0;
+    if (pr_clone_list_tags(clone_path, NULL, &names, &n) != 0) {
+        fprintf(stderr, "  FAIL: pr_clone_list_tags rc != 0\n"); failures++;
+    }
+    if (n != 3) {
+        fprintf(stderr, "  FAIL: expected 3 tags, got %zu\n", n); failures++;
+    }
+    if (n >= 3) {
+        /* git tag -l output is sorted; v1.0, v1.1, v2.0. */
+        EXPECT_STREQ(names[0], "v1.0");
+        EXPECT_STREQ(names[1], "v1.1");
+        EXPECT_STREQ(names[2], "v2.0");
+    }
+    pr_git_tags_free(names, n);
+
+    /* Second invocation should hit the fetch path (clone exists). */
+    if (pr_clone_ensure(clone, bare, NULL, "repo") != 0) {
+        fprintf(stderr, "  FAIL: second pr_clone_ensure (fetch path) rc != 0\n");
+        failures++;
+    }
+
+    /* Cleanup — best-effort. */
+    snprintf(cmd, sizeof cmd, "rm -rf '%s' '%s' '%s'", workdir, bare, clone);
+    run(cmd);
+}
+
+int main(void)
+{
+    test_extract_repo_name();
+    test_clone_and_tags();
+
+    if (failures == 0) {
+        fprintf(stderr, "test_phase6d: ALL PASSED\n");
+        return 0;
+    }
+    fprintf(stderr, "test_phase6d: %d failure(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary
First end-to-end git plumbing for the C port — the C tool can now clone an upstream repo, fetch new tags, and pick the latest one to populate column 10 (`UpdateDownloadName`) and column 5 (`UpdateAvailable`) in the `.prn` row when a Source0LookupData row exposes a `gitSource`.

- **`pr_extract_repo_name`** — PS L 2363 regex port, parses `.../foo.git → "foo"`.
- **`pr_clone_ensure`** — sequential clone-or-fetch with rm+retry on broken `.git` (mirrors PS L 2385-2424, max 2 attempts). Uses Phase 1 `invoke_git_with_timeout` for all git calls.
- **`pr_clone_list_tags`** — wraps `invoke_git_with_timeout "tag -l"` (120 s timeout, matching PS L 2441) → Phase 6c `pr_parse_tag_list`.
- **`check_urlhealth` extended** with `clone_root` parameter. When set AND PR_TEST_NETWORK=1 AND the lookup row has `gitSource`, runs the clone+tag chain and populates cols 5/10.
- **`main.c --generate-urlhealth-report`** now passes `<upstreamsDir>/<branch>/clones` as clone root (mirrors PS L 2369 `$ClonePath`).

## Phase tracker
| Phase | Title | Status |
|-------|-------|--------|
| 0–6c | (all merged) | ✅ |
| 6d | **Local-clone manager + tag enumeration wired** | **this PR** |
| 6e | HeapSort + Get-HighestJdkVersion + openjdk special cases + UpdateURL/HealthUpdateURL construction | pending |
| 6f | Anomaly handlers + multi-branch diff reports + remaining ~1k lines | pending |
| 7 | Cluster orchestrator + worker pool (+ Wait-ForFetchCompletion mutex coord) | pending |
| 8 | Side-by-side CI parity gate | pending |
| 9 | PS retirement | pending |
| M | Maintainer ops & debug tooling | PR #56 still open |

## PS-source mapping (strict parity)
| PS lines | Operation | C site |
|----------|-----------|--------|
| 2363 | `/([^/]+)\.git$` regex repo name extract | `pr_extract_repo_name` |
| 2369 | `$ClonePath = $UpstreamsDir/$photonDir/clones` | `main.c` clone root path |
| 2376 | `Test-DiskSpace` pre-flight | pending — Phase 6f (uses Phase 1 `test_disk_space`) |
| 2385-2424 | clone-or-fetch with rm+retry | `pr_clone_ensure` |
| 2393-2395 | `fetch --prune --prune-tags --tags --force` ± `origin <branch>` | `do_fetch` |
| 2441 | `Invoke-GitWithTimeout "tag -l"` 120 s | `pr_clone_list_tags` |
| 2442-2443 | optional customRegex filter | already in Phase 6c `pr_parse_tag_list` |
| 1928-1935 | `Get-LatestName` bubble-search-by-`pr_version_compare` | already in Phase 6c |

## Out of scope (deferred)
- **Wait-ForFetchCompletion mutex** (PS L 2003-2073) — Phase 7. For 6d we run sequentially so a per-repo `flock` would suffice if needed; punting.
- **`Test-DiskSpace` pre-flight** (PS L 2376) — Phase 6f. Already implemented in Phase 1 (`test_disk_space`), just needs to be wired.
- **`UpdateURL` / `HealthUpdateURL` construction** (cols 6/7) — Phase 6e. Intertwined with ~80 spec-specific URL transformations at PS L 2217+ (the "anomalies" section).

## Test plan
- [x] `cmake -B build -S .` configures cleanly
- [x] `cmake --build build` zero warnings
- [x] `ctest --test-dir build` → 10/10 passed
  - `test_phase6d` — `pr_extract_repo_name` (5 URL shapes including SSH-style, missing-.git, NULL), **plus live-git integration**: creates a bare repo in `/tmp` with three tags via `git init` + `git tag`, clones it via `pr_clone_ensure`, lists via `pr_clone_list_tags`, asserts tag ordering. Re-runs to exercise the fetch path. Auto-skips if `git --version` fails.
- [x] `test_phase6` still passes — `check_urlhealth(task, lookup_table, NULL)` API back-compat preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)