### PR TITLE
phase-8 task 080-085: CI side-by-side parity gate

### DIFF
--- a/.github/scripts/parity-reconstruct.sh
+++ b/.github/scripts/parity-reconstruct.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# parity-reconstruct.sh — rebuild a working tree from a parity snapshot's
+# manifests, for the C-side replay workflow.
+#
+# Phase 8 task 081.
+#
+# Reads:
+#   <snapshot>/branch-clones-manifest.tsv     (3-col TSV: branch, url, sha)
+#   <snapshot>/upstream-clones-manifest.tsv   (4-col TSV: branch, sub, url, sha)
+#
+# Restores:
+#   <out-working-dir>/<branch>/              — Photon branch clone @ SHA
+#   <out-upstreams-dir>/<branch>/clones/<sub>/ — upstream repo clone @ SHA
+#
+# Upstream clones are best-effort: a failed clone is logged as a warning
+# but does not abort the script. The C binary's phase 6d local-clone
+# fetch will re-create any missing clone on first use.
+#
+# Branch clones are required: a failed branch clone aborts.
+#
+# Usage:
+#   parity-reconstruct.sh <snapshot-dir> <out-working-dir> <out-upstreams-dir>
+set -eu
+
+if [ "$#" -ne 3 ]; then
+    echo "usage: $0 <snapshot-dir> <out-working-dir> <out-upstreams-dir>" >&2
+    exit 1
+fi
+
+SNAP="$1"
+WDIR="$2"
+UPSTREAMS="$3"
+
+if [ ! -d "$SNAP" ]; then
+    echo "::error::parity-reconstruct: snapshot dir does not exist: $SNAP" >&2
+    exit 1
+fi
+
+mkdir -p "$WDIR" "$UPSTREAMS"
+
+# ---- Branch clones (required) ------------------------------------------
+BRANCH_MAN="$SNAP/branch-clones-manifest.tsv"
+n_branch=0
+if [ -s "$BRANCH_MAN" ]; then
+    while IFS="$(printf '\t')" read -r branch url sha; do
+        # Skip empty rows.
+        [ -n "$branch" ] && [ -n "$url" ] && [ -n "$sha" ] || continue
+        dest="$WDIR/$branch"
+        if [ ! -d "$dest/.git" ]; then
+            echo "  clone $url -> $dest"
+            git clone --quiet "$url" "$dest"
+        else
+            echo "  fetch $branch (cached)"
+            git -C "$dest" fetch --quiet origin || true
+        fi
+        # Try to check out the recorded SHA. If the SHA isn't reachable
+        # (e.g. dangling commit on PS side), fetch it explicitly.
+        if ! git -C "$dest" rev-parse --verify --quiet "$sha^{commit}" >/dev/null; then
+            git -C "$dest" fetch --quiet origin "$sha" 2>/dev/null || {
+                echo "::error::reconstruct: branch $branch SHA $sha not fetchable from $url" >&2
+                exit 1
+            }
+        fi
+        git -C "$dest" -c advice.detachedHead=false checkout --quiet "$sha"
+        n_branch=$((n_branch + 1))
+    done < "$BRANCH_MAN"
+else
+    echo "::error::reconstruct: branch-clones-manifest is empty — cannot reconstruct" >&2
+    exit 1
+fi
+
+# ---- Upstream clones (best-effort) -------------------------------------
+UP_MAN="$SNAP/upstream-clones-manifest.tsv"
+n_upstream=0
+n_upstream_failed=0
+if [ -s "$UP_MAN" ]; then
+    while IFS="$(printf '\t')" read -r branch sub url sha; do
+        [ -n "$branch" ] && [ -n "$sub" ] && [ -n "$url" ] || continue
+        dest="$UPSTREAMS/$branch/clones/$sub"
+        mkdir -p "$(dirname "$dest")"
+        if [ ! -d "$dest/.git" ] && [ ! -f "$dest/HEAD" ]; then
+            if git clone --quiet "$url" "$dest" 2>/dev/null; then
+                :
+            else
+                echo "::warning::reconstruct: upstream clone failed for $url" >&2
+                n_upstream_failed=$((n_upstream_failed + 1))
+                continue
+            fi
+        fi
+        # Best-effort fetch + checkout at recorded SHA; tolerate failure.
+        git -C "$dest" fetch --quiet origin 2>/dev/null || true
+        if [ "$sha" != "unknown" ] && [ -n "$sha" ]; then
+            git -C "$dest" -c advice.detachedHead=false checkout --quiet "$sha" 2>/dev/null || true
+        fi
+        n_upstream=$((n_upstream + 1))
+    done < "$UP_MAN"
+fi
+
+printf 'parity-reconstruct: branch-clones=%d  upstream-clones=%d  upstream-failed=%d\n' \
+    "$n_branch" "$n_upstream" "$n_upstream_failed"

--- a/.github/scripts/parity-snapshot.sh
+++ b/.github/scripts/parity-snapshot.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+# parity-snapshot.sh — capture parity inputs for the C-side replay workflow.
+#
+# Phase 8 task 080. Runs at the tail of the PS-side package-report.yml
+# workflow, immediately after .prn files are collected to staging. Captures
+# the *state* the PS run saw (branch clone SHAs, upstream clone SHAs,
+# tarball sha256s) and the .prn outputs PS produced — not the bytes of
+# the working tree itself. The C-side workflow (package-report-C.yml)
+# uses the manifests to reconstruct an equivalent working tree by
+# re-cloning at the recorded SHAs, then diffs its .prn against the
+# snapshot's prn-snapshot/.
+#
+# Usage:
+#   parity-snapshot.sh <working-dir> <upstreams-dir> <prn-staging-dir> <out-tar>
+#
+# Arguments:
+#   working-dir       — root containing per-branch Photon clones (<wd>/3.0, <wd>/4.0, ...)
+#   upstreams-dir     — root containing per-branch upstream state
+#                       (<ud>/<branch>/{clones,SOURCES_NEW,SPECS_NEW})
+#   prn-staging-dir   — directory holding .prn files produced by this run
+#                       (e.g. /tmp/new-reports as written by the workflow's
+#                       Collect-new-reports step)
+#   out-tar           — output path for the tar.gz snapshot artifact
+#
+# Output: writes <out-tar>. Echoes one final line with counts:
+#   branch-clones=N  upstream-clones=N  tarballs=N  prn-files=N
+#
+# Exit codes:
+#   0 success
+#   1 missing required argument
+#   2 working-dir or upstreams-dir not a directory
+set -eu
+
+if [ "$#" -ne 4 ]; then
+    echo "usage: $0 <working-dir> <upstreams-dir> <prn-staging-dir> <out-tar>" >&2
+    exit 1
+fi
+
+WORKING_DIR="$1"
+UPSTREAMS_DIR="$2"
+PRN_STAGING="$3"
+OUT_TAR="$4"
+
+if [ ! -d "$WORKING_DIR" ]; then
+    echo "::error::parity-snapshot: working-dir not a directory: $WORKING_DIR" >&2
+    exit 2
+fi
+if [ ! -d "$UPSTREAMS_DIR" ]; then
+    echo "::warning::parity-snapshot: upstreams-dir not a directory: $UPSTREAMS_DIR (empty manifests)" >&2
+fi
+
+stage="$(mktemp -d -t parity-snap.XXXXXX)"
+trap 'rm -rf "$stage"' EXIT
+
+mkdir -p "$stage/prn-snapshot"
+
+# ---- 1. Branch-clones manifest -----------------------------------------
+# Each <working-dir>/<branch> is a Photon repo clone (the SPECS tree the
+# PS script + C binary read from). One row per branch.
+{
+    for branch_dir in "$WORKING_DIR"/*; do
+        [ -d "$branch_dir/.git" ] || continue
+        branch="$(basename "$branch_dir")"
+        sha="$(git -C "$branch_dir" rev-parse HEAD 2>/dev/null || echo unknown)"
+        url="$(git -C "$branch_dir" remote get-url origin 2>/dev/null || echo unknown)"
+        printf '%s\t%s\t%s\n' "$branch" "$url" "$sha"
+    done
+} > "$stage/branch-clones-manifest.tsv"
+
+# ---- 2. Upstream-clones manifest ---------------------------------------
+# Per-branch upstream repository clones (used for git-tag detection in
+# phase 6c, local fetch in 6d). One row per clone.
+{
+    for branch_dir in "$UPSTREAMS_DIR"/*; do
+        [ -d "$branch_dir/clones" ] || continue
+        branch="$(basename "$branch_dir")"
+        for clone in "$branch_dir/clones"/*; do
+            # A clone may be a bare repo (HEAD file) or a working tree (.git dir).
+            if [ -d "$clone/.git" ] || [ -f "$clone/HEAD" ]; then
+                sha="$(git -C "$clone" rev-parse HEAD 2>/dev/null || echo unknown)"
+                url="$(git -C "$clone" remote get-url origin 2>/dev/null || echo unknown)"
+                printf '%s\t%s\t%s\t%s\n' "$branch" "$(basename "$clone")" "$url" "$sha"
+            fi
+        done
+    done
+} > "$stage/upstream-clones-manifest.tsv"
+
+# ---- 3. Tarball manifest -----------------------------------------------
+# Per-branch downloaded source tarballs in SOURCES_NEW. Records size + sha256
+# so the C run can validate it sees byte-identical tarballs when it fetches
+# them (Phase 6f col-9 SHA assembly).
+{
+    for branch_dir in "$UPSTREAMS_DIR"/*; do
+        src_new="$branch_dir/SOURCES_NEW"
+        [ -d "$src_new" ] || continue
+        branch="$(basename "$branch_dir")"
+        find "$src_new" -maxdepth 1 -type f -print | while read -r f; do
+            size="$(stat -c %s "$f" 2>/dev/null || echo 0)"
+            sha="$(sha256sum "$f" 2>/dev/null | awk '{print $1}')"
+            printf '%s\t%s\t%s\t%s\n' "$branch" "$(basename "$f")" "$size" "$sha"
+        done
+    done
+} > "$stage/tarball-manifest.tsv"
+
+# ---- 4. PRN snapshot ---------------------------------------------------
+# Copy in the .prn files PS produced this run — these are the diff
+# target the C run will compare against. Optional .md issue summaries
+# are excluded; only .prn matters for parity.
+if [ -d "$PRN_STAGING" ]; then
+    for f in "$PRN_STAGING"/*.prn; do
+        [ -f "$f" ] || continue
+        cp "$f" "$stage/prn-snapshot/"
+    done
+fi
+
+# ---- 5. Run info -------------------------------------------------------
+# Captured so the C-side journal row can reference the PS run by id.
+cat > "$stage/ps-run-info.json" <<EOF
+{
+  "run_id":      "${GITHUB_RUN_ID:-local}",
+  "run_attempt": "${GITHUB_RUN_ATTEMPT:-1}",
+  "github_sha":  "${GITHUB_SHA:-unknown}",
+  "github_ref":  "${GITHUB_REF:-unknown}",
+  "captured_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF
+
+# ---- 6. Tar ------------------------------------------------------------
+# gzip rather than zstd for portability; manifests + .prn are highly
+# compressible text. Expected size << 100 MB.
+tar -C "$stage" -czf "$OUT_TAR" .
+
+# ---- 7. Summary line for the workflow log ------------------------------
+n_branch=$(wc -l < "$stage/branch-clones-manifest.tsv")
+n_upstream=$(wc -l < "$stage/upstream-clones-manifest.tsv")
+n_tarball=$(wc -l < "$stage/tarball-manifest.tsv")
+n_prn=$(find "$stage/prn-snapshot" -maxdepth 1 -name '*.prn' -type f | wc -l)
+size=$(stat -c %s "$OUT_TAR" 2>/dev/null || echo 0)
+
+printf 'parity-snapshot: branch-clones=%d  upstream-clones=%d  tarballs=%d  prn-files=%d  archive-bytes=%d\n' \
+    "$n_branch" "$n_upstream" "$n_tarball" "$n_prn" "$size"

--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -1,0 +1,242 @@
+name: Photon OS Package Report (C-side parity)
+
+# Phase 8 task 081. Runs the C port of photonos-package-report against
+# the working state captured by the PS-side workflow, diffs the .prn
+# outputs, and appends a row to tools/parity-journal.tsv.
+#
+# Triggers:
+#   - workflow_run on success of "Photon OS Package Report"
+#   - workflow_dispatch with explicit snapshot run id (manual replay)
+#
+# This workflow does NOT produce production .prn files; the PS workflow
+# remains the source-of-truth until Phase 9 retirement.
+
+on:
+  workflow_run:
+    workflows: ["Photon OS Package Report"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      snapshot_run_id:
+        description: 'PS run id whose parity-snapshot-<id> artifact to consume'
+        required: true
+
+permissions:
+  contents: write   # commit the journal back to master
+  actions:  read    # download artifact from the triggering workflow
+
+jobs:
+  parity:
+    # Only run on success of upstream PS workflow (or on manual dispatch).
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: self-hosted
+    timeout-minutes: 480
+
+    steps:
+      - name: Determine PS run id
+        id: ps_run
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            ID="${{ github.event.inputs.snapshot_run_id }}"
+          else
+            ID="${{ github.event.workflow_run.id }}"
+          fi
+          if [ -z "$ID" ]; then
+            echo "::error::Could not resolve PS run id"; exit 1
+          fi
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+          echo "Resolved PS run id: $ID"
+
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          path: repo
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install build deps
+        run: |
+          # Idempotent: tdnf install reports "already installed" cleanly.
+          tdnf install -y cmake gcc libcurl-devel pcre2-devel pkg-config make tar gzip git || true
+          cmake --version
+          gcc --version | head -1
+
+      - name: Build C binary
+        run: |
+          cd repo/photonos-package-report
+          cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --parallel
+          ls -lh build/photonos-package-report
+
+      - name: Download parity snapshot
+        id: dl
+        uses: actions/download-artifact@v5
+        with:
+          name: parity-snapshot-${{ steps.ps_run.outputs.id }}
+          path: snapshot-raw
+          run-id: ${{ steps.ps_run.outputs.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract snapshot
+        id: extract
+        run: |
+          mkdir -p snapshot
+          cd snapshot
+          # The artifact contains exactly one tar.gz; find and extract it.
+          TAR=$(ls ../snapshot-raw/*.tar.gz | head -1)
+          tar -xzf "$TAR"
+          ls -la
+          if [ ! -s prn-snapshot ] || [ -z "$(ls prn-snapshot/*.prn 2>/dev/null)" ]; then
+            echo "::error::snapshot has no prn-snapshot/*.prn — nothing to diff"
+            exit 1
+          fi
+          echo "dir=$(pwd)" >> "$GITHUB_OUTPUT"
+
+      - name: Reconstruct working tree from manifests
+        id: reconstruct
+        run: |
+          WDIR="${RUNNER_TEMP:-/tmp}/parity-c-wd"
+          UPSTREAMS="$WDIR/photon-upstreams"
+          SCRIPT="repo/.github/scripts/parity-reconstruct.sh"
+          chmod +x "$SCRIPT" || true
+          "$SCRIPT" "${{ steps.extract.outputs.dir }}" "$WDIR" "$UPSTREAMS"
+          echo "wdir=$WDIR" >> "$GITHUB_OUTPUT"
+          echo "upstreams=$UPSTREAMS" >> "$GITHUB_OUTPUT"
+
+      - name: Determine enabled branches from snapshot
+        id: branches
+        run: |
+          # PS files in the snapshot follow: photonos-urlhealth-<branch>_<YYYYMMDDHHMM>.prn
+          SNAP="${{ steps.extract.outputs.dir }}"
+          BRANCHES=$(ls "$SNAP"/prn-snapshot/photonos-urlhealth-*.prn 2>/dev/null \
+                     | sed -E 's|.*photonos-urlhealth-(.+)_[0-9]+\.prn|\1|' \
+                     | sort -u)
+          echo "Branches in snapshot:"
+          printf '  %s\n' $BRANCHES
+
+          PH3=false; PH4=false; PH5=false; PH6=false
+          COMMON=false; DEV=false; MASTER=false
+          for b in $BRANCHES; do
+            case "$b" in
+              3.0)    PH3=true ;;
+              4.0)    PH4=true ;;
+              5.0)    PH5=true ;;
+              6.0)    PH6=true ;;
+              common) COMMON=true ;;
+              dev)    DEV=true ;;
+              master) MASTER=true ;;
+            esac
+          done
+          {
+            echo "ph3=$PH3"
+            echo "ph4=$PH4"
+            echo "ph5=$PH5"
+            echo "ph6=$PH6"
+            echo "common=$COMMON"
+            echo "dev=$DEV"
+            echo "master=$MASTER"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run C binary (-ThrottleLimit 1)
+        id: c_run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd repo/photonos-package-report
+          WDIR="${{ steps.reconstruct.outputs.wdir }}"
+          UPSTREAMS="${{ steps.reconstruct.outputs.upstreams }}"
+          SCANS="$WDIR/scans"
+          mkdir -p "$SCANS"
+
+          # Run with -ThrottleLimit 1 per ADR-0009 to keep stderr ordering
+          # byte-stable during the parity window.
+          ./build/photonos-package-report \
+            -workingDir   "$WDIR" \
+            -upstreamsDir "$UPSTREAMS" \
+            -scansDir     "$SCANS" \
+            -ThrottleLimit 1 \
+            -github_token "$GITHUB_TOKEN" \
+            -GeneratePh3URLHealthReport      "${{ steps.branches.outputs.ph3 }}" \
+            -GeneratePh4URLHealthReport      "${{ steps.branches.outputs.ph4 }}" \
+            -GeneratePh5URLHealthReport      "${{ steps.branches.outputs.ph5 }}" \
+            -GeneratePh6URLHealthReport      "${{ steps.branches.outputs.ph6 }}" \
+            -GeneratePhCommonURLHealthReport "${{ steps.branches.outputs.common }}" \
+            -GeneratePhDevURLHealthReport    "${{ steps.branches.outputs.dev }}" \
+            -GeneratePhMasterURLHealthReport "${{ steps.branches.outputs.master }}" \
+            -GeneratePhPackageReport         "false"
+
+          echo "scans=$SCANS" >> "$GITHUB_OUTPUT"
+          ls -l "$SCANS"
+
+      - name: Run parity-diff per branch
+        id: diff
+        run: |
+          SNAP="${{ steps.extract.outputs.dir }}"
+          PS_DIR="$SNAP/prn-snapshot"
+          C_DIR="${{ steps.c_run.outputs.scans }}"
+          DIFF="repo/photonos-package-report/tools/parity-diff.sh"
+          JNL="repo/photonos-package-report/tools/parity-journal.tsv"
+          APPEND="repo/photonos-package-report/tools/parity-journal-append.sh"
+          PS_RID="${{ steps.ps_run.outputs.id }}"
+          C_RID="${{ github.run_id }}"
+
+          chmod +x "$DIFF" "$APPEND" || true
+
+          {
+            echo "# Parity diff verdict"
+            echo
+            echo "| Branch | Verdict | Strict rows | Soft rows |"
+            echo "|--------|---------|-------------|-----------|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          overall="green"
+          for ps_prn in "$PS_DIR"/photonos-urlhealth-*.prn; do
+            [ -f "$ps_prn" ] || continue
+            base=$(basename "$ps_prn")
+            branch=$(echo "$base" | sed -E 's|photonos-urlhealth-(.+)_[0-9]+\.prn|\1|')
+            c_prn=$(ls -t "$C_DIR"/photonos-urlhealth-"$branch"_*.prn 2>/dev/null | head -1)
+            if [ -z "$c_prn" ]; then
+              echo "::error::parity-diff: no C output for branch $branch"
+              "$APPEND" "$JNL" "$PS_RID" "$C_RID" "$branch" 1 0 strict
+              overall="strict"
+              echo "| $branch | **strict** | n/a | n/a (no C output) |" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            # The diff script exits 1 on strict but we want to keep going.
+            result=$("$DIFF" "$ps_prn" "$c_prn" -q 2>/dev/null) || true
+            verdict=$(echo "$result" | awk '{print $1}')
+            strict=$(echo "$result" | awk '{print $2}')
+            soft=$(echo "$result"   | awk '{print $3}')
+
+            "$APPEND" "$JNL" "$PS_RID" "$C_RID" "$branch" "${strict:-0}" "${soft:-0}" "${verdict:-strict}"
+
+            case "$verdict" in
+              strict) overall="strict" ;;
+              soft)   [ "$overall" = "green" ] && overall="soft" ;;
+            esac
+
+            echo "| $branch | $verdict | $strict | $soft |" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+          {
+            echo
+            echo "**Overall: \`$overall\`**"
+            echo
+            echo "PS run [\`$PS_RID\`](https://github.com/${{ github.repository }}/actions/runs/$PS_RID) · C run \`$C_RID\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "overall=$overall" >> "$GITHUB_OUTPUT"
+
+      - name: Commit journal
+        if: always() && steps.diff.outputs.overall != ''
+        run: |
+          cd repo
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add photonos-package-report/tools/parity-journal.tsv
+          if git diff --cached --quiet; then
+            echo "No journal changes to commit"
+          else
+            git commit -m "parity: PS=${{ steps.ps_run.outputs.id }} C=${{ github.run_id }} overall=${{ steps.diff.outputs.overall }}"
+            git push
+          fi

--- a/.github/workflows/package-report.yml
+++ b/.github/workflows/package-report.yml
@@ -313,6 +313,40 @@ jobs:
           echo "staging=$STAGING" >> "$GITHUB_OUTPUT"
           echo "New .prn files from this run: $NEW_COUNT"
 
+      - name: Capture parity snapshot
+        if: always() && steps.collect.outputs.new_count != '0'
+        id: parity_snapshot
+        run: |
+          # Phase 8 task 080 (ADR-0009, FRD-016): freeze the PS-side input
+          # state so the C-side workflow can replay against bit-identical
+          # inputs. The artifact carries manifests (clone SHAs, tarball
+          # sha256s) + the .prn outputs PS produced — not the working-tree
+          # bytes themselves (those are reconstructible from the manifests).
+          WDIR="${{ github.event.inputs.workingDir }}"
+          [ -z "$WDIR" ] && WDIR="$REPORT_DIR"
+          UPSTREAMS="${{ github.event.inputs.upstreamsDir }}"
+          [ -z "$UPSTREAMS" ] && UPSTREAMS="$WDIR/photon-upstreams"
+          STAGING="${{ steps.collect.outputs.staging }}"
+
+          OUT="/tmp/parity-snapshot-${{ github.run_id }}.tar.gz"
+          SCRIPT="repo/.github/scripts/parity-snapshot.sh"
+          chmod +x "$SCRIPT" || true
+
+          "$SCRIPT" "$WDIR" "$UPSTREAMS" "$STAGING" "$OUT"
+          echo "tar=$OUT" >> "$GITHUB_OUTPUT"
+
+      - name: Upload parity snapshot artifact
+        if: always() && steps.parity_snapshot.outputs.tar != ''
+        uses: actions/upload-artifact@v7
+        with:
+          # Name embeds the PS run id so the C workflow can find it via
+          # the workflow_run.id payload field. Retention matches the
+          # ADR-0009 90-day clock plus 5 days slack.
+          name: parity-snapshot-${{ github.run_id }}
+          path: ${{ steps.parity_snapshot.outputs.tar }}
+          retention-days: 95
+          if-no-files-found: warn
+
       - name: Upload report artifacts
         if: always() && steps.collect.outputs.new_count != '0'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/parity-check.yml
+++ b/.github/workflows/parity-check.yml
@@ -1,0 +1,98 @@
+name: Parity gate (PR)
+
+# Phase 8 task 083. Applies the 30/60/90-day strictness ladder from
+# ADR-0009 to tools/parity-journal.tsv and emits a commit status.
+#
+# Runs on every PR. Reads the journal at PR base; does NOT trigger
+# a parity run. The journal is updated by package-report-C.yml on
+# its own schedule (which itself is gated by the PS workflow).
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents:        read
+  statuses:        write
+  pull-requests:   write   # to comment, optional
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Apply gate
+        id: gate
+        run: |
+          set -e
+          JNL="photonos-package-report/tools/parity-journal.tsv"
+          GATE="photonos-package-report/tools/parity-gate.sh"
+          chmod +x "$GATE" || true
+
+          # Tolerate exit codes for the verdict capture; we want the
+          # state/window strings even on a fail verdict.
+          result=$("$GATE" "$JNL" 2>/dev/null) || rc=$? && rc=0
+          rc=${rc:-0}
+
+          state=$(echo "$result"   | awk '{print $1}')
+          days=$(echo "$result"    | awk '{print $2}')
+          window=$(echo "$result"  | awk '{print $3}')
+          latest=$(echo "$result"  | awk '{print $4}')
+          rows=$(echo "$result"    | awk '{print $5}')
+
+          {
+            echo "state=$state"
+            echo "days=$days"
+            echo "window=$window"
+            echo "latest=$latest"
+            echo "rows=$rows"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "# Parity gate"
+            echo
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| State            | \`$state\` |"
+            echo "| Days since start | $days |"
+            echo "| Window           | $window |"
+            echo "| Latest verdict   | \`$latest\` |"
+            echo "| Journal rows     | $rows |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Post commit status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          STATE="${{ steps.gate.outputs.state }}"
+          WINDOW="${{ steps.gate.outputs.window }}"
+          LATEST="${{ steps.gate.outputs.latest }}"
+          DAYS="${{ steps.gate.outputs.days }}"
+
+          # Map gate-state → commit-status state.
+          case "$STATE" in
+            pass)    cs=success; desc="parity ok (window=$WINDOW, day=$DAYS, latest=$LATEST)" ;;
+            warn)    cs=success; desc="parity warning (window=$WINDOW, day=$DAYS, latest=$LATEST)" ;;
+            fail)    cs=failure; desc="parity strict-fail (window=$WINDOW, day=$DAYS, latest=$LATEST)" ;;
+            no-data) cs=success; desc="parity clock not started (no journal data)" ;;
+            *)       cs=error;   desc="parity gate produced unknown state $STATE" ;;
+          esac
+
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -f "state=$cs" \
+            -f "context=parity-gate" \
+            -f "description=$desc" \
+            -f "target_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Fail PR if strict-fail window
+        run: |
+          if [ "${{ steps.gate.outputs.state }}" = "fail" ]; then
+            echo "::error::Parity gate failed (strict-fail window 60-90 days)"
+            exit 1
+          fi

--- a/photonos-package-report/photonos-package-report/docs/maintainer-runbook.md
+++ b/photonos-package-report/photonos-package-report/docs/maintainer-runbook.md
@@ -332,3 +332,114 @@ into `build/generated/source0_lookup_data.h`.
   PS-source: photonos-package-report.ps1 L <start>-<end>
   Parity: <strict|semantic|n/a>
   ```
+
+---
+
+## 9. Reading the parity gate verdict
+
+Phase 8 (PR-pending) ships a three-workflow parity harness around the
+PS-side production workflow. The gate decides whether a PR is allowed
+to merge based on how recent runs have diffed.
+
+### Workflow shape
+
+```
+package-report.yml (PS)         package-report-C.yml (C)         parity-check.yml (gate)
+─────────────────────           ────────────────────────         ──────────────────────
+schedule / dispatch             workflow_run trigger             pull_request trigger
+       │                              │                                 │
+       ▼                              ▼                                 ▼
+  produce .prn                   download parity-snapshot         read parity-journal.tsv
+       │                         reconstruct working tree         apply 30/60/90 ladder
+       ▼                         build C / run C                  set commit status
+  upload parity-snapshot         parity-diff per branch
+                                 append journal row + commit
+```
+
+### The 30/60/90-day ladder (ADR-0009)
+
+| Days since clock start | Latest verdict → gate state |
+|---|---|
+| 0-30   | any → `pass` (soft window, informational) |
+| 30-60  | green→`pass`, else `warn` |
+| 60-90  | green→`pass`, soft→`warn`, strict→`fail` (PR blocked) |
+| 90+    | any → `pass` (cutover-ready; Phase 9 retirement trigger) |
+
+The clock starts with the first row in `tools/parity-journal.tsv`. The
+gate workflow (`parity-check.yml`) runs on every PR; it reads the
+journal as-checked-in and emits a `parity-gate` commit status.
+
+### Journal schema
+
+`tools/parity-journal.tsv` — one row per (PS run, C run, branch):
+
+```
+ts             ISO 8601 UTC
+ps_run_id      GitHub run id of the PS workflow
+c_run_id       GitHub run id of the C workflow run
+branch         3.0 | 4.0 | 5.0 | 6.0 | common | dev | master
+strict_rows    rows differing in non-volatile columns
+soft_rows      rows differing only in cols 4 and/or 7
+volatile_only  "true" iff soft_rows > 0 AND strict_rows == 0
+verdict        green | soft | strict
+```
+
+Volatile columns are 4 (`UrlHealth`) and 7 (`HealthUpdateURL`) — both
+HTTP status codes that legitimately shift day-to-day (ADR-0006). All
+other columns are strict.
+
+### Manual snapshot replay
+
+You can re-run the C workflow against any past PS snapshot:
+
+```sh
+# 1. Find the PS run id you want to replay against.
+gh run list --workflow="Photon OS Package Report" --limit 5
+
+# 2. Trigger the C workflow with that id (no PS rerun).
+gh workflow run "Photon OS Package Report (C-side parity)" \
+   -f snapshot_run_id=<PS_RUN_ID>
+```
+
+For fully-offline replay:
+
+```sh
+gh run download <PS_RUN_ID> -n parity-snapshot-<PS_RUN_ID> -D /tmp/snap
+cd /tmp/snap && tar -xzf parity-snapshot-*.tar.gz
+
+# Reconstruct working tree from manifests.
+.github/scripts/parity-reconstruct.sh /tmp/snap /tmp/wd /tmp/wd/photon-upstreams
+
+# Build + run C with the same -ThrottleLimit 1 the workflow uses.
+cmake --build build
+./build/photonos-package-report \
+   -workingDir /tmp/wd -upstreamsDir /tmp/wd/photon-upstreams \
+   -scansDir /tmp/wd/scans -ThrottleLimit 1 \
+   -GeneratePh6URLHealthReport true   # ...etc per branches in /tmp/snap/prn-snapshot/
+
+# Diff a single branch.
+./tools/parity-diff.sh \
+   /tmp/snap/prn-snapshot/photonos-urlhealth-6.0_*.prn \
+   /tmp/wd/scans/photonos-urlhealth-6.0_*.prn
+```
+
+### Common gate-verdict troubleshooting
+
+| Verdict | Meaning | First thing to check |
+|---|---|---|
+| `green` | byte-identical PRN | nothing to do |
+| `soft`  | only cols 4 / 7 differ | day-to-day HTTP flux; ignore unless persistent |
+| `strict` | non-volatile column drift | run replay (above) locally and `diff` the .prn pair to find the offending spec |
+| `no-data` | journal empty | first paired run hasn't happened yet; not an error |
+
+### When the clock should be reset
+
+Resetting means deleting `parity-journal.tsv` and re-committing. Do this
+only when:
+
+* The PS script itself has been intentionally changed and the previous
+  parity baseline is no longer the canonical target.
+* The C-side ADR-0006 column set has changed (new column added, etc.).
+
+In both cases open a separate PR that resets the journal explicitly
+with a justification linked to the ADR or PRD change.

--- a/photonos-package-report/photonos-package-report/tools/parity-diff.sh
+++ b/photonos-package-report/photonos-package-report/tools/parity-diff.sh
@@ -1,0 +1,142 @@
+#!/bin/sh
+# parity-diff.sh — diff PS vs C .prn output, classify by column volatility.
+#
+# Phase 8 task 082. ADR-0006 (bit-identical parity) + ADR-0009 (parity gate)
+# + FRD-016 (parity harness).
+#
+# The .prn is a 12-column CSV produced by both the PS script and the C
+# port:
+#
+#   col 1   Spec
+#   col 2   Source0 original
+#   col 3   Modified Source0 for url health check
+#   col 4   UrlHealth                 — VOLATILE (HTTP status, day-to-day)
+#   col 5   UpdateAvailable
+#   col 6   UpdateURL
+#   col 7   HealthUpdateURL           — VOLATILE (HTTP status)
+#   col 8   Name
+#   col 9   SHAName
+#   col 10  UpdateDownloadName
+#   col 11  warning
+#   col 12  ArchivationDate
+#
+# Volatile columns (4 and 7) are soft-diffed; all other columns are
+# strict — one byte ≠ → strict-diff verdict. The verdict feeds into the
+# 30/60/90-day ladder in tools/parity-gate.sh (task 083).
+#
+# Usage:
+#   parity-diff.sh <ps.prn> <c.prn> [-q]
+#
+# Output (machine-readable, one TSV line on stdout):
+#   <verdict>\t<strict_rows>\t<soft_rows>\t<lines_ps>\t<lines_c>
+#
+# verdict ∈ {green, soft, strict}
+#   green   — byte-identical (or all-volatile + zero-diff after stripping vol cols)
+#   soft    — rows differ only in cols 4 and/or 7
+#   strict  — at least one row differs in a non-volatile column (or
+#             line counts differ)
+#
+# Per-row detail prints to stderr unless -q is given.
+#
+# Exit:
+#   0 — green or soft
+#   1 — strict diff
+#   2 — bad arguments / missing files
+set -eu
+
+quiet=0
+if [ "${3-}" = "-q" ]; then
+    quiet=1
+fi
+
+if [ "$#" -lt 2 ]; then
+    echo "usage: $0 <ps.prn> <c.prn> [-q]" >&2
+    exit 2
+fi
+
+PS_PRN="$1"
+C_PRN="$2"
+
+for f in "$PS_PRN" "$C_PRN"; do
+    if [ ! -f "$f" ]; then
+        echo "::error::parity-diff: missing file $f" >&2
+        exit 2
+    fi
+done
+
+# Fast path: byte-identical → green.
+if cmp -s "$PS_PRN" "$C_PRN"; then
+    n=$(wc -l < "$PS_PRN")
+    printf 'green\t0\t0\t%d\t%d\n' "$n" "$n"
+    exit 0
+fi
+
+awk -F',' -v PS="$PS_PRN" -v C="$C_PRN" -v QUIET="$quiet" '
+BEGIN {
+    ln_ps = 0
+    while ((getline line < PS) > 0) ps[++ln_ps] = line
+    close(PS)
+    ln_c = 0
+    while ((getline line < C) > 0) c[++ln_c] = line
+    close(C)
+
+    strict = 0
+    soft   = 0
+    n      = (ln_ps > ln_c) ? ln_ps : ln_c
+
+    for (i = 1; i <= n; i++) {
+        ps_line = (i <= ln_ps) ? ps[i] : ""
+        c_line  = (i <= ln_c)  ? c[i]  : ""
+
+        if (ps_line == c_line) continue
+
+        if (ps_line == "" || c_line == "") {
+            # Row added/removed — always strict (parity contract is
+            # that both sides produce the same row set).
+            strict++
+            if (!QUIET)
+                printf("STRICT row %d  line-count-mismatch  PS=<%s>  C=<%s>\n",
+                       i, ps_line, c_line) > "/dev/stderr"
+            continue
+        }
+
+        # Naïve comma split — relies on identical quoting on both
+        # sides, which is the parity contract (ADR-0006). PS uses
+        # Out-File with the "Sort-Object" OrdinalIgnoreCase path; C
+        # uses setlocale(LC_ALL,"C")+strcasecmp. They emit the same
+        # column count and the same quote-handling for embedded commas.
+        npf = split(ps_line, pf, FS)
+        ncf = split(c_line,  cf, FS)
+
+        only_volatile = 1
+        diff_cols = ""
+        max = (npf > ncf) ? npf : ncf
+        for (k = 1; k <= max; k++) {
+            pv = (k <= npf) ? pf[k] : ""
+            cv = (k <= ncf) ? cf[k] : ""
+            if (pv != cv) {
+                if (k != 4 && k != 7) only_volatile = 0
+                diff_cols = diff_cols " " k
+            }
+        }
+
+        if (only_volatile) {
+            soft++
+            if (!QUIET)
+                printf("SOFT   row %d  cols[%s]  spec=%s\n",
+                       i, diff_cols, pf[1]) > "/dev/stderr"
+        } else {
+            strict++
+            if (!QUIET)
+                printf("STRICT row %d  cols[%s]  spec=%s\n",
+                       i, diff_cols, pf[1]) > "/dev/stderr"
+        }
+    }
+
+    if      (strict > 0) verdict = "strict"
+    else if (soft   > 0) verdict = "soft"
+    else                 verdict = "green"
+
+    printf("%s\t%d\t%d\t%d\t%d\n", verdict, strict, soft, ln_ps, ln_c)
+    exit (strict > 0 ? 1 : 0)
+}'

--- a/photonos-package-report/photonos-package-report/tools/parity-gate.sh
+++ b/photonos-package-report/photonos-package-report/tools/parity-gate.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# parity-gate.sh — apply the 30/60/90-day strictness ladder to the
+# parity journal and emit a verdict for the gate workflow.
+#
+# Phase 8 task 082. ADR-0009.
+#
+# Window matrix (days since the FIRST journal row, i.e. clock-start):
+#
+#    0-30  : soft       — informational; pass regardless of latest verdict
+#   30-60  : warning    — pass with warning if latest is not green
+#   60-90  : strict     — fail PR if latest is strict-diff
+#   90+    : cutover    — pass (Phase 9 retirement trigger)
+#
+# Usage:
+#   parity-gate.sh <journal.tsv>
+#
+# Output (one TSV line on stdout, machine-readable):
+#   <state>\t<days_elapsed>\t<window>\t<latest_verdict>\t<journal_rows>
+#
+# state ∈ {pass, warn, fail, no-data}
+# window ∈ {0-30, 30-60, 60-90, 90+, no-data}
+#
+# Detailed message goes to stderr.
+#
+# Exit:
+#   0 — pass (state=pass or warn)
+#   1 — fail (state=fail)
+#   2 — no journal data / bad arguments
+set -eu
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <journal.tsv>" >&2
+    exit 2
+fi
+
+J="$1"
+
+if [ ! -f "$J" ]; then
+    printf 'no-data\t0\tno-data\tnone\t0\n'
+    echo "::warning::parity-gate: journal file does not exist yet — clock not started" >&2
+    exit 2
+fi
+
+# Skip header, count data rows.
+rows=$(awk 'NR > 1' "$J" | wc -l)
+if [ "$rows" -eq 0 ]; then
+    printf 'no-data\t0\tno-data\tnone\t0\n'
+    echo "::warning::parity-gate: journal is empty (header only) — clock not started" >&2
+    exit 2
+fi
+
+# First data row's ts → clock start. Latest data row's verdict → current state.
+first_ts=$(awk 'NR == 2 { print $1; exit }' "$J")
+latest_verdict=$(awk 'END { print $NF }' "$J")
+
+# Days elapsed (integer division, second-precision input).
+now_epoch=$(date -u +%s)
+first_epoch=$(date -u -d "$first_ts" +%s 2>/dev/null || echo "$now_epoch")
+days=$(( (now_epoch - first_epoch) / 86400 ))
+
+# Window classification.
+if   [ "$days" -lt 30 ];  then window="0-30"
+elif [ "$days" -lt 60 ];  then window="30-60"
+elif [ "$days" -lt 90 ];  then window="60-90"
+else                            window="90+"
+fi
+
+# State per ADR-0009 ladder.
+state="pass"
+case "$window" in
+    "0-30")
+        # Soft window: pass regardless. Surface the verdict for visibility.
+        state="pass"
+        ;;
+    "30-60")
+        # Strict-warning: pass with warning if not green.
+        if [ "$latest_verdict" = "green" ]; then
+            state="pass"
+        else
+            state="warn"
+        fi
+        ;;
+    "60-90")
+        # Strict-failure: fail on strict; warn on soft; pass on green.
+        case "$latest_verdict" in
+            green) state="pass" ;;
+            soft)  state="warn" ;;
+            strict) state="fail" ;;
+            *)      state="warn" ;;
+        esac
+        ;;
+    "90+")
+        # Cutover-ready: pass. Retirement (Phase 9 task 090) is a
+        # separate action triggered by sustained green in this window.
+        state="pass"
+        ;;
+esac
+
+printf '%s\t%d\t%s\t%s\t%d\n' "$state" "$days" "$window" "$latest_verdict" "$rows"
+
+case "$state" in
+    pass) exit 0 ;;
+    warn) exit 0 ;;
+    fail) exit 1 ;;
+    *)    exit 2 ;;
+esac

--- a/photonos-package-report/photonos-package-report/tools/parity-journal-append.sh
+++ b/photonos-package-report/photonos-package-report/tools/parity-journal-append.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# parity-journal-append.sh — append one row to tools/parity-journal.tsv.
+#
+# Phase 8 task 082. ADR-0009 (30/60/90-day ladder).
+#
+# The journal is committed alongside each C-side workflow run so the
+# 90-day clock survives runner restarts. One row per (PS run, C run,
+# branch) triple. tools/parity-gate.sh (task 083) reads this file.
+#
+# Schema (TSV with header):
+#   ts             ISO 8601 UTC, second precision
+#   ps_run_id      GitHub run id of the PS workflow that produced the snapshot
+#   c_run_id       GitHub run id of this C workflow run
+#   branch         Photon branch the .prn pair came from (3.0, 5.0, common, ...)
+#   strict_rows    count of rows differing in non-volatile columns
+#   soft_rows      count of rows differing only in cols 4 and/or 7
+#   volatile_only  "true" if soft_rows > 0 and strict_rows == 0
+#   verdict        green | soft | strict
+#
+# Usage:
+#   parity-journal-append.sh <journal.tsv> <ps_run_id> <c_run_id> <branch> \
+#                            <strict_rows> <soft_rows> <verdict>
+set -eu
+
+if [ "$#" -ne 7 ]; then
+    echo "usage: $0 <journal.tsv> <ps_run_id> <c_run_id> <branch> <strict> <soft> <verdict>" >&2
+    exit 2
+fi
+
+J="$1"
+PS_RID="$2"
+C_RID="$3"
+BR="$4"
+STRICT="$5"
+SOFT="$6"
+V="$7"
+
+case "$V" in
+    green|soft|strict) ;;
+    *)
+        echo "::error::parity-journal-append: invalid verdict '$V' (want green|soft|strict)" >&2
+        exit 2
+        ;;
+esac
+
+# Initialise the file with a header row if absent. The header lets
+# downstream consumers ignore field-order changes safely.
+if [ ! -f "$J" ]; then
+    printf 'ts\tps_run_id\tc_run_id\tbranch\tstrict_rows\tsoft_rows\tvolatile_only\tverdict\n' > "$J"
+fi
+
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+volatile_only="false"
+if [ "$V" = "soft" ]; then
+    volatile_only="true"
+fi
+
+printf '%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\n' \
+    "$ts" "$PS_RID" "$C_RID" "$BR" "$STRICT" "$SOFT" "$volatile_only" "$V" >> "$J"


### PR DESCRIPTION
## Summary

Implements the three-workflow parity harness from ADR-0009 (90-day clock) + FRD-016 (parity harness):

- **PS workflow** captures a snapshot of its working state (manifests + .prn outputs) at the tail of every run
- **C workflow** (new) consumes that snapshot, reconstructs the working tree from manifests, runs the C port with `-ThrottleLimit 1`, diffs per-branch, appends to `tools/parity-journal.tsv`
- **Gate workflow** (new) runs on PRs, applies the 30/60/90-day strictness ladder to the journal, emits a `parity-gate` commit status

The PS workflow remains the source-of-truth for production `.prn` files until Phase 9. No `.prn` byte that ships to downstream consumers is touched by this PR.

## Files

| Path | Why |
|---|---|
| `.github/workflows/package-report.yml` | +2 steps: capture parity snapshot + upload artifact |
| `.github/workflows/package-report-C.yml` | new — C-side replay workflow |
| `.github/workflows/parity-check.yml` | new — PR gate |
| `.github/scripts/parity-snapshot.sh` | new — captures manifests + .prn outputs |
| `.github/scripts/parity-reconstruct.sh` | new — re-clones at recorded SHAs |
| `photonos-package-report/tools/parity-diff.sh` | new — 12-col .prn diff, vol cols 4/7 soft |
| `photonos-package-report/tools/parity-journal-append.sh` | new — TSV append helper |
| `photonos-package-report/tools/parity-gate.sh` | new — 30/60/90 ladder |
| `photonos-package-report/docs/maintainer-runbook.md` | +§9 "Reading the parity gate verdict" |

## Test plan

- [x] All three workflow YAMLs parse via `yaml.safe_load`
- [x] `parity-diff.sh` smoke-tested: byte-identical → green; col 4 mutation → soft (exit 0); col 8 mutation → strict (exit 1)
- [x] `parity-gate.sh` smoke-tested: 7 ladder scenarios incl. day-0, day-40 warn, day-75 fail, day-95 cutover
- [x] `parity-reconstruct.sh` smoke-tested: empty branch-manifest aborts with exit 1
- [x] `parity-snapshot.sh` smoke-tested: produces a well-formed tar against an empty working dir
- [ ] First real paired run on the next scheduled PS workflow (task 084)
- [ ] Verify `actions/download-artifact@v5` with `run-id` parameter works across workflows (needs first live trigger)
- [ ] Verify `workflow_run` trigger fires on PS success

## Out of scope

- Task 084 (first three paired runs all soft-green to start the clock) — happens automatically once this lands; the next scheduled PS run will trigger the C workflow.
- Phase 9 retirement — only relevant at day 90+ of green-strict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)