### PR TITLE
phase-7: pthread worker pool + per-repo fetch flock + -ThrottleLimit

### DIFF
--- a/photonos-package-report/photonos-package-report/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/CMakeLists.txt
@@ -110,6 +110,7 @@ add_executable(photonos-package-report
     src/url_util.c
     src/sha.c
     src/diff_report.c
+    src/pool.c
     ${PR_GEN_HOOK_DISPATCH}
     ${PR_HOOK_SOURCES}
 )

--- a/photonos-package-report/photonos-package-report/include/pr_pool.h
+++ b/photonos-package-report/photonos-package-report/include/pr_pool.h
@@ -1,0 +1,44 @@
+/* pr_pool.h — fixed-size pthread worker pool.
+ *
+ * Mirrors photonos-package-report.ps1 L 5054 (`ForEach-Object -Parallel
+ * -ThrottleLimit $ThrottleLimit`) — the PS author uses runspaces; the
+ * C port uses POSIX threads. The default `-ThrottleLimit` is 20
+ * (PS L 5214 hard cap).
+ *
+ * Submit-order is preserved across the pool: `pr_pool_join` returns
+ * results in the order tasks were submitted, mirroring how PS's
+ * ConcurrentBag-then-sort flow yields stable output (PS L 5052-5078).
+ *
+ * The pool is single-use: create, submit N tasks, join (which destroys
+ * and frees the pool). Re-creating is cheap.
+ *
+ * Tasks take a `void *arg` and return a `void *result`. Lifecycle of
+ * `arg` and `result` is caller-managed.
+ */
+#ifndef PR_POOL_H
+#define PR_POOL_H
+
+#include <stddef.h>
+
+typedef void *(*pr_task_fn)(void *arg);
+
+typedef struct pr_pool pr_pool_t;
+
+/* Create a pool with `n_workers` threads. Returns NULL on failure.
+ * `n_workers` is clamped to [1, 256]. */
+pr_pool_t *pr_pool_create(int n_workers);
+
+/* Submit a task. Not thread-safe; the caller must submit all tasks
+ * before any worker starts processing them. Returns 0 on success. */
+int pr_pool_submit(pr_pool_t *pool, pr_task_fn fn, void *arg);
+
+/* Run all submitted tasks across the worker threads and return when
+ * every task has completed. Returns a heap array of `void *` results
+ * in submission order. Sets *out_n to the array length. Destroys the
+ * pool. The caller must free() the returned array (results themselves
+ * are caller-managed).
+ *
+ * Returns NULL on internal error. */
+void **pr_pool_run(pr_pool_t *pool, size_t *out_n);
+
+#endif /* PR_POOL_H */

--- a/photonos-package-report/photonos-package-report/include/pr_types.h
+++ b/photonos-package-report/photonos-package-report/include/pr_types.h
@@ -38,6 +38,9 @@ typedef struct {
     int GeneratePh5toPh6DiffHigherPackageVersionReport;                        /* L 105 */
     int GeneratePh4toPh5DiffHigherPackageVersionReport;                        /* L 106 */
     int GeneratePh3toPh4DiffHigherPackageVersionReport;                        /* L 107 */
+    /* Phase 7: parallel worker count. Mirrors PS L 5214
+     * `$throttleLimit = 20` hard cap. 1 = sequential. */
+    int ThrottleLimit;
 } pr_params_t;
 
 /* ===== Per-spec task — mirrors PS PSCustomObject built at L 345-372 ====

--- a/photonos-package-report/photonos-package-report/src/clone.c
+++ b/photonos-package-report/photonos-package-report/src/clone.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/file.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -132,6 +133,25 @@ int pr_clone_ensure(const char *clone_root,
     char *git_dir = NULL;
     if (asprintf(&git_dir, "%s/.git", clone_path) < 0) { free(clone_path); return -1; }
 
+    /* Phase 7: per-repo flock so concurrent workers can't collide on
+     * the same clone directory. Mirrors PS L 2028 Wait-ForFetchCompletion
+     * mutex (simplified — flock is sufficient when we always finish a
+     * clone/fetch under the lock, which our path does).
+     *
+     * Lock-file path: <clone_root>/.<repo_name>.lock. We never delete
+     * the lock file — leaving it in place is harmless and avoids races
+     * around unlink. */
+    char *lock_path = NULL;
+    int   lock_fd   = -1;
+    if (asprintf(&lock_path, "%s/.%s.lock", clone_root, repo_name) >= 0) {
+        lock_fd = open(lock_path, O_CREAT | O_RDWR, 0644);
+        if (lock_fd >= 0) {
+            /* Block until acquired — short critical section. */
+            (void)flock(lock_fd, LOCK_EX);
+        }
+        free(lock_path);
+    }
+
     /* PS L 2390-2421: up to 2 attempts, deleting and re-cloning on
      * a corrupt working tree. */
     int rc = -1;
@@ -153,6 +173,11 @@ int pr_clone_ensure(const char *clone_root,
         if (attempt == 1) {
             rm_rf(clone_path);
         }
+    }
+
+    if (lock_fd >= 0) {
+        flock(lock_fd, LOCK_UN);
+        close(lock_fd);
     }
     free(git_dir);
     free(clone_path);

--- a/photonos-package-report/photonos-package-report/src/main.c
+++ b/photonos-package-report/photonos-package-report/src/main.c
@@ -27,6 +27,7 @@
 
 #include "pr_types.h"
 #include "pr_check_urlhealth.h"
+#include "pr_pool.h"
 #include "pr_prn.h"
 #include "source0_lookup.h"
 #include <time.h>
@@ -118,6 +119,7 @@ int main(int argc, char **argv)
     params.GeneratePh5toPh6DiffHigherPackageVersionReport                      = 1;  /* L 105 */
     params.GeneratePh4toPh5DiffHigherPackageVersionReport                      = 1;  /* L 106 */
     params.GeneratePh3toPh4DiffHigherPackageVersionReport                      = 1;  /* L 107 */
+    params.ThrottleLimit                                                       = 20; /* PS L 5214 */
 
     /* Long-option table, declaration order matches PS param-block order. */
     enum {
@@ -142,6 +144,7 @@ int main(int argc, char **argv)
         OPT_GeneratePh3toPh4DiffHigherPackageVersionReport,
         OPT_dump_tasks,                /* Phase 2 parity helper, not in PS. */
         OPT_generate_urlhealth_report, /* Phase 6a end-to-end pipeline.    */
+        OPT_throttle_limit,            /* Phase 7 worker count override.   */
     };
     const char *dump_tasks_branch          = NULL;
     const char *generate_urlhealth_branch  = NULL;
@@ -167,6 +170,7 @@ int main(int argc, char **argv)
         { "GeneratePh3toPh4DiffHigherPackageVersionReport",                     required_argument, 0, OPT_GeneratePh3toPh4DiffHigherPackageVersionReport },
         { "dump-tasks",                                                         required_argument, 0, OPT_dump_tasks },
         { "generate-urlhealth-report",                                          required_argument, 0, OPT_generate_urlhealth_report },
+        { "ThrottleLimit",                                                      required_argument, 0, OPT_throttle_limit },
         { "help",                                                               no_argument,       0, 'h' },
         { 0, 0, 0, 0 },
     };
@@ -202,6 +206,11 @@ int main(int argc, char **argv)
             dump_tasks_branch = optarg; break;
         case OPT_generate_urlhealth_report:
             generate_urlhealth_branch = optarg; break;
+        case OPT_throttle_limit:
+            params.ThrottleLimit = (int)strtol(optarg, NULL, 10);
+            if (params.ThrottleLimit < 1)   params.ThrottleLimit = 1;
+            if (params.ThrottleLimit > 256) params.ThrottleLimit = 256;
+            break;
         case 'h':
             usage(argv[0]);
             return 0;
@@ -430,8 +439,45 @@ static int generate_urlhealth_main(const pr_params_t *params, const char *branch
     if (asprintf(&clone_root, "%s/%s/clones", up_dir, branch) < 0) {
         clone_root = NULL;
     }
-    for (size_t i = 0; i < list.count; i++) {
-        rows[i] = check_urlhealth(&list.items[i], &lut, clone_root);
+
+    /* Phase 7: parallel execution when ThrottleLimit > 1. */
+    if (params->ThrottleLimit <= 1) {
+        for (size_t i = 0; i < list.count; i++) {
+            rows[i] = check_urlhealth(&list.items[i], &lut, clone_root);
+        }
+    } else {
+        /* Per-task closure capturing (task, lut, clone_root) so the
+         * worker function only takes one `void *`. */
+        typedef struct {
+            pr_task_t                       *task;
+            const pr_source0_lookup_table_t *lut;
+            const char                      *clone_root;
+        } closure_t;
+        closure_t *closures = (closure_t *)calloc(list.count, sizeof *closures);
+        if (!closures) {
+            free(rows); free(clone_root);
+            pr_prn_close(p); pr_source0_lookup_free(&lut); pr_task_list_free(&list);
+            return 1;
+        }
+        pr_pool_t *pool = pr_pool_create(params->ThrottleLimit);
+        if (!pool) { free(closures); free(rows); free(clone_root);
+                     pr_prn_close(p); pr_source0_lookup_free(&lut);
+                     pr_task_list_free(&list); return 1; }
+        for (size_t i = 0; i < list.count; i++) {
+            closures[i] = (closure_t){ &list.items[i], &lut, clone_root };
+        }
+        /* Worker thunk — declared inline via a static helper. */
+        extern void *pr_check_urlhealth_worker(void *arg);  /* below */
+        for (size_t i = 0; i < list.count; i++) {
+            pr_pool_submit(pool, pr_check_urlhealth_worker, &closures[i]);
+        }
+        size_t n_out = 0;
+        void **results = pr_pool_run(pool, &n_out);
+        for (size_t i = 0; i < list.count && i < n_out; i++) {
+            rows[i] = (char *)results[i];
+        }
+        free(results);
+        free(closures);
     }
     free(clone_root);
     pr_prn_append_rows(p, rows, list.count);
@@ -445,4 +491,18 @@ static int generate_urlhealth_main(const pr_params_t *params, const char *branch
 
     fprintf(stderr, "Wrote %s\n", out_path);
     return 0;
+}
+
+/* Phase 7 worker thunk. Closure: { pr_task_t *, source0 lookup,
+ * clone_root }. Returns a malloc'd row string the parent collects. */
+typedef struct {
+    pr_task_t                       *task;
+    const pr_source0_lookup_table_t *lut;
+    const char                      *clone_root;
+} pr_check_urlhealth_closure_t;
+
+void *pr_check_urlhealth_worker(void *arg)
+{
+    pr_check_urlhealth_closure_t *c = (pr_check_urlhealth_closure_t *)arg;
+    return (void *)check_urlhealth(c->task, c->lut, c->clone_root);
 }

--- a/photonos-package-report/photonos-package-report/src/pool.c
+++ b/photonos-package-report/photonos-package-report/src/pool.c
@@ -1,0 +1,125 @@
+/* pool.c — fixed-size pthread worker pool.
+ * Mirrors PS `ForEach-Object -Parallel -ThrottleLimit N` semantics.
+ *
+ * Lifecycle:
+ *   1. pr_pool_create(N) — spawn nothing yet; allocate state.
+ *   2. pr_pool_submit() repeatedly — pushes tasks into an internal queue.
+ *   3. pr_pool_run() — spawns N worker threads, each pulls from the
+ *      queue until empty, writes its result to the shared results
+ *      array indexed by submission order. Returns the results array.
+ *      Pool is destroyed before return.
+ */
+#include "pr_pool.h"
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct {
+    pr_task_fn fn;
+    void      *arg;
+} task_t;
+
+struct pr_pool {
+    int            n_workers;
+    size_t         n_tasks;
+    size_t         tasks_cap;
+    task_t        *tasks;
+    /* Submission-order results. */
+    void         **results;
+    /* Pull index — workers atomically advance this. */
+    size_t         next_idx;
+    pthread_mutex_t mu;
+};
+
+pr_pool_t *pr_pool_create(int n_workers)
+{
+    if (n_workers < 1)   n_workers = 1;
+    if (n_workers > 256) n_workers = 256;
+    pr_pool_t *p = (pr_pool_t *)calloc(1, sizeof *p);
+    if (!p) return NULL;
+    p->n_workers = n_workers;
+    pthread_mutex_init(&p->mu, NULL);
+    return p;
+}
+
+int pr_pool_submit(pr_pool_t *pool, pr_task_fn fn, void *arg)
+{
+    if (pool == NULL || fn == NULL) return -1;
+    if (pool->n_tasks == pool->tasks_cap) {
+        size_t nc = pool->tasks_cap == 0 ? 64 : pool->tasks_cap * 2;
+        task_t *np = (task_t *)realloc(pool->tasks, nc * sizeof *np);
+        if (!np) return -1;
+        pool->tasks    = np;
+        pool->tasks_cap = nc;
+    }
+    pool->tasks[pool->n_tasks].fn  = fn;
+    pool->tasks[pool->n_tasks].arg = arg;
+    pool->n_tasks++;
+    return 0;
+}
+
+static void *worker_main(void *arg)
+{
+    pr_pool_t *pool = (pr_pool_t *)arg;
+    for (;;) {
+        pthread_mutex_lock(&pool->mu);
+        if (pool->next_idx >= pool->n_tasks) {
+            pthread_mutex_unlock(&pool->mu);
+            break;
+        }
+        size_t idx = pool->next_idx++;
+        pthread_mutex_unlock(&pool->mu);
+
+        task_t *t = &pool->tasks[idx];
+        void *r = t->fn(t->arg);
+        pool->results[idx] = r;
+    }
+    return NULL;
+}
+
+void **pr_pool_run(pr_pool_t *pool, size_t *out_n)
+{
+    if (pool == NULL || out_n == NULL) return NULL;
+    *out_n = pool->n_tasks;
+    if (pool->n_tasks == 0) {
+        free(pool->tasks);
+        pthread_mutex_destroy(&pool->mu);
+        free(pool);
+        return NULL;
+    }
+
+    pool->results = (void **)calloc(pool->n_tasks, sizeof *pool->results);
+    if (!pool->results) {
+        free(pool->tasks);
+        pthread_mutex_destroy(&pool->mu);
+        free(pool);
+        return NULL;
+    }
+
+    int n = pool->n_workers;
+    if ((size_t)n > pool->n_tasks) n = (int)pool->n_tasks;
+
+    pthread_t *threads = (pthread_t *)calloc((size_t)n, sizeof *threads);
+    if (!threads) {
+        free(pool->results); free(pool->tasks);
+        pthread_mutex_destroy(&pool->mu);
+        free(pool);
+        return NULL;
+    }
+
+    for (int i = 0; i < n; i++) {
+        pthread_create(&threads[i], NULL, worker_main, pool);
+    }
+    for (int i = 0; i < n; i++) {
+        pthread_join(threads[i], NULL);
+    }
+    free(threads);
+
+    void **results = pool->results;
+    free(pool->tasks);
+    pthread_mutex_destroy(&pool->mu);
+    free(pool);
+    return results;
+}

--- a/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
@@ -201,3 +201,14 @@ target_link_libraries(test_phase6f PRIVATE pthread ${PCRE2_LIBRARIES} ${CURL_LIB
 target_compile_options(test_phase6f PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE ${PCRE2_CFLAGS_OTHER} ${CURL_CFLAGS_OTHER} ${OPENSSL_CFLAGS_OTHER})
 
 add_test(NAME test_phase6f COMMAND test_phase6f)
+
+# ----- Phase 7 unit tests (pthread worker pool) -----------------------
+add_executable(test_phase7
+    test_phase7.c
+    ${CMAKE_SOURCE_DIR}/src/pool.c
+)
+target_include_directories(test_phase7 PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(test_phase7 PRIVATE pthread)
+target_compile_options(test_phase7 PRIVATE -Wall -Wextra -O0 -g -D_GNU_SOURCE)
+
+add_test(NAME test_phase7 COMMAND test_phase7)

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase7.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase7.c
@@ -1,0 +1,110 @@
+/* test_phase7.c — unit tests for the pthread worker pool. */
+#include "pr_pool.h"
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures = 0;
+
+#define EXPECT_INT(actual, expected) do {                                      \
+    long _a = (long)(actual); long _e = (long)(expected);                      \
+    if (_a != _e) {                                                            \
+        fprintf(stderr, "  FAIL %s:%d: expected %ld got %ld\n",                \
+                __FILE__, __LINE__, _e, _a);                                   \
+        failures++;                                                            \
+    }                                                                          \
+} while (0)
+
+/* Task that echoes its arg as the result. */
+static void *echo_task(void *arg) { return arg; }
+
+static void test_pool_order(void)
+{
+    fprintf(stderr, "[test_pool_order]\n");
+    pr_pool_t *p = pr_pool_create(4);
+    long expected[64];
+    for (long i = 0; i < 64; i++) {
+        expected[i] = i;
+        pr_pool_submit(p, echo_task, (void *)expected[i]);
+    }
+    size_t n = 0;
+    void **r = pr_pool_run(p, &n);
+    EXPECT_INT(n, 64);
+    /* Results must arrive in submission order despite parallel exec. */
+    for (size_t i = 0; i < n; i++) {
+        long v = (long)r[i];
+        if (v != (long)i) {
+            fprintf(stderr, "  FAIL: result[%zu] = %ld, expected %zu\n", i, v, i);
+            failures++;
+        }
+    }
+    free(r);
+}
+
+/* Race test: many workers increment a shared counter via mutex. */
+static pthread_mutex_t G_MU = PTHREAD_MUTEX_INITIALIZER;
+static long            G_COUNTER;
+
+static void *inc_task(void *arg)
+{
+    long iters = (long)arg;
+    for (long i = 0; i < iters; i++) {
+        pthread_mutex_lock(&G_MU);
+        G_COUNTER++;
+        pthread_mutex_unlock(&G_MU);
+    }
+    return NULL;
+}
+
+static void test_pool_race(void)
+{
+    fprintf(stderr, "[test_pool_race]\n");
+    G_COUNTER = 0;
+    pr_pool_t *p = pr_pool_create(8);
+    /* 8 tasks × 1000 increments = 8000 total. */
+    for (int i = 0; i < 8; i++) pr_pool_submit(p, inc_task, (void *)(long)1000);
+    size_t n = 0;
+    void **r = pr_pool_run(p, &n);
+    free(r);
+    EXPECT_INT(G_COUNTER, 8000);
+}
+
+static void test_pool_single_worker(void)
+{
+    fprintf(stderr, "[test_pool_single_worker]\n");
+    /* ThrottleLimit=1 fast path: pool still works, just sequentially. */
+    pr_pool_t *p = pr_pool_create(1);
+    for (long i = 0; i < 8; i++) pr_pool_submit(p, echo_task, (void *)i);
+    size_t n = 0;
+    void **r = pr_pool_run(p, &n);
+    EXPECT_INT(n, 8);
+    for (size_t i = 0; i < n; i++) EXPECT_INT((long)r[i], (long)i);
+    free(r);
+}
+
+static void test_pool_empty(void)
+{
+    fprintf(stderr, "[test_pool_empty]\n");
+    pr_pool_t *p = pr_pool_create(4);
+    size_t n = 42;
+    void **r = pr_pool_run(p, &n);
+    EXPECT_INT(n, 0);
+    if (r != NULL) { fprintf(stderr, "  FAIL: empty pool returned non-NULL\n"); failures++; }
+}
+
+int main(void)
+{
+    test_pool_order();
+    test_pool_race();
+    test_pool_single_worker();
+    test_pool_empty();
+
+    if (failures == 0) {
+        fprintf(stderr, "test_phase7: ALL PASSED\n");
+        return 0;
+    }
+    fprintf(stderr, "test_phase7: %d failure(s)\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary
Mirrors the PS `ForEach-Object -Parallel -ThrottleLimit 20` pattern from `GenerateUrlHealthReports` (PS L 5009-5078). Default 20 workers (PS L 5214 hard cap); `-ThrottleLimit 1` forces sequential for parity-diff runs and gdb sessions.

- **`pr_pool_*`** — fixed-size pthread pool. Pull-pattern over a shared task index; results stay in **submission order** so the downstream `pr_prn_append_rows` sort+filter produces byte-identical output to a sequential run.
- **`pr_clone_ensure` per-repo flock** — `<clone_root>/.<repo_name>.lock` is `flock(LOCK_EX)`'d for the duration of clone/fetch. Mirrors PS L 2003-2073 `Wait-ForFetchCompletion` mutex (simplified — `flock` blocks until the previous worker finishes, no FETCH_HEAD age check needed). Concurrent workers cloning the same repo serialize cleanly without colliding on `.git/index.lock`.
- **`pr_params_t.ThrottleLimit`** (default 20) + `-ThrottleLimit N` arg. `generate_urlhealth_main` picks sequential when N==1 else uses the pool.

End-to-end smoke against the fixture tree:
```
$ ./build/photonos-package-report -workingDir tests/fixtures -scansDir /tmp \
    -ThrottleLimit 4 --generate-urlhealth-report photon-fixture
Wrote /tmp/photonos-urlhealth-photon-fixture_*.prn
```
The `.prn` is byte-identical to the sequential run thanks to submission-order preservation + the existing PS-mirroring sort.

## Phase tracker
| Phase | Title | Status |
|-------|-------|--------|
| 0–6f | (all merged) | ✅ |
| 7 | **pthread worker pool + per-repo fetch flock + -ThrottleLimit** | **this PR** |
| 8 | Side-by-side CI parity gate | pending |
| 9 | PS retirement | pending |
| M | Maintainer ops & debug tooling | PR #56 still open |

## PS-source mapping (strict parity)
| PS lines | Operation | C site |
|----------|-----------|--------|
| 5009-5063 | `ForEach-Object -Parallel -ThrottleLimit` over packages | `pr_pool` + `generate_urlhealth_main` parallel path |
| 5052-5078 | ConcurrentBag collect → sort → append | submission-order results + existing `pr_prn` sort |
| 5214 | `$throttleLimit = 20` hard cap | `pr_params_t.ThrottleLimit` default 20, clamp 256 |
| 2003-2073 | `Wait-ForFetchCompletion` mutex | `pr_clone_ensure` flock |
| 5081-5097 | Sequential fallback when `!UseParallel` | `if (ThrottleLimit <= 1)` branch in `generate_urlhealth_main` |

## Test plan
- [x] `cmake -B build -S .` configures cleanly
- [x] `cmake --build build` zero warnings
- [x] `ctest --test-dir build` → 13/13 passed
  - `test_phase7` — submission-order preservation across 64 tasks / 4 workers; race correctness (8×1000 mutex-protected increments = 8000); ThrottleLimit=1 single-worker fallback; empty-pool no-op
- [x] Manual smoke: `-ThrottleLimit 4` against the fixture tree produces a `.prn` byte-identical to the sequential run (submission-order + existing sort guarantee this)

## Out of scope (Phase 8+)
- **Multi-branch orchestrator** — iterating Ph3/Ph4/Ph5/Ph6/Common/Dev/Master under one invocation. Phase 8's parity gate will drive the exact wiring (one `.prn` per branch).
- **`GitPhoton` photon-tree clone** (PS L 451) — used by the multi-branch orchestrator to ensure the photon-N.0 SPECS trees exist locally. Lands with the multi-branch wiring.
- **The ~80 per-spec anomaly handlers** — continue to land per-feature via Phase 3b hooks as Phase 8 parity demands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)