### PR TITLE
phase-6e: HeapSort + Get-HighestJdkVersion + URL helpers + cols 6/7/10 wired

### DIFF
--- a/photonos-package-report/photonos-package-report/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/CMakeLists.txt
@@ -104,6 +104,9 @@ add_executable(photonos-package-report
     src/latest_name.c
     src/git_tags.c
     src/clone.c
+    src/heapsort.c
+    src/jdk.c
+    src/url_util.c
     ${PR_GEN_HOOK_DISPATCH}
     ${PR_HOOK_SOURCES}
 )

--- a/photonos-package-report/photonos-package-report/include/pr_heapsort.h
+++ b/photonos-package-report/photonos-package-report/include/pr_heapsort.h
@@ -1,0 +1,30 @@
+/* pr_heapsort.h — Doug-Finke heapsort with ASCII-byte concat comparator.
+ *
+ * Mirrors photonos-package-report.ps1 L 1576-1641 — a max-heapsort over
+ * an array of strings where the comparator is:
+ *
+ *   key(s) := int64( concat( for b in bytes(s): format(b, "000") ) )
+ *
+ * Example: "abc" → "097098099" → 97098099 (fits in int64).
+ *
+ * For ASCII-only strings the resulting key has the same ordering as
+ * strcmp (lexicographic), so HeapSort behaves like a lex sort for short
+ * inputs. For inputs longer than 6 bytes the int64 conversion overflows
+ * (1000^7 = 1e21 > 9.2e18); PS throws OverflowException on hit, the C
+ * port silently truncates because `int64_t` C wraps. This quirk is
+ * preserved per CLAUDE.md invariant #2 — the only PS call site
+ * (PS L 4252 for docbook-xml.spec) feeds short fragment strings so
+ * overflow is unreachable in practice.
+ *
+ * Mutates the input array in place. Returns 0 on success, -1 on alloc
+ * failure. After return the array is sorted ascending by the key,
+ * so the last element is the maximum.
+ */
+#ifndef PR_HEAPSORT_H
+#define PR_HEAPSORT_H
+
+#include <stddef.h>
+
+int pr_heapsort_strings(char **arr, size_t n);
+
+#endif /* PR_HEAPSORT_H */

--- a/photonos-package-report/photonos-package-report/include/pr_jdk.h
+++ b/photonos-package-report/photonos-package-report/include/pr_jdk.h
@@ -1,0 +1,27 @@
+/* pr_jdk.h — Get-HighestJdkVersion port.
+ *
+ * Mirrors photonos-package-report.ps1 L 1638-1735.
+ *
+ * Given a list of OpenJDK-style tag names ("jdk-11.0.28+6",
+ * "jdk-11.0.28-ga", "jdk-11+0", ...), pick the highest. Sorting keys
+ * (descending priority): Major, Minor, Patch, then GA-wins-over-Build
+ * (GA acts as max int).
+ *
+ * Returns the winner's Original-stripped-of-"jdk-" prefix as a heap
+ * string (caller frees), or NULL if no candidate matched the prefix.
+ *
+ * `major_release` is used as the default Major when the tag has no
+ * version-number component (e.g. bare "jdk-11" → Major=11). `filter`
+ * is the literal "jdk-NN" prefix to match against (PS uses
+ * "jdk-11" / "jdk-17" / "jdk-21").
+ */
+#ifndef PR_JDK_H
+#define PR_JDK_H
+
+#include <stddef.h>
+
+char *pr_get_highest_jdk_version(char **names, size_t n,
+                                 int major_release,
+                                 const char *filter);
+
+#endif /* PR_JDK_H */

--- a/photonos-package-report/photonos-package-report/include/pr_url_util.h
+++ b/photonos-package-report/photonos-package-report/include/pr_url_util.h
@@ -1,0 +1,23 @@
+/* pr_url_util.h — URL helpers shared across the C port.
+ *
+ * PS L 4716-4718:
+ *
+ *   if ($UpdateURL -match '/download$') {
+ *       $segments = $UpdateURL -split '/'
+ *       $UpdateDownloadName = $segments[-2]
+ *   } else {
+ *       $UpdateDownloadName = ($UpdateURL -split '/')[-1]
+ *   }
+ *
+ * SourceForge mirror URLs end in `/download` as a redirect trigger;
+ * the real filename is the penultimate path segment. For everything
+ * else the basename is the last segment.
+ */
+#ifndef PR_URL_UTIL_H
+#define PR_URL_UTIL_H
+
+/* Returns a malloc'd basename string the caller frees.
+ * Returns NULL on NULL/empty input. */
+char *pr_basename_from_url(const char *url);
+
+#endif /* PR_URL_UTIL_H */

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -21,6 +21,7 @@
 #include "pr_latest.h"
 #include "pr_state.h"
 #include "pr_substitute.h"
+#include "pr_url_util.h"
 #include "pr_urlhealth.h"
 #include "pr_version.h"
 
@@ -120,17 +121,52 @@ char *check_urlhealth(pr_task_t                       *task,
                                            &names, &n) == 0 && n > 0) {
                         char *latest = pr_get_latest_name(names, n);
                         if (latest && latest[0]) {
-                            free(state.UpdateDownloadName);
-                            state.UpdateDownloadName = latest;
-                            latest = NULL;  /* moved */
+                            /* Phase 6e: construct UpdateURL by re-running
+                             * the Source0 substitution with version=NameLatest
+                             * against the RAW Source0Lookup template (PS L
+                             * 4659-4710 normal-path logic, simplified). */
+                            const char *template = (row->Source0Lookup
+                                                    && row->Source0Lookup[0])
+                                                   ? row->Source0Lookup
+                                                   : (task->Source0 ? task->Source0 : "");
+                            char *update_url = dup_or_empty(template);
+                            if (update_url) {
+                                pr_source0_substitute(task, &update_url, latest);
+                                free(state.UpdateURL);
+                                state.UpdateURL = update_url;
+                            }
 
-                            /* UpdateAvailable: set to NameLatest iff
+                            /* HealthUpdateURL (col 7): urlhealth probe of
+                             * the rewritten UpdateURL. Same network gate. */
+                            if (state.UpdateURL && state.UpdateURL[0]) {
+                                int h = urlhealth(state.UpdateURL);
+                                char buf[16];
+                                snprintf(buf, sizeof buf, "%d", h);
+                                free(state.HealthUpdateURL);
+                                state.HealthUpdateURL = strdup(buf);
+                            }
+
+                            /* UpdateDownloadName (col 10): PS L 4716-4718
+                             * — basename of UpdateURL, with SourceForge
+                             * /download → penultimate segment. */
+                            char *dl_name = pr_basename_from_url(state.UpdateURL);
+                            if (dl_name) {
+                                free(state.UpdateDownloadName);
+                                state.UpdateDownloadName = dl_name;
+                            } else {
+                                /* Fallback: keep the raw NameLatest if
+                                 * we couldn't derive a basename. */
+                                free(state.UpdateDownloadName);
+                                state.UpdateDownloadName = dup_or_empty(latest);
+                            }
+
+                            /* UpdateAvailable (col 5): set to NameLatest iff
                              * pr_version_compare(NameLatest, task.version) == 1. */
-                            int rc = pr_version_compare(state.UpdateDownloadName,
+                            int rc = pr_version_compare(latest,
                                                         task->Version ? task->Version : "");
                             if (rc == 1) {
                                 free(state.UpdateAvailable);
-                                state.UpdateAvailable = dup_or_empty(state.UpdateDownloadName);
+                                state.UpdateAvailable = dup_or_empty(latest);
                             }
                         }
                         free(latest);

--- a/photonos-package-report/photonos-package-report/src/heapsort.c
+++ b/photonos-package-report/photonos-package-report/src/heapsort.c
@@ -1,0 +1,87 @@
+/* heapsort.c — Doug-Finke max-heapsort port.
+ * Mirrors photonos-package-report.ps1 L 1590-1641 line-for-line.
+ *
+ * PS source (abbreviated):
+ *
+ *   class HeapSort {
+ *       [array] static Sort($targetList) {
+ *           $heapSize = $targetList.Count
+ *           for ($p = ($heapSize - 1) / 2; $p -ge 0; $p--) MaxHeapify(...)
+ *           for ($i = $targetList.Count - 1; $i -gt 0; $i--) {
+ *               swap targetList[0] <-> targetList[$i]
+ *               $heapSize--; MaxHeapify($targetList, $heapSize, 0)
+ *           }
+ *           return $targetList
+ *       }
+ *       static MaxHeapify($targetList, $heapSize, $index) {
+ *           $left  = ($index + 1) * 2 - 1
+ *           $right = ($index + 1) * 2
+ *           ... pick largest by  [int64](concat bytes-as-"000") ...
+ *           if largest != index: swap + recurse
+ *       }
+ *   }
+ *
+ * The bizarre comparator is preserved verbatim. For ASCII-only short
+ * (≤6-byte) strings it is equivalent to strcmp; longer inputs silently
+ * wrap. PS L 4252 is the only call site and feeds short fragments
+ * (docbook-xml directory names), so overflow is unreachable in practice.
+ */
+#include "pr_heapsort.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* PS key: bytes → 3-digit zero-padded decimals → concat → int64. */
+static int64_t key_of(const char *s)
+{
+    int64_t k = 0;
+    for (const unsigned char *p = (const unsigned char *)s; *p; p++) {
+        /* multiply by 1000, add byte value. Overflow wraps; PS would
+         * throw — we mirror the algorithm not the exception model. */
+        k = k * 1000 + (int64_t)(*p);
+    }
+    return k;
+}
+
+static void swap_str(char **arr, size_t i, size_t j)
+{
+    char *t = arr[i];
+    arr[i] = arr[j];
+    arr[j] = t;
+}
+
+static void max_heapify(char **arr, size_t heap_size, size_t index)
+{
+    /* PS uses 1-based math: left = (index+1)*2-1, right = (index+1)*2.
+     * Translates 1:1 to 0-based: left = 2*index+1, right = 2*index+2. */
+    size_t left    = index * 2 + 1;
+    size_t right   = index * 2 + 2;
+    size_t largest = index;
+
+    if (left  < heap_size && key_of(arr[left])  > key_of(arr[largest])) largest = left;
+    if (right < heap_size && key_of(arr[right]) > key_of(arr[largest])) largest = right;
+
+    if (largest != index) {
+        swap_str(arr, index, largest);
+        max_heapify(arr, heap_size, largest);
+    }
+}
+
+int pr_heapsort_strings(char **arr, size_t n)
+{
+    if (arr == NULL && n != 0) return -1;
+    if (n <= 1) return 0;
+
+    /* Build the heap. PS iterates p from (heapSize - 1) / 2 down to 0. */
+    for (long p = (long)((n - 1) / 2); p >= 0; p--) {
+        max_heapify(arr, n, (size_t)p);
+    }
+
+    /* Sort: swap root with last, shrink heap, re-heapify. */
+    for (size_t i = n - 1; i > 0; i--) {
+        swap_str(arr, 0, i);
+        max_heapify(arr, i, 0);
+    }
+    return 0;
+}

--- a/photonos-package-report/photonos-package-report/src/jdk.c
+++ b/photonos-package-report/photonos-package-report/src/jdk.c
@@ -1,0 +1,157 @@
+/* jdk.c — Get-HighestJdkVersion port.
+ * Mirrors photonos-package-report.ps1 L 1638-1735 line-for-line.
+ *
+ * Parse jdk-X[.Y[.Z]][+B][-ga] / "jdk-X+B" / "jdk-X" into Major / Minor /
+ * Patch / Build / IsGa. Sort descending by (Major, Minor, Patch, IsGa-then-Build).
+ * Return Original -ireplace "jdk-".
+ */
+#include "pr_jdk.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+typedef struct {
+    const char *original;     /* not owned */
+    int  major;
+    int  minor;
+    int  patch;
+    int  build;
+    int  is_ga;
+} jdk_version_t;
+
+/* Returns 1 if `s` starts with `prefix` (case-sensitive). */
+static int starts_with(const char *s, const char *prefix)
+{
+    return strncmp(s, prefix, strlen(prefix)) == 0;
+}
+
+/* Returns 1 if every character in [s, s+len) is a digit. */
+static int all_digit(const char *s, size_t len)
+{
+    if (len == 0) return 0;
+    for (size_t i = 0; i < len; i++) {
+        if (!isdigit((unsigned char)s[i])) return 0;
+    }
+    return 1;
+}
+
+static int parse_int(const char *s)
+{
+    return (int)strtol(s, NULL, 10);
+}
+
+/* PS L 1648-1697: parse a single tag string. */
+static void parse_one(const char *version, int default_major, const char *filter,
+                       jdk_version_t *out)
+{
+    out->original = version;
+    out->major    = default_major;
+    out->minor    = 0;
+    out->patch    = 0;
+    out->build    = 0;
+    out->is_ga    = 0;
+
+    /* PS L 1661-1662: remove the literal "<filter>" prefix.
+     * In C, `version` is guaranteed to start with `filter` (we only
+     * called parse_one on filtered names). Skip it. */
+    const char *p = version;
+    size_t fl = strlen(filter);
+    if (strncmp(p, filter, fl) == 0) p += fl;
+
+    /* PS L 1665-1668: check for "-ga" suffix and strip it. */
+    size_t plen = strlen(p);
+    if (plen >= 3 && strcmp(p + plen - 3, "-ga") == 0) {
+        out->is_ga = 1;
+        plen -= 3;
+    }
+
+    /* Work on a heap copy so we can null-terminate after splitting. */
+    char *body = (char *)malloc(plen + 1);
+    if (!body) return;
+    memcpy(body, p, plen);
+    body[plen] = '\0';
+
+    /* PS L 1671: split on '+' — version vs build. */
+    char *plus = strchr(body, '+');
+    char *version_part = body;
+    char *build_part   = NULL;
+    if (plus) { *plus = '\0'; build_part = plus + 1; }
+
+    /* PS L 1675-1690: parse dotted version or bare major. */
+    if (strchr(version_part, '.') != NULL) {
+        /* Dotted: 11.0.28 etc. */
+        char *save = NULL;
+        char *tok = strtok_r(version_part, ".", &save);
+        int   idx = 0;
+        while (tok) {
+            size_t tlen = strlen(tok);
+            if (all_digit(tok, tlen)) {
+                int v = parse_int(tok);
+                if      (idx == 0) out->major = v;
+                else if (idx == 1) out->minor = v;
+                else if (idx == 2) out->patch = v;
+            }
+            tok = strtok_r(NULL, ".", &save);
+            idx++;
+        }
+    } else if (all_digit(version_part, strlen(version_part))) {
+        /* Bare major: "11", "17", ... */
+        out->major = parse_int(version_part);
+    }
+
+    if (build_part && all_digit(build_part, strlen(build_part))) {
+        out->build = parse_int(build_part);
+    }
+
+    free(body);
+}
+
+/* qsort comparator: descending by (Major, Minor, Patch, IsGa-prio, Build). */
+static int cmp_jdk_desc(const void *a, const void *b)
+{
+    const jdk_version_t *x = (const jdk_version_t *)a;
+    const jdk_version_t *y = (const jdk_version_t *)b;
+    if (x->major != y->major) return y->major - x->major;
+    if (x->minor != y->minor) return y->minor - x->minor;
+    if (x->patch != y->patch) return y->patch - x->patch;
+    /* PS L 1718: IsGa => [int]::MaxValue, else Build. We model that
+     * by treating is_ga as a tiebreaker BEFORE build. */
+    if (x->is_ga != y->is_ga) return y->is_ga - x->is_ga;
+    return y->build - x->build;
+}
+
+char *pr_get_highest_jdk_version(char **names, size_t n,
+                                 int major_release,
+                                 const char *filter)
+{
+    if (names == NULL || n == 0 || filter == NULL || filter[0] == '\0') return NULL;
+
+    /* PS L 1654: filter to names starting with `<filter>` (no '*' here
+     * because the input is already individual tag strings, not the
+     * full git tag list — PS `-like '<filter>*'` is just prefix-match). */
+    jdk_version_t *parsed = (jdk_version_t *)calloc(n, sizeof *parsed);
+    if (!parsed) return NULL;
+    size_t k = 0;
+    for (size_t i = 0; i < n; i++) {
+        if (names[i] == NULL) continue;
+        if (!starts_with(names[i], filter)) continue;
+        parse_one(names[i], major_release, filter, &parsed[k++]);
+    }
+    if (k == 0) { free(parsed); return NULL; }
+
+    qsort(parsed, k, sizeof *parsed, cmp_jdk_desc);
+
+    /* PS L 1733: return Original -ireplace "jdk-",""
+     * For the C port, strip the literal "jdk-" prefix once. */
+    const char *winner = parsed[0].original;
+    const char *strip  = "jdk-";
+    size_t slen = strlen(strip);
+    if (strncasecmp(winner, strip, slen) == 0) winner += slen;
+
+    char *out = strdup(winner);
+    free(parsed);
+    return out;
+}

--- a/photonos-package-report/photonos-package-report/src/url_util.c
+++ b/photonos-package-report/photonos-package-report/src/url_util.c
@@ -1,0 +1,46 @@
+/* url_util.c — URL helpers.
+ * Mirrors photonos-package-report.ps1 L 4716-4718.
+ */
+#include "pr_url_util.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static char *xstrndup(const char *s, size_t n)
+{
+    char *p = (char *)malloc(n + 1);
+    if (!p) return NULL;
+    memcpy(p, s, n);
+    p[n] = '\0';
+    return p;
+}
+
+char *pr_basename_from_url(const char *url)
+{
+    if (url == NULL || url[0] == '\0') return NULL;
+    size_t n = strlen(url);
+
+    /* SourceForge-style: URL ends with "/download". Return penultimate
+     * segment. */
+    static const char DOWNLOAD[] = "/download";
+    static const size_t DLEN     = sizeof(DOWNLOAD) - 1;
+    if (n > DLEN && memcmp(url + n - DLEN, DOWNLOAD, DLEN) == 0) {
+        /* Skip the trailing "/download", then find the previous '/'. */
+        const char *end   = url + n - DLEN;
+        const char *start = end;
+        while (start > url && *(start - 1) != '/') start--;
+        if (start == end) {
+            /* No prior segment — pathological "/download" only. */
+            return xstrndup("", 0);
+        }
+        return xstrndup(start, (size_t)(end - start));
+    }
+
+    /* Default: last segment after the final '/'. */
+    const char *last_slash = strrchr(url, '/');
+    if (last_slash == NULL) {
+        /* No slash anywhere — treat the whole string as the basename. */
+        return xstrndup(url, n);
+    }
+    return xstrndup(last_slash + 1, n - (size_t)(last_slash - url) - 1);
+}

--- a/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
@@ -107,6 +107,7 @@ add_executable(test_phase6
     ${CMAKE_SOURCE_DIR}/src/git_with_timeout.c
     ${CMAKE_SOURCE_DIR}/src/latest_name.c
     ${CMAKE_SOURCE_DIR}/src/version.c
+    ${CMAKE_SOURCE_DIR}/src/url_util.c
     ${PR_GEN_HOOK_DISPATCH}
     ${PR_HOOK_SOURCES}
 )
@@ -167,3 +168,15 @@ target_link_libraries(test_phase6d PRIVATE pthread ${PCRE2_LIBRARIES})
 target_compile_options(test_phase6d PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER})
 
 add_test(NAME test_phase6d COMMAND test_phase6d)
+
+# ----- Phase 6e unit tests (HeapSort + JDK picker + URL basename) ----
+add_executable(test_phase6e
+    test_phase6e.c
+    ${CMAKE_SOURCE_DIR}/src/heapsort.c
+    ${CMAKE_SOURCE_DIR}/src/jdk.c
+    ${CMAKE_SOURCE_DIR}/src/url_util.c
+)
+target_include_directories(test_phase6e PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_compile_options(test_phase6e PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE)
+
+add_test(NAME test_phase6e COMMAND test_phase6e)

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase6e.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase6e.c
@@ -1,0 +1,151 @@
+/* test_phase6e.c — unit tests for HeapSort, Get-HighestJdkVersion,
+ * pr_basename_from_url.
+ */
+#include "pr_heapsort.h"
+#include "pr_jdk.h"
+#include "pr_url_util.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures = 0;
+
+#define EXPECT_STREQ(actual, expected) do {                                    \
+    const char *_a = (actual);                                                 \
+    const char *_e = (expected);                                               \
+    if (_a == NULL || strcmp(_a, _e) != 0) {                                   \
+        fprintf(stderr, "  FAIL %s:%d: expected '%s' got '%s'\n",              \
+                __FILE__, __LINE__, _e, _a ? _a : "(null)");                   \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+#define EXPECT_NULL(actual) do {                                               \
+    if ((actual) != NULL) {                                                    \
+        fprintf(stderr, "  FAIL %s:%d: expected NULL\n", __FILE__, __LINE__);  \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+
+/* --- HeapSort ------------------------------------------------------- */
+
+static void test_heapsort_short(void)
+{
+    fprintf(stderr, "[test_heapsort_short]\n");
+    /* All inputs ≤ 6 bytes — int64 key fits, sort matches strcmp. */
+    char *a = strdup("v1.0");
+    char *b = strdup("v0.5");
+    char *c = strdup("v2.1");
+    char *arr[] = { a, b, c };
+    pr_heapsort_strings(arr, 3);
+    /* Ascending → max is last. */
+    EXPECT_STREQ(arr[2], "v2.1");
+    EXPECT_STREQ(arr[0], "v0.5");
+    free(a); free(b); free(c);
+}
+
+static void test_heapsort_single(void)
+{
+    fprintf(stderr, "[test_heapsort_single]\n");
+    char *a = strdup("only");
+    char *arr[] = { a };
+    pr_heapsort_strings(arr, 1);
+    EXPECT_STREQ(arr[0], "only");
+    free(a);
+}
+
+/* --- Get-HighestJdkVersion ----------------------------------------- */
+
+static void test_jdk_basic(void)
+{
+    fprintf(stderr, "[test_jdk_basic]\n");
+    char *names[] = {
+        (char *)"jdk-11.0.27+10",
+        (char *)"jdk-11.0.28+6",
+        (char *)"jdk-11.0.28-ga",     /* GA wins tie on patch */
+        (char *)"jdk-11.0.27-ga",
+        (char *)"openjdk-irrelevant", /* skipped — wrong prefix */
+        (char *)"jdk-17.0.1+0",       /* skipped — major filter is jdk-11 */
+    };
+    char *w = pr_get_highest_jdk_version(names, 6, 11, "jdk-11");
+    /* Among 11.0.27+10 / 11.0.28+6 / 11.0.28-ga / 11.0.27-ga:
+     *   sort desc by major(=11), minor(=0), patch -> 28 > 27 first;
+     *   among 28: ga vs +6 → ga wins (is_ga=1 sorts before is_ga=0).
+     * Original "jdk-11.0.28-ga" → strip "jdk-" → "11.0.28-ga". */
+    EXPECT_STREQ(w, "11.0.28-ga");
+    free(w);
+}
+
+static void test_jdk_bare_major(void)
+{
+    fprintf(stderr, "[test_jdk_bare_major]\n");
+    char *names[] = {
+        (char *)"jdk-11",
+        (char *)"jdk-11+28",
+        (char *)"jdk-11.0+0",
+    };
+    char *w = pr_get_highest_jdk_version(names, 3, 11, "jdk-11");
+    /* All major=11, minor=0, patch=0. Tiebreaker on Build:
+     *   jdk-11+28 (build=28) > jdk-11.0+0 (build=0) > jdk-11 (build=0). */
+    EXPECT_STREQ(w, "11+28");
+    free(w);
+}
+
+static void test_jdk_no_match(void)
+{
+    fprintf(stderr, "[test_jdk_no_match]\n");
+    char *names[] = { (char *)"openjdk-21", (char *)"jdk-17+1" };
+    /* Both miss "jdk-11" prefix → NULL. */
+    EXPECT_NULL(pr_get_highest_jdk_version(names, 2, 11, "jdk-11"));
+}
+
+/* --- pr_basename_from_url ------------------------------------------- */
+
+static void test_basename_simple(void)
+{
+    fprintf(stderr, "[test_basename_simple]\n");
+    char *b = pr_basename_from_url("https://example.invalid/foo/bar-1.0.tar.gz");
+    EXPECT_STREQ(b, "bar-1.0.tar.gz"); free(b);
+}
+
+static void test_basename_sourceforge(void)
+{
+    fprintf(stderr, "[test_basename_sourceforge]\n");
+    char *b = pr_basename_from_url(
+        "https://sourceforge.net/projects/foo/files/foo-1.0.tar.gz/download");
+    /* PS quirk: /download suffix → penultimate segment. */
+    EXPECT_STREQ(b, "foo-1.0.tar.gz"); free(b);
+}
+
+static void test_basename_edge(void)
+{
+    fprintf(stderr, "[test_basename_edge]\n");
+    EXPECT_NULL(pr_basename_from_url(NULL));
+    EXPECT_NULL(pr_basename_from_url(""));
+
+    char *b = pr_basename_from_url("noslash.tar.gz");
+    EXPECT_STREQ(b, "noslash.tar.gz"); free(b);
+
+    /* Trailing slash → empty basename (last segment is empty). */
+    b = pr_basename_from_url("https://example.invalid/");
+    EXPECT_STREQ(b, ""); free(b);
+}
+
+int main(void)
+{
+    test_heapsort_short();
+    test_heapsort_single();
+    test_jdk_basic();
+    test_jdk_bare_major();
+    test_jdk_no_match();
+    test_basename_simple();
+    test_basename_sourceforge();
+    test_basename_edge();
+
+    if (failures == 0) {
+        fprintf(stderr, "test_phase6e: ALL PASSED\n");
+        return 0;
+    }
+    fprintf(stderr, "test_phase6e: %d failure(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Three small algorithm ports + the wiring that finally populates columns 6, 7, and 10 of the `.prn` row when the Phase 6d git-tag chain finds a NameLatest:

- **`pr_heapsort_strings`** — Doug-Finke max-heapsort with the PS comparator that builds an int64 from concatenated 3-digit ASCII bytes. Used at PS L 4252 (docbook-xml.spec only). PS quirk preserved per CLAUDE.md invariant #2 (overflow on > 6-byte inputs; unreachable in practice).
- **`pr_get_highest_jdk_version`** — Get-HighestJdkVersion port (PS L 1638-1735). Filters by `jdk-NN` prefix, parses Major.Minor.Patch+Build with optional `-ga`, sorts descending by `(Major, Minor, Patch, is_ga, Build)`. Used by `openjdk{11,17,21}.spec` hooks (PS L 2460-2462).
- **`pr_basename_from_url`** — PS L 4716-4718 port. SourceForge `/download` → penultimate segment; everything else → last segment.
- **`check_urlhealth.c` cols 6/7/10**: after Phase 6d's NameLatest, re-runs `pr_source0_substitute` against the raw Source0Lookup template with `version=NameLatest` → UpdateURL; `urlhealth(UpdateURL)` → HealthUpdateURL; `pr_basename_from_url(UpdateURL)` → UpdateDownloadName.

## Phase tracker
| Phase | Title | Status |
|-------|-------|--------|
| 0–6d | (all merged) | ✅ |
| 6e | **HeapSort + Get-HighestJdkVersion + URL helpers + cols 6/7/10** | **this PR** |
| 6f | Anomaly handlers + multi-branch diff reports + remaining ~1k lines | pending |
| 7 | Cluster orchestrator + worker pool (+ Wait-ForFetchCompletion mutex) | pending |
| 8 | Side-by-side CI parity gate | pending |
| 9 | PS retirement | pending |
| M | Maintainer ops & debug tooling | PR #56 still open |

## PS-source mapping (strict parity)
| PS lines | Operation | C site |
|----------|-----------|--------|
| 1590-1641 | HeapSort class + MaxHeapify | `pr_heapsort_strings`, `max_heapify` |
| 1620-1631 | int64 ASCII-3-digit comparator | `key_of` |
| 1638-1735 | Get-HighestJdkVersion (parse + sort + strip "jdk-") | `pr_get_highest_jdk_version` |
| 1665-1670 | -ga suffix detection | `parse_one` is_ga branch |
| 1671 | split on '+' (version vs build) | `parse_one` plus split |
| 1675-1690 | dotted-version parsing (Major.Minor.Patch) | `parse_one` strtok |
| 1715-1718 | sort desc with IsGa as MaxInt | `cmp_jdk_desc` |
| 4716-4718 | SourceForge `/download` → penultimate | `pr_basename_from_url` |
| (new) | re-substitute template with NameLatest | `check_urlhealth.c` |

## End-to-end smoke (with PR_TEST_NETWORK=1)
With the network gate enabled, the C tool will now emit `.prn` rows that look like:
```
abseil-cpp.spec,...,200,20250127,https://.../abseil-cpp-20250127.tar.gz,200,abseil-cpp,...,abseil-cpp-20250127.tar.gz,,
```
Cols 4, 5, 6, 7, 10 all populated. Cols 11/12 (Warning, ArchivationDate) populated from the lookup row since Phase 6a. Cols 8 (Name), 2/3 (Source0 original / rewritten) populated since Phase 6a.

Only **col 9 (SHAValue)** remains stubbed — that's Phase 6f (Get-FileHashWithRetry + the ~30 anomaly-driven SHA recomputations).

## Test plan
- [x] `cmake -B build -S .` configures cleanly
- [x] `cmake --build build` zero warnings
- [x] `ctest --test-dir build` → 11/11 passed
  - `test_phase6e` — HeapSort (short-string + single), Get-HighestJdkVersion (GA-wins-build, bare-major, prefix-miss), pr_basename_from_url (simple, SourceForge /download, no-slash, trailing slash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)