### PR TITLE
phase-6f: SHA helpers + cross-branch diff reports + col 9 wired (Phase 6 complete)

### DIFF
--- a/photonos-package-report/photonos-package-report/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/CMakeLists.txt
@@ -11,8 +11,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # Phase 1 used libc + pthread; Phase 2 added PCRE2; Phase 3 adds the
 # bash+awk Source0LookupData generator (no extra runtime deps).
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(PCRE2 REQUIRED libpcre2-8)
-pkg_check_modules(CURL  REQUIRED libcurl)
+pkg_check_modules(PCRE2   REQUIRED libpcre2-8)
+pkg_check_modules(CURL    REQUIRED libcurl)
+pkg_check_modules(OPENSSL REQUIRED openssl)
 
 # ----- Phase 3 generator: embedded Source0LookupData CSV -------------
 # Runs at build time. Output lives under ${CMAKE_BINARY_DIR}/generated
@@ -107,6 +108,8 @@ add_executable(photonos-package-report
     src/heapsort.c
     src/jdk.c
     src/url_util.c
+    src/sha.c
+    src/diff_report.c
     ${PR_GEN_HOOK_DISPATCH}
     ${PR_HOOK_SOURCES}
 )
@@ -118,9 +121,10 @@ target_include_directories(photonos-package-report PRIVATE
     ${PR_GEN_DIR}
     ${PCRE2_INCLUDE_DIRS}
     ${CURL_INCLUDE_DIRS}
+    ${OPENSSL_INCLUDE_DIRS}
 )
-target_link_libraries(photonos-package-report PRIVATE pthread ${PCRE2_LIBRARIES} ${CURL_LIBRARIES})
-target_compile_options(photonos-package-report PRIVATE -Wall -Wextra -O2 -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER} ${CURL_CFLAGS_OTHER})
+target_link_libraries(photonos-package-report PRIVATE pthread ${PCRE2_LIBRARIES} ${CURL_LIBRARIES} ${OPENSSL_LIBRARIES})
+target_compile_options(photonos-package-report PRIVATE -Wall -Wextra -O2 -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER} ${CURL_CFLAGS_OTHER} ${OPENSSL_CFLAGS_OTHER})
 
 # ----- Tests --------------------------------------------------------
 enable_testing()

--- a/photonos-package-report/photonos-package-report/include/pr_diff_report.h
+++ b/photonos-package-report/photonos-package-report/include/pr_diff_report.h
@@ -1,0 +1,46 @@
+/* pr_diff_report.h — cross-branch diff-report generator.
+ *
+ * Mirrors photonos-package-report.ps1 L 5440-5500:
+ *
+ *   "Spec,<label_a>,<label_b>" | out-file $outputfile
+ *   $result | foreach-object {
+ *       if ($_.SubRelease) { return }     # skip vendor-pinned subreleases
+ *       if (both versions non-empty) {
+ *           if (VersionCompare $a $b -eq 1) {
+ *               "$spec,$a,$b" | out-file -append
+ *           }
+ *       }
+ *   }
+ *
+ * In the C port the two input task lists come from
+ * parse_directory(branch_a) / parse_directory(branch_b). For each
+ * matching spec basename (case-sensitive strcmp), the function emits
+ * one CSV row when pr_version_compare(version_a, version_b) == 1.
+ *
+ * Rows are filtered by the PS L 5446 SubRelease guard: tasks whose
+ * SubRelease is non-empty are skipped (vendor-pinned subreleases
+ * shouldn't compete in the diff).
+ *
+ * Output order matches the order specs appear in `tasks_a` (PS uses
+ * `$result | foreach-object` which is insertion order).
+ */
+#ifndef PR_DIFF_REPORT_H
+#define PR_DIFF_REPORT_H
+
+#include "pr_types.h"
+
+/* Write a diff report to `output_path`. Returns 0 on success, -1 on I/O.
+ *
+ * The header line is: "Spec,<label_a>,<label_b>"
+ * Each emitted row: "<spec>,<version_a>,<version_b>"
+ *
+ * `label_a` and `label_b` are usually branch identifiers like
+ * "photon-5.0" / "photon-6.0".
+ */
+int pr_write_diff_report(const pr_task_list_t *tasks_a,
+                         const pr_task_list_t *tasks_b,
+                         const char           *label_a,
+                         const char           *label_b,
+                         const char           *output_path);
+
+#endif /* PR_DIFF_REPORT_H */

--- a/photonos-package-report/photonos-package-report/include/pr_sha.h
+++ b/photonos-package-report/photonos-package-report/include/pr_sha.h
@@ -1,0 +1,40 @@
+/* pr_sha.h — SHA1/256/512 digest helpers backed by libcrypto.
+ *
+ * Mirrors Get-FileHash + Get-FileHashWithRetry at
+ * photonos-package-report.ps1 L 1952-2000.
+ *
+ * The PS author retries on Win32 "file in use" errors (HResult
+ * 0x80070020). On Linux that lock class doesn't exist, so the C port
+ * simply uses libcrypto's streaming EVP API directly with no retry.
+ *
+ * Algorithms supported (subset of PS Get-FileHash):
+ *   PR_SHA1   — 40-char hex digest
+ *   PR_SHA256 — 64-char hex digest
+ *   PR_SHA512 — 128-char hex digest
+ *
+ * All returned strings are uppercase hex (matching PS Get-FileHash).
+ */
+#ifndef PR_SHA_H
+#define PR_SHA_H
+
+#include <stddef.h>
+
+typedef enum {
+    PR_SHA1 = 0,
+    PR_SHA256,
+    PR_SHA512,
+} pr_sha_alg_t;
+
+/* Hash a buffer in memory. Returns malloc'd uppercase-hex digest or
+ * NULL on failure. */
+char *pr_sha_hex(pr_sha_alg_t alg, const void *data, size_t len);
+
+/* Hash a local file. Returns malloc'd uppercase-hex digest or NULL. */
+char *pr_sha_file(pr_sha_alg_t alg, const char *path);
+
+/* Download `url` via libcurl into a temp file, then hash it.
+ * Returns malloc'd uppercase-hex digest or NULL on transport / I/O /
+ * hash failure. */
+char *pr_sha_of_url(pr_sha_alg_t alg, const char *url);
+
+#endif /* PR_SHA_H */

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -20,6 +20,7 @@
 #include "pr_hook.h"
 #include "pr_latest.h"
 #include "pr_state.h"
+#include "pr_sha.h"
 #include "pr_substitute.h"
 #include "pr_url_util.h"
 #include "pr_urlhealth.h"
@@ -167,6 +168,29 @@ char *check_urlhealth(pr_task_t                       *task,
                             if (rc == 1) {
                                 free(state.UpdateAvailable);
                                 state.UpdateAvailable = dup_or_empty(latest);
+                            }
+
+                            /* Phase 6f col 9 SHAValue (PS L 4912-4921):
+                             * download UpdateURL, hash with the algorithm
+                             * the spec file currently uses. Default
+                             * SHA512 when no sha define is present.
+                             * Hidden behind PR_TEST_NETWORK gate. */
+                            if (state.UpdateURL && state.UpdateURL[0]) {
+                                pr_sha_alg_t alg = PR_SHA512;
+                                /* Inspect task->content for sha1/256/512
+                                 * defines. PS L 4917-4919 form. */
+                                for (size_t li = 0; li < task->content_lines; li++) {
+                                    const char *line = task->content[li];
+                                    if (line == NULL) continue;
+                                    if (strstr(line, "%define sha1")   != NULL) { alg = PR_SHA1;   break; }
+                                    if (strstr(line, "%define sha256") != NULL) { alg = PR_SHA256; break; }
+                                    if (strstr(line, "%define sha512") != NULL) { alg = PR_SHA512; break; }
+                                }
+                                char *hex = pr_sha_of_url(alg, state.UpdateURL);
+                                if (hex) {
+                                    free(state.SHAValue);
+                                    state.SHAValue = hex;
+                                }
                             }
                         }
                         free(latest);

--- a/photonos-package-report/photonos-package-report/src/diff_report.c
+++ b/photonos-package-report/photonos-package-report/src/diff_report.c
@@ -1,0 +1,65 @@
+/* diff_report.c — cross-branch diff-report generator.
+ * Mirrors photonos-package-report.ps1 L 5440-5500 verbatim.
+ */
+#include "pr_diff_report.h"
+#include "pr_version.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Look up a task by Spec in `list`. Returns NULL if absent. */
+static const pr_task_t *find_by_spec(const pr_task_list_t *list, const char *spec)
+{
+    if (list == NULL || spec == NULL) return NULL;
+    for (size_t i = 0; i < list->count; i++) {
+        if (list->items[i].Spec && strcmp(list->items[i].Spec, spec) == 0) {
+            return &list->items[i];
+        }
+    }
+    return NULL;
+}
+
+int pr_write_diff_report(const pr_task_list_t *tasks_a,
+                         const pr_task_list_t *tasks_b,
+                         const char           *label_a,
+                         const char           *label_b,
+                         const char           *output_path)
+{
+    if (tasks_a == NULL || tasks_b == NULL ||
+        label_a == NULL || label_b == NULL || output_path == NULL) {
+        return -1;
+    }
+
+    FILE *f = fopen(output_path, "w");
+    if (!f) return -1;
+
+    /* PS L 5442 header: "Spec,<label_a>,<label_b>" */
+    fprintf(f, "Spec,%s,%s\n", label_a, label_b);
+
+    /* Walk tasks_a in insertion order. */
+    for (size_t i = 0; i < tasks_a->count; i++) {
+        const pr_task_t *a = &tasks_a->items[i];
+
+        /* PS L 5446: skip vendor-pinned subreleases. */
+        if (a->SubRelease && a->SubRelease[0] != '\0') continue;
+
+        const pr_task_t *b = find_by_spec(tasks_b, a->Spec);
+        if (b == NULL) continue;
+        if (b->SubRelease && b->SubRelease[0] != '\0') continue;
+
+        /* PS L 5447: both versions non-empty. */
+        const char *va = a->Version ? a->Version : "";
+        const char *vb = b->Version ? b->Version : "";
+        if (va[0] == '\0' || vb[0] == '\0') continue;
+
+        /* PS L 5449: VersionCompare $a $b -eq 1 → a > b. */
+        if (pr_version_compare(va, vb) == 1) {
+            fprintf(f, "%s,%s,%s\n", a->Spec, va, vb);
+        }
+    }
+
+    int rc = fflush(f) == 0 ? 0 : -1;
+    if (fclose(f) != 0) rc = -1;
+    return rc;
+}

--- a/photonos-package-report/photonos-package-report/src/sha.c
+++ b/photonos-package-report/photonos-package-report/src/sha.c
@@ -1,0 +1,128 @@
+/* sha.c — SHA1/256/512 helpers via libcrypto + URL download.
+ * Mirrors Get-FileHash / Get-FileHashWithRetry semantics from PS L 1952-2000.
+ */
+#include "pr_sha.h"
+
+#include <curl/curl.h>
+#include <openssl/evp.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static const EVP_MD *md_for(pr_sha_alg_t alg)
+{
+    switch (alg) {
+    case PR_SHA1:   return EVP_sha1();
+    case PR_SHA256: return EVP_sha256();
+    case PR_SHA512: return EVP_sha512();
+    }
+    return NULL;
+}
+
+/* Lowercase byte → uppercase hex pair. */
+static char *to_hex_upper(const unsigned char *bytes, size_t n)
+{
+    static const char HEX[] = "0123456789ABCDEF";
+    char *out = (char *)malloc(n * 2 + 1);
+    if (!out) return NULL;
+    for (size_t i = 0; i < n; i++) {
+        out[i * 2]     = HEX[(bytes[i] >> 4) & 0xF];
+        out[i * 2 + 1] = HEX[ bytes[i]       & 0xF];
+    }
+    out[n * 2] = '\0';
+    return out;
+}
+
+char *pr_sha_hex(pr_sha_alg_t alg, const void *data, size_t len)
+{
+    const EVP_MD *md = md_for(alg);
+    if (!md) return NULL;
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    if (!ctx) return NULL;
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned int  digest_len = 0;
+    char *hex = NULL;
+    if (EVP_DigestInit_ex(ctx, md, NULL) == 1 &&
+        EVP_DigestUpdate(ctx, data, len) == 1 &&
+        EVP_DigestFinal_ex(ctx, digest, &digest_len) == 1) {
+        hex = to_hex_upper(digest, digest_len);
+    }
+    EVP_MD_CTX_free(ctx);
+    return hex;
+}
+
+char *pr_sha_file(pr_sha_alg_t alg, const char *path)
+{
+    if (path == NULL) return NULL;
+    const EVP_MD *md = md_for(alg);
+    if (!md) return NULL;
+
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    if (!ctx) { fclose(f); return NULL; }
+
+    char *hex = NULL;
+    if (EVP_DigestInit_ex(ctx, md, NULL) != 1) goto cleanup;
+
+    unsigned char buf[64 * 1024];
+    size_t n;
+    while ((n = fread(buf, 1, sizeof buf, f)) > 0) {
+        if (EVP_DigestUpdate(ctx, buf, n) != 1) goto cleanup;
+    }
+    if (ferror(f)) goto cleanup;
+
+    unsigned char digest[EVP_MAX_MD_SIZE];
+    unsigned int  digest_len = 0;
+    if (EVP_DigestFinal_ex(ctx, digest, &digest_len) != 1) goto cleanup;
+    hex = to_hex_upper(digest, digest_len);
+
+cleanup:
+    EVP_MD_CTX_free(ctx);
+    fclose(f);
+    return hex;
+}
+
+/* libcurl WRITEFUNCTION → fwrite into the temp file. */
+static size_t write_to_file(char *p, size_t s, size_t n, void *u)
+{
+    return fwrite(p, s, n, (FILE *)u);
+}
+
+char *pr_sha_of_url(pr_sha_alg_t alg, const char *url)
+{
+    if (url == NULL || url[0] == '\0') return NULL;
+
+    /* Download to a /tmp file, then hash it. The PS Get-FileHash
+     * accepts a path, so this matches the PS flow. */
+    char tmpl[] = "/tmp/pr_sha_XXXXXX";
+    int fd = mkstemp(tmpl);
+    if (fd < 0) return NULL;
+    FILE *f = fdopen(fd, "w+b");
+    if (!f) { close(fd); unlink(tmpl); return NULL; }
+
+    CURL *c = curl_easy_init();
+    if (!c) { fclose(f); unlink(tmpl); return NULL; }
+    curl_easy_setopt(c, CURLOPT_URL,            url);
+    curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(c, CURLOPT_TIMEOUT_MS,     120000);
+    curl_easy_setopt(c, CURLOPT_WRITEFUNCTION,  write_to_file);
+    curl_easy_setopt(c, CURLOPT_WRITEDATA,      f);
+    curl_easy_setopt(c, CURLOPT_USERAGENT,      "photonos-package-report/C");
+    CURLcode rc = curl_easy_perform(c);
+    long status = 0;
+    curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &status);
+    curl_easy_cleanup(c);
+    fflush(f);
+    fclose(f);
+
+    char *hex = NULL;
+    if (rc == CURLE_OK && status >= 200 && status < 300) {
+        hex = pr_sha_file(alg, tmpl);
+    }
+    unlink(tmpl);
+    return hex;
+}

--- a/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
@@ -108,6 +108,7 @@ add_executable(test_phase6
     ${CMAKE_SOURCE_DIR}/src/latest_name.c
     ${CMAKE_SOURCE_DIR}/src/version.c
     ${CMAKE_SOURCE_DIR}/src/url_util.c
+    ${CMAKE_SOURCE_DIR}/src/sha.c
     ${PR_GEN_HOOK_DISPATCH}
     ${PR_HOOK_SOURCES}
 )
@@ -117,8 +118,9 @@ target_include_directories(test_phase6 PRIVATE
     ${PR_GEN_DIR}
     ${PCRE2_INCLUDE_DIRS}
     ${CURL_INCLUDE_DIRS}
+    ${OPENSSL_INCLUDE_DIRS}
 )
-target_link_libraries(test_phase6 PRIVATE pthread ${PCRE2_LIBRARIES} ${CURL_LIBRARIES})
+target_link_libraries(test_phase6 PRIVATE pthread ${PCRE2_LIBRARIES} ${CURL_LIBRARIES} ${OPENSSL_LIBRARIES})
 target_compile_options(test_phase6 PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER} ${CURL_CFLAGS_OTHER})
 
 add_test(NAME test_phase6 COMMAND test_phase6)
@@ -180,3 +182,22 @@ target_include_directories(test_phase6e PRIVATE ${CMAKE_SOURCE_DIR}/include)
 target_compile_options(test_phase6e PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE)
 
 add_test(NAME test_phase6e COMMAND test_phase6e)
+
+# ----- Phase 6f unit tests (SHA helpers + diff_report) ----------------
+add_executable(test_phase6f
+    test_phase6f.c
+    ${CMAKE_SOURCE_DIR}/src/sha.c
+    ${CMAKE_SOURCE_DIR}/src/diff_report.c
+    ${CMAKE_SOURCE_DIR}/src/version.c
+    ${CMAKE_SOURCE_DIR}/src/task.c
+)
+target_include_directories(test_phase6f PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${PCRE2_INCLUDE_DIRS}
+    ${CURL_INCLUDE_DIRS}
+    ${OPENSSL_INCLUDE_DIRS}
+)
+target_link_libraries(test_phase6f PRIVATE pthread ${PCRE2_LIBRARIES} ${CURL_LIBRARIES} ${OPENSSL_LIBRARIES})
+target_compile_options(test_phase6f PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER} ${CURL_CFLAGS_OTHER} ${OPENSSL_CFLAGS_OTHER})
+
+add_test(NAME test_phase6f COMMAND test_phase6f)

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase6f.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase6f.c
@@ -1,0 +1,152 @@
+/* test_phase6f.c — unit tests for SHA helpers + cross-branch diff report. */
+#include "pr_sha.h"
+#include "pr_diff_report.h"
+#include "pr_types.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int failures = 0;
+
+#define EXPECT_STREQ(actual, expected) do {                                    \
+    const char *_a = (actual);                                                 \
+    const char *_e = (expected);                                               \
+    if (_a == NULL || strcmp(_a, _e) != 0) {                                   \
+        fprintf(stderr, "  FAIL %s:%d: expected '%s' got '%s'\n",              \
+                __FILE__, __LINE__, _e, _a ? _a : "(null)");                   \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+#define EXPECT_INT(actual, expected) do {                                      \
+    long _a = (long)(actual); long _e = (long)(expected);                      \
+    if (_a != _e) {                                                            \
+        fprintf(stderr, "  FAIL %s:%d: expected %ld got %ld\n",                \
+                __FILE__, __LINE__, _e, _a);                                   \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+
+/* --- SHA helpers ---------------------------------------------------- */
+
+static void test_sha_hex(void)
+{
+    fprintf(stderr, "[test_sha_hex]\n");
+    /* Reference vectors from RFC 3174 / NIST: "abc" */
+    char *s = pr_sha_hex(PR_SHA1, "abc", 3);
+    EXPECT_STREQ(s, "A9993E364706816ABA3E25717850C26C9CD0D89D");
+    free(s);
+
+    s = pr_sha_hex(PR_SHA256, "abc", 3);
+    EXPECT_STREQ(s,
+        "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD");
+    free(s);
+
+    s = pr_sha_hex(PR_SHA512, "abc", 3);
+    EXPECT_STREQ(s,
+        "DDAF35A193617ABACC417349AE20413112E6FA4E89A97EA20A9EEEE64B55D39A"
+        "2192992A274FC1A836BA3C23A3FEEBBD454D4423643CE80E2A9AC94FA54CA49F");
+    free(s);
+}
+
+static void test_sha_file(void)
+{
+    fprintf(stderr, "[test_sha_file]\n");
+    char tmpl[] = "/tmp/pr_sha_test_XXXXXX";
+    int fd = mkstemp(tmpl);
+    if (fd < 0) { failures++; return; }
+    const char *bytes = "abc";
+    if (write(fd, bytes, 3) != 3) { failures++; close(fd); unlink(tmpl); return; }
+    close(fd);
+
+    char *s = pr_sha_file(PR_SHA256, tmpl);
+    EXPECT_STREQ(s,
+        "BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD");
+    free(s);
+    unlink(tmpl);
+}
+
+/* --- diff_report ---------------------------------------------------- */
+
+/* Test fixture: build a pr_task_list_t with a few known (Spec, Version,
+ * SubRelease) tuples. Field ownership: every string is heap-alloc'd. */
+static char *xs(const char *s) { return s ? strdup(s) : NULL; }
+
+static void add_task(pr_task_list_t *L,
+                     const char *spec, const char *version,
+                     const char *subrel)
+{
+    pr_task_t t = {0};
+    t.Spec       = xs(spec);
+    t.Version    = xs(version);
+    t.SubRelease = xs(subrel ? subrel : "");
+    t.Name       = xs("");
+    pr_task_list_add(L, &t);
+}
+
+static void test_diff_report(void)
+{
+    fprintf(stderr, "[test_diff_report]\n");
+
+    pr_task_list_t a, b;
+    pr_task_list_init(&a);
+    pr_task_list_init(&b);
+
+    /* hello: 2.10 vs 2.5     → emit (a > b) */
+    /* dbus:  1.12 vs 1.13    → suppress (a < b) */
+    /* kernel: 6.6 vs 6.6     → suppress (equal) */
+    /* zlib: 1.3 vs <missing> → suppress (no counterpart in b) */
+    /* foo SubRelease in a    → suppress (subrelease guard) */
+    add_task(&a, "hello.spec",  "2.10",  NULL);
+    add_task(&b, "hello.spec",  "2.5",   NULL);
+    add_task(&a, "dbus.spec",   "1.12",  NULL);
+    add_task(&b, "dbus.spec",   "1.13",  NULL);
+    add_task(&a, "kernel.spec", "6.6",   NULL);
+    add_task(&b, "kernel.spec", "6.6",   NULL);
+    add_task(&a, "zlib.spec",   "1.3",   NULL);
+    add_task(&a, "foo.spec",    "9.9",   "91");
+    add_task(&b, "foo.spec",    "1.0",   NULL);
+
+    char path[] = "/tmp/pr_diff_test_XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) { failures++; goto cleanup; }
+    close(fd);
+
+    int rc = pr_write_diff_report(&a, &b, "photon-5.0", "photon-6.0", path);
+    EXPECT_INT(rc, 0);
+
+    FILE *f = fopen(path, "rb");
+    if (!f) { failures++; goto cleanup_path; }
+    char buf[1024]; size_t n = fread(buf, 1, sizeof buf - 1, f); buf[n] = '\0';
+    fclose(f);
+
+    const char *expected =
+        "Spec,photon-5.0,photon-6.0\n"
+        "hello.spec,2.10,2.5\n";
+    if (strcmp(buf, expected) != 0) {
+        fprintf(stderr, "  FAIL: diff content mismatch\nGOT:\n%s\nEXPECTED:\n%s\n",
+                buf, expected);
+        failures++;
+    }
+
+cleanup_path:
+    unlink(path);
+cleanup:
+    pr_task_list_free(&a);
+    pr_task_list_free(&b);
+}
+
+int main(void)
+{
+    test_sha_hex();
+    test_sha_file();
+    test_diff_report();
+
+    if (failures == 0) {
+        fprintf(stderr, "test_phase6f: ALL PASSED\n");
+        return 0;
+    }
+    fprintf(stderr, "test_phase6f: %d failure(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary
**This PR closes the structural surface of Phase 6** — every column of the `.prn` schema (PS L 4933) is now populated end-to-end and the cross-branch diff-report machinery is in place. The remaining ~80 per-spec anomaly handlers at PS L 2217+ land per-feature via the Phase 3b hook dispatch when downstream parity testing demands them.

- **`pr_sha_*`** — libcrypto-backed SHA1/256/512 in three flavors: in-memory, local file, and download-via-libcurl-then-hash. Uppercase hex to match PS `Get-FileHash`.
- **`pr_write_diff_report`** — PS L 5440-5500 port. Walks `tasks_a`, looks up the matching spec in `tasks_b`, emits `<spec>,<va>,<vb>` when `pr_version_compare(va, vb) == 1`. Skips vendor-pinned subreleases per the PS L 5446 guard.
- **Col 9 (SHAValue) wired** in `check_urlhealth.c`: inspects `task->content` for `%define sha1/sha256/sha512` to pick the algorithm (PS L 4917-4921 form), then downloads `UpdateURL` and hashes. Default SHA512 when no sha define is present.

## Phase tracker
| Phase | Title | Status |
|-------|-------|--------|
| 0–6e | (all merged) | ✅ |
| 6f | **SHA + cross-branch diff reports + col 9 wired (Phase 6 complete)** | **this PR** |
| 7 | Cluster orchestrator + 20-worker pthread pool + Wait-ForFetchCompletion mutex | pending |
| 8 | Side-by-side CI parity gate | pending |
| 9 | PS retirement | pending |
| M | Maintainer ops & debug tooling | PR #56 still open |

## All 12 `.prn` columns now populated
With `PR_TEST_NETWORK=1` and a real upstream tree, the C tool emits rows like:
```
abseil-cpp.spec,
https://github.com/abseil/abseil-cpp/releases/download/%{version}/abseil-cpp-%{version}.tar.gz,
https://github.com/.../abseil-cpp-20250127.tar.gz,
200,
20250127,
https://github.com/.../abseil-cpp-20250127.tar.gz,
200,
abseil-cpp,
F0E91E... (128-hex),
abseil-cpp-20250127.tar.gz,
,
```
All 12 columns from PS L 4933 now have C origins. The per-spec anomaly handlers that further mutate UpdateURL / SHAValue / UpdateDownloadName (PS L 2217-3700, ~80 spec-specific blocks) flow through the Phase 3b hook dispatch — each gets ported as the downstream parity gate (Phase 8) demands.

## PS-source mapping (strict parity)
| PS lines | Operation | C site |
|----------|-----------|--------|
| 1952-2000 | Get-FileHashWithRetry | `pr_sha_*` |
| 4912-4921 | choose sha algorithm from `%define sha*` in spec content | `check_urlhealth.c` inspection loop |
| 4921 | default SHA512 when no `%define sha*` | fallback `PR_SHA512` |
| 5442 | "Spec,<a>,<b>" header | `pr_write_diff_report` first `fprintf` |
| 5446 | `if ($_.SubRelease) { return }` | `pr_write_diff_report` skip |
| 5447 | both versions non-empty guard | empty-string check |
| 5449 | `VersionCompare $a $b -eq 1` filter | `pr_version_compare == 1` |
| 5451 | row emit | `fprintf "%s,%s,%s"` |

## Test plan
- [x] `cmake -B build -S .` configures cleanly (OpenSSL 3.0.18 detected)
- [x] `cmake --build build` zero warnings
- [x] `ctest --test-dir build` → 12/12 passed
  - `test_phase6f` — SHA1/256/512 NIST reference vectors for "abc", SHA256 of a temp file, diff_report against a 5-row fixture covering all 5 paths (a>b emit, a<b suppress, equal suppress, missing-counterpart skip, SubRelease guard)

## Out of scope (still pending after Phase 6)
- **The ~80 per-spec anomaly handlers** (PS L 2217-3700) — land per-feature via the Phase 3b hook dispatch. Phase 3b's drift check already tracks 93 unported PS hooks as `WARNING`; Phase 8 parity gate will surface which ones the .prn output actually depends on.
- **`Wait-ForFetchCompletion` mutex coordination** (PS L 2003-2073) — Phase 7
- **Top-level `GenerateUrlHealthReports` parallel pool** (PS L 5009-5078) — Phase 7
- **Top-level cross-branch package-report** (PS L 5432-5436) — depends on multi-branch parse, lands with Phase 7's cluster orchestrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)