### PR TITLE
tdnf-depgraph phase-3: ADRs 0001–0006 (cycle detection)

### DIFF
--- a/tdnf-depgraph/ARCHITECTURE.md
+++ b/tdnf-depgraph/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`tdnf-depgraph` exports the RPM dependency graph that libsolv materializes in memory after `pool_createwhatprovides()`. The exporter is implemented as a small C extension to [vmware/tdnf](https://github.com/vmware/tdnf), patched on top of the system-installed tdnf version at workflow time. The resulting `tdnf depgraph --json` command emits a graph of `Requires` / `BuildRequires` / `Conflicts` edges over every spec/binary node, which the [Dependency Graph Scan](../.github/workflows/depgraph-scan.yml) workflow runs once per Photon branch (and, going forward, once per branch *flavor* — see [ADR-0002](specs/adr/0002-subrelease-overlay-flavors.md) when it lands).
+`tdnf-depgraph` exports the RPM dependency graph that libsolv materializes in memory after `pool_createwhatprovides()`. The exporter is implemented as a small C extension to [vmware/tdnf](https://github.com/vmware/tdnf), patched on top of the system-installed tdnf version at workflow time. The resulting `tdnf depgraph --json` command emits a graph of `Requires` / `BuildRequires` / `Conflicts` edges over every spec/binary node, which the [Dependency Graph Scan](../.github/workflows/depgraph-scan.yml) workflow runs once per Photon branch (and, going forward, once per branch *flavor* — see [ADR-0002](specs/adr/0002-subrelease-overlay-flavors.md)).
 
 ```
                 ┌──────────────────────────────────────────────────────────┐
@@ -54,6 +54,19 @@ The active workflow at the repo root (`/.github/workflows/depgraph-scan.yml`) is
 
 Append-only history of the workflow's output JSONs, one filename per (branch, flavor, timestamp). Consumers downstream (Snyk classifier, package report, gating-conflict detector) read from here. File naming is contractual; see [specs/features/subrelease-flavors.md](specs/features/subrelease-flavors.md) when it lands.
 
+## Cycle Detection Pipeline
+
+The cycle pass runs as a Python post-step after the C `tdnf depgraph` extension emits its v1 JSON. The pass rewrites each file in place as schema v2, with `sccs[]`, `cycles[]`, and `cycle_summary{}` populated. Architectural decisions are captured in the following ADRs:
+
+| ADR | Decision |
+|-----|----------|
+| [ADR-0001](specs/adr/0001-cycle-detection-in-python-postprocess.md) | Detect cycles in a Python post-step, not in the C extension. |
+| [ADR-0002](specs/adr/0002-subrelease-overlay-flavors.md) | Scan each `SPECS/[0-9]+/` as an overlay flavor (`SPECS/` + `SPECS/<N>/`, same-name wins). |
+| [ADR-0003](specs/adr/0003-tarjan-scc-plus-representative.md) | Tarjan SCC + one shortest representative cycle per SCC via BFS. Deterministic tie-breaks on node name. |
+| [ADR-0004](specs/adr/0004-schema-v2-additive.md) | Bump `metadata.schema_version` 1 → 2. Purely additive; every v1 key preserved. |
+| [ADR-0005](specs/adr/0005-bootstrap-resolved-classification.md) | Classify each SCC against `data/builder-pkg-preq.json`; `bootstrap_resolved: true` iff every member is pre-staged. |
+| [ADR-0006](specs/adr/0006-fail-on-buildrequires-cycle-input.md) | New workflow input `fail_on_buildrequires_cycle` (default `false`); only `bootstrap_resolved: false` buildrequires cycles trip the gate. |
+
 ## Spec-Driven Development
 
 This subproject follows the same SDD methodology as the other initiatives in this repo (`upstream-source-code-dependency-scanner`, `vCenter-CVE-drift-analyzer`, `photon-gating-conflict-detection`, `photonos-package-report`, `docsystem`). All design changes flow through `specs/`:
@@ -69,8 +82,9 @@ New work begins by writing the spec, gating implementation behind a merged spec 
 
 | Initiative | Phase | Spec | Status |
 |---|---|---|---|
-| Cycle detection (libselinux ↔ python3 class of bugs) | 0 — SDD scaffolding | this file + `specs/README.md` | in progress |
-| Cycle detection — PRD | 1 | `specs/prd.md` | pending |
-| Cycle detection — ADRs 0001–0006 | 3 | `specs/adr/` | pending |
+| Cycle detection (libselinux ↔ python3 class of bugs) | 0 — SDD scaffolding | this file + `specs/README.md` | complete |
+| Cycle detection — PRD | 1 | `specs/prd.md` | complete |
+| Cycle detection — ADRs 0001–0006 | 3 | `specs/adr/` | complete |
 | Cycle detection — feature specs | 4 | `specs/features/` | pending |
 | Cycle detection — task breakdown | 5 | `specs/tasks/0001-task-cycles-post-step.md` | pending |
+| Cycle detection — implementation | 6 | per-task PRs | pending |

--- a/tdnf-depgraph/specs/adr/0001-cycle-detection-in-python-postprocess.md
+++ b/tdnf-depgraph/specs/adr/0001-cycle-detection-in-python-postprocess.md
@@ -1,0 +1,77 @@
+# ADR-0001: Cycle Detection in Python Post-Process Step
+
+**Date**: 2026-05-13
+**Status**: Accepted
+
+## Context
+
+The *Dependency Graph Scan* workflow emits one JSON artifact per Photon branch from a custom `tdnf depgraph` C extension that walks libsolv's `Pool`. The PRD ([../prd.md](../prd.md)) requires this artifact to carry cycle information so that incidents like the 2026-05-12 `libselinux ↔ python3` build-time loop are flagged in the run summary instead of being silently encoded in raw edge data.
+
+Cycle detection logically belongs *somewhere* in the pipeline; the question is whether it runs inside the C extension as part of `tdnf depgraph --json`, or as a separate post-processing step against the existing JSON.
+
+## Decision Drivers
+
+- **Iteration speed.** Cycle algorithms, tie-breaking rules, and schema field choices will likely change as we learn from real artifacts. Workflow YAML / Python is cheap to iterate; C requires rebuilding the patched `tdnf-src` for every run.
+- **Risk of regression.** The existing C extension is shared with downstream consumers; modifying it risks breaking the v1 JSON contract or the in-memory libsolv walk.
+- **Data sufficiency.** The artifact JSON already contains all `nodes` and typed `edges`; no information is lost in serialization. Cycle detection does not need libsolv state.
+- **Performance budget.** Graph sizes are ~1,500–2,000 nodes / ~10,000 edges per branch. Tarjan SCC is O(V+E) — trivially under a second in Python.
+- **Deployment.** Python 3 is already required on the workflow runner (used elsewhere in the same job).
+
+## Considered Options
+
+### Option 1: Extend the C `tdnf depgraph` extension
+
+Add a cycle pass to `src/solv_tdnfdepgraph.c` that runs after graph construction and emits `sccs`/`cycles` directly in the JSON.
+
+**Pros:**
+- Single binary, single JSON write.
+- Could share data structures with the existing graph build.
+
+**Cons:**
+- Every iteration of the algorithm requires patching `tdnf-src` and rebuilding inside the workflow.
+- Higher risk: a bug in the cycle pass can crash `tdnf depgraph` and fail the whole scan, not just the cycle field.
+- Forks the C code further from upstream `vmware/tdnf`, raising the maintenance cost when tdnf bumps.
+- C is the wrong language for prototyping schema field names; the JSON shape is still being shaped.
+
+### Option 2: Standalone offline analyzer (separate CLI tool)
+
+Ship a `cycle-analyzer` binary or Python script that runs out-of-band against checked-in `scans/*.json`.
+
+**Pros:**
+- Zero risk to the existing pipeline.
+- Can be re-run against historical artifacts without re-scanning.
+
+**Cons:**
+- Splits the artifact: consumers must run two tools to get the full picture.
+- The GitHub Actions step summary cannot report cycles inline.
+- `fail_on_buildrequires_cycle` (G3 in the PRD) requires inline detection.
+
+### Option 3 (Chosen): Python post-step in the workflow
+
+Add a single Python script under `tdnf-depgraph/tools/depgraph_cycles.py` that runs inside the same workflow job, immediately after `tdnf depgraph --json`. It loads the v1 JSON, computes cycles, and rewrites the same file as v2.
+
+**Pros:**
+- The C extension remains untouched. v1 → v2 schema bump is the Python step's responsibility alone.
+- Algorithm and schema can iterate without rebuilding tdnf.
+- The same Python step can populate the step summary table (G5) and decide the job exit code (G3).
+- Trivially testable in isolation (unit tests on a hand-built graph dict — see AC-2).
+- Python stdlib alone is sufficient; no new runner dependencies.
+
+**Cons:**
+- Two languages in the pipeline (C for extraction, Python for analysis).
+- Re-parses JSON the C extension just wrote (negligible cost at our graph sizes).
+
+## Decision
+
+Implement cycle detection as a Python post-step **(Option 3)**.
+
+- File: `tdnf-depgraph/tools/depgraph_cycles.py`, Python 3 stdlib only.
+- Invocation: one process per produced JSON, file rewritten in place.
+- Schema bump from v1 to v2 happens here; the C extension continues to emit v1.
+
+## Consequences
+
+- The C source under `tdnf-depgraph/src/` stays at the v1 contract. Any future port of the algorithm to C is a separate ADR; until then, the Python step is canonical.
+- The workflow YAML grows a new `Detect cycles` step that runs `depgraph_cycles.py` per output file, plus a step-summary writer (see [ADR-0004](0004-schema-v2-additive.md), [ADR-0006](0006-fail-on-buildrequires-cycle-input.md)).
+- Unit tests live under `tdnf-depgraph/tests/` and exercise the Python step in isolation; no tdnf install required.
+- If runtime ever exceeds budget (current expectation: under a second per branch), the Python implementation is a reference for a future C port — no algorithm decisions are locked in language.

--- a/tdnf-depgraph/specs/adr/0002-subrelease-overlay-flavors.md
+++ b/tdnf-depgraph/specs/adr/0002-subrelease-overlay-flavors.md
@@ -1,0 +1,69 @@
+# ADR-0002: Sub-Release Overlay Flavors
+
+**Date**: 2026-05-13
+**Status**: Accepted
+
+## Context
+
+Photon 5.0's `vmware/photon` checkout contains a top-level `SPECS/` tree and additional sub-release directories `SPECS/90/`, `SPECS/91/`, `SPECS/92/`. The latter hold per-flavor overrides — most commonly the kernel and kernel-adjacent specs — while everything else comes from the base `SPECS/` tree. The 2026-05-12 fix at `vmware/photon@8fb8549c` was applied to *both* `SPECS/libselinux/libselinux.spec` *and* `SPECS/91/libselinux/libselinux.spec` because each flavor is built independently from its own merged view.
+
+Today's *Dependency Graph Scan* emits a single graph per branch by pointing `tdnf depgraph --setopt specsdir=` at `SPECS/`. Sub-release content is therefore ignored: scans of 5.0 do not see what builds for 5.0.91 actually depend on. The PRD requires per-flavor visibility (G2) so that flavor-specific cycles do not hide behind the base view.
+
+The question is not whether to scan sub-releases — it is what *flavor* means when the on-disk tree is partial.
+
+## Decision Drivers
+
+- **Match build reality.** When the Photon build system constructs a 5.0.91 image, it composes `SPECS/` with `SPECS/91/` on top. The graph we emit for the `91` flavor should reflect what is actually built.
+- **Discoverability.** The sub-release directory layout is conventional but not centrally declared. Hardcoding `90/91/92` will silently misbehave when 6.0 or `dev` grow their own sub-releases.
+- **Stability of consumer contracts.** Downstream consumers parse filenames; the existing per-branch filenames must not change for branches that have no sub-releases.
+
+## Considered Options
+
+### Option 1: Treat each `SPECS/<N>/` as an independent, standalone tree
+
+Run `tdnf depgraph --setopt specsdir=SPECS/91` directly.
+
+**Pros:** Simple.
+**Cons:** Wrong. `SPECS/91/` typically contains only a handful of overrides (kernel, microcode, perhaps glibc); a depgraph over it alone produces a graph with ~50 nodes that omits the bulk of the system. This does not match how Photon builds the 91 flavor.
+
+### Option 2 (Chosen): Overlay `SPECS/<N>/` on top of `SPECS/`
+
+For flavor `N`, assemble a temporary directory that contains every file from `SPECS/`, with every file from `SPECS/<N>/` copied on top — same-name wins. Run `tdnf depgraph` against the overlay.
+
+**Pros:**
+- Matches the build's effective view of the 91 spec tree.
+- Cycle detection sees the same edges the builder sees, so detected cycles reflect real build-order problems.
+- Naturally handles the empty case: branches with no `SPECS/[0-9]+/` directories produce a single (base) flavor identical to today's output.
+
+**Cons:**
+- Requires a temporary overlay directory per flavor; cleanup discipline in the workflow.
+- Overlay semantics must be documented for consumers (see [`../features/subrelease-flavors.md`](../features/subrelease-flavors.md)).
+
+### Option 3: Static configuration of (branch → flavor list)
+
+Maintain a JSON file (or workflow input) enumerating the flavors per branch.
+
+**Pros:** Explicit; reviewable.
+**Cons:** Must be updated whenever Photon adds a sub-release. Drift between configuration and actual on-disk state is exactly the failure mode we want to avoid.
+
+## Decision
+
+For each (branch, flavor) pair:
+
+1. Sparse-checkout `SPECS/` from the target branch.
+2. Discover flavors dynamically: `find SPECS -maxdepth 1 -mindepth 1 -type d -regex 'SPECS/[0-9]+' -printf '%f\n' | sort`.
+3. For the empty (base) flavor, run `tdnf depgraph --setopt specsdir=SPECS`.
+4. For each numeric flavor `N`, materialize an overlay at `/tmp/photon-overlay-<branch>-<N>/` by:
+   - `cp -a SPECS/. overlay/`
+   - `cp -a SPECS/<N>/. overlay/` (same-name files overwrite)
+   then run `tdnf depgraph --setopt specsdir=overlay`.
+5. Emit one JSON per (branch, flavor). Filename convention is fixed in [`../features/subrelease-flavors.md`](../features/subrelease-flavors.md): unflavored branches keep `dependency-graph-<branch>-<datetime>.json`; flavored runs gain a `-<flavor>` suffix.
+6. `metadata.flavor` carries the flavor token (`""` for base). `metadata.specsdir` carries a human-readable overlay descriptor (e.g. `"SPECS+SPECS/91"`).
+
+## Consequences
+
+- Photon 5.0 emits four files per run: base + 90 + 91 + 92. Branches 3.0/4.0/6.0/common/master/dev emit one file each with names unchanged.
+- A future Photon 6.0 or `dev` sub-release directory is picked up automatically with no code change.
+- Workflow cleanup must delete `/tmp/photon-overlay-*` between runs; covered as part of the existing `cleanup` step.
+- Consumers that today iterate `tdnf-depgraph/scans/dependency-graph-5.0-*.json` will see new files matching the same glob. They must guard on `metadata.flavor` if they want only the base view. This is documented in the feature spec and the v2 schema notes.
+- The overlay copy adds a small filesystem cost per flavor; at Photon spec-tree sizes (~30 MB) this is negligible compared to the existing tdnf clone+build step.

--- a/tdnf-depgraph/specs/adr/0003-tarjan-scc-plus-representative.md
+++ b/tdnf-depgraph/specs/adr/0003-tarjan-scc-plus-representative.md
@@ -1,0 +1,71 @@
+# ADR-0003: Tarjan SCC + Shortest Representative Cycle per SCC
+
+**Date**: 2026-05-13
+**Status**: Accepted
+
+## Context
+
+The cycle pass must produce, for each emitted JSON, both a structural view of cyclic dependencies (which packages are entangled) and a concrete actionable view (a specific chain of edges illustrating the cycle). Two algorithmic families dominate:
+
+- **Strongly-connected-component (SCC) decomposition** — Tarjan or Kosaraju — finds every set of mutually-reachable nodes in O(V+E). Any SCC of size ≥ 2 contains at least one cycle. A self-loop edge `(v, v)` is a cycle on a singleton SCC.
+- **Elementary cycle enumeration** — Johnson's algorithm — enumerates *every* simple cycle in time bounded by O((V+E) · (C+1)) where C is the number of elementary cycles. C can be exponential in V even for modest graphs.
+
+Photon graphs run ~1,500–2,000 nodes / ~10,000 edges per (branch, flavor). Worst-case Johnson on a densely-cyclic SCC would be unacceptable; on the typical Photon graph it would be fine, but we cannot guarantee bounds without per-graph profiling.
+
+## Decision Drivers
+
+- **Bounded runtime.** The detection step must complete deterministically in well under a second per graph, regardless of graph topology.
+- **Actionable output.** A maintainer reading the Actions summary needs at least one concrete cycle path per problematic component — not just a set of node names.
+- **Determinism.** AC-2 in the PRD requires byte-identical `cycles[]` / `sccs[]` output across two runs of the same input. This rules out algorithms whose output depends on hash iteration order.
+- **No external dependencies.** Python stdlib only ([ADR-0001](0001-cycle-detection-in-python-postprocess.md)).
+
+## Considered Options
+
+### Option 1: Johnson's algorithm — enumerate every elementary cycle
+
+**Pros:** Complete view of every distinct cycle.
+**Cons:** Exponential worst case. Output size unbounded. Reviewer drowns in cycles when SCCs are large. Determinism requires careful node ordering. Not justified at Photon scale, where one cycle per problematic component is enough to motivate a fix.
+
+### Option 2: Tarjan SCC only — no cycle paths
+
+Report SCCs as `{size, members}` without producing any concrete cycle.
+
+**Pros:** Cheapest. Deterministic.
+**Cons:** Reviewer cannot read the Actions summary and immediately see *which* dependency edges form the cycle. The PRD G5 success metric ("a reviewer can determine whether any unresolved buildrequires cycle exists by reading the Actions run summary alone") is unmet.
+
+### Option 3 (Chosen): Tarjan SCC + one shortest representative cycle per non-trivial SCC
+
+Run Tarjan to find SCCs. For every SCC of size ≥ 2 (and every self-loop), compute the shortest cycle through any node of that SCC via BFS restricted to the SCC's induced subgraph. Emit:
+
+- One entry per SCC in `sccs[]` (size, members, edge types observed, bootstrap-resolved flag).
+- One entry per representative cycle in `cycles[]` (ordered node path, edge types, length, category, bootstrap-resolved, `scc_id`, `representative: true`).
+- `scc_size` field tells the consumer how many additional non-representative cycles exist in the same SCC — without us enumerating them.
+
+**Pros:**
+- Bounded runtime: Tarjan O(V+E), BFS O(V'+E') per SCC where V'/E' are SCC-local.
+- Actionable: every cyclic SCC contributes one concrete cycle path.
+- Deterministic with explicit tie-breaks (below).
+
+**Cons:**
+- A reviewer who wants to see *every* cycle in a large SCC has to either trace edges manually or run a separate tool. Acceptable: such SCCs are rare in package graphs and indicate a much larger structural problem that one cycle path will already motivate.
+
+## Decision
+
+Use **Tarjan SCC + shortest representative cycle per SCC via BFS**. Specifically:
+
+1. **SCC pass.** Iterative Tarjan over the directed graph filtered by edge category (`buildrequires`, `requires`, `mixed`). Tarjan is iterative — recursion depth can exceed Python's default limit on degenerate inputs.
+2. **Representative selection.** For each SCC of size ≥ 2:
+   - Sort SCC members lexicographically by node *name* (not id).
+   - Starting from the lexicographically smallest member `v0`, BFS within the SCC to find the shortest path that returns to `v0`. Tie-break BFS frontier expansion by node name (sorted) so the BFS itself is deterministic.
+   - The returned path is the representative cycle for that SCC.
+3. **Self-loops.** Treated as singleton SCCs in their own right; the cycle is `[v, v]`, length 1.
+4. **Categorization.** A cycle is `buildrequires` if every edge in its representative path is `buildrequires`; `requires` if every edge is `requires`; `mixed` otherwise; `self-loop` for length-1 cycles. SCCs whose induced subgraph has more than one edge type are summarized in `sccs[i].edge_types_present`.
+5. **Bootstrap classification.** Deferred to [ADR-0005](0005-bootstrap-resolved-classification.md).
+6. **Determinism.** Members in `sccs[].members`, `sccs[].names`, and `cycles[]` ordering are all sorted by name (then id as final tie-break). Two runs of the same input must produce byte-identical JSON.
+
+## Consequences
+
+- Output size is bounded: at most one cycle entry per SCC + one per self-loop. Typical Photon scans produce 0 cycles; pathological branches produce O(SCC count) entries, not O(elementary-cycle count).
+- A future enhancement could emit additional non-representative cycles per SCC behind a workflow input, without changing the schema's existing fields.
+- The `representative: true` boolean and `scc_size` integer together let downstream tooling distinguish "this is *the* cycle" from "this is one of N cycles in a big SCC, look closer".
+- Algorithm pseudocode is captured in [`../features/cycle-detection.md`](../features/cycle-detection.md) for implementers.

--- a/tdnf-depgraph/specs/adr/0004-schema-v2-additive.md
+++ b/tdnf-depgraph/specs/adr/0004-schema-v2-additive.md
@@ -1,0 +1,62 @@
+# ADR-0004: Additive v1 → v2 Schema Bump
+
+**Date**: 2026-05-13
+**Status**: Accepted
+
+## Context
+
+The cycle pass adds new top-level keys (`sccs`, `cycles`, `cycle_summary`) and a new metadata field (`metadata.flavor`) to the artifact JSON. The artifact is consumed by multiple downstream workflows in this repository (`gating-conflict-detection`, `package-classifier`, `snyk-analysis`, `upstream-source-code-dependency-scanner`, `photonos-package-report`) and accumulates in `tdnf-depgraph/scans/` as a long-lived history. Any schema change must respect both the consumer base and the historical record.
+
+PRD acceptance criterion AC-5 mandates a version bump; AC-8 mandates that v1 consumers continue to parse v2 files. These two together constrain the change to be *purely additive*.
+
+## Decision Drivers
+
+- **No silent breakage of downstream parsers.** Workflows that grep or `jq` on `nodes[]` / `edges[]` / `node_count` must continue to work after the bump.
+- **Detectability.** A consumer must be able to detect v2 unambiguously when it wants to opt into the new fields.
+- **Historical coherence.** `tdnf-depgraph/scans/*.json` files from before this change continue to be readable and identifiable as v1.
+
+## Considered Options
+
+### Option 1: No version field, structural detection
+
+Consumers infer the schema from key presence (`if "cycles" in d: ...`).
+
+**Pros:** Zero ceremony.
+**Cons:** Fragile. A future v3 with different `cycles` semantics would force every consumer to add a second probe. No way to migrate historical scans without re-scanning.
+
+### Option 2: Breaking rename of existing v1 fields
+
+E.g. rename `node_count` → `metadata.counts.nodes`, `nodes` → `graph.nodes`, etc.
+
+**Pros:** Cleaner long-term layout.
+**Cons:** Breaks every consumer. Violates AC-8. Forces a coordinated rollout across five downstream workflows for no functional gain.
+
+### Option 3 (Chosen): Bump `metadata.schema_version` from 1 to 2, additive-only changes
+
+`metadata.schema_version: 2` is set on every emitted file. Every v1 key is preserved with identical name, position, and semantics. New keys are appended.
+
+**Pros:**
+- Existing consumers continue to work without modification.
+- New consumers opt in by branching on `schema_version`.
+- Historical v1 scans remain valid; they simply lack the new fields.
+
+**Cons:**
+- Cumulative schema growth over time. Acceptable at our pace of change (one ADR-driven bump per quarter, at most).
+
+## Decision
+
+The cycle pass (see [ADR-0001](0001-cycle-detection-in-python-postprocess.md)) is the sole writer of v2 fields. Specifically:
+
+- Set `metadata.schema_version = 2`. Add `metadata.flavor` (string, `""` for base) and `metadata.specsdir` (string, e.g. `"SPECS+SPECS/91"`). Add `metadata.cycles_engine` (string identifier of the algorithm version, initially `"tarjan-py-v1"`).
+- Add top-level `sccs[]`, `cycles[]`, `cycle_summary{}` arrays/objects. Empty arrays and zero counters are explicitly emitted (not omitted) for acyclic graphs.
+- Do **not** rename, remove, reposition, or change the type of any v1 field. Specifically: `metadata.{branch, specsdir, generated_at}`, `node_count`, `edge_count`, `nodes`, `edges` are immutable.
+- v1 consumers that never look at `schema_version` continue to function. v2-aware consumers check `metadata.schema_version >= 2` before reading the new fields.
+
+The complete v2 schema is documented in [`../features/cycle-detection.md`](../features/cycle-detection.md).
+
+## Consequences
+
+- Historical scans under `tdnf-depgraph/scans/*.json` written before this change are valid v1; they lack `metadata.schema_version`. Consumers should treat absent `schema_version` as `1`.
+- A future v3 must follow the same additive discipline unless the cost of breaking is explicitly weighed in a follow-up ADR.
+- The `cycles_engine` string lets us evolve the algorithm (e.g. swap representative selection) without bumping the schema version, as long as the *shape* of the output is unchanged. A v3 bump is reserved for true structural changes.
+- The cycle pass is the schema-version writer; the C `tdnf depgraph` extension continues to emit v1. The Python step is responsible for the bump on every output.

--- a/tdnf-depgraph/specs/adr/0005-bootstrap-resolved-classification.md
+++ b/tdnf-depgraph/specs/adr/0005-bootstrap-resolved-classification.md
@@ -1,0 +1,66 @@
+# ADR-0005: Bootstrap-Resolved Cycle Classification
+
+**Date**: 2026-05-13
+**Status**: Accepted
+
+## Context
+
+Not every cycle in the dependency graph is a bug. The Photon build system maintains `data/builder-pkg-preq.json` — a list of packages that the bootstrap pre-stages before normal `BuildRequires` resolution begins. Packages in this list can participate in cycles without breaking the build, because the build never needs to *resolve* their `BuildRequires` from scratch: their binaries are already on disk when the dependent build starts.
+
+The 2026-05-12 fix at `vmware/photon@8fb8549c` is the canonical example. It both:
+
+1. Split `libselinux.spec` into `libselinux.spec` + `libselinux-python3.spec`, removing the most concrete edge in the cycle.
+2. Added `libselinux` and `libsepol` to `data/builder-pkg-preq.json`, so any residual cyclicity is tolerated by the build sequencing.
+
+A cycle-detection step that fails the workflow on every cycle would have flagged the post-fix state as broken — even though the maintainer's intent was exactly to leave the cycle resolved by pre-staging. The cycle pass must distinguish actionable cycles from intentionally-tolerated ones.
+
+The PRD requires this as goal G3 and acceptance criterion AC-6, and the repo owner pre-locked the rule on 2026-05-13: `bootstrap_resolved: true` cycles never trip the failure gate (formalized in [ADR-0006](0006-fail-on-buildrequires-cycle-input.md)).
+
+## Decision Drivers
+
+- **Match the build system's effective view.** A cycle whose every node is pre-staged is, by construction, not a build-order problem.
+- **Branch sensitivity.** `data/builder-pkg-preq.json` differs per branch. The check must use the same branch checkout that produced the graph.
+- **Failure mode safety.** If the pre-stage list is missing or unparseable, default to the conservative classification (`bootstrap_resolved: false`) so that real cycles do not slip through.
+- **No false negatives on partial overlap.** A cycle where *most* members are pre-staged but one is not is still actionable; classification must be strict ("every member").
+
+## Considered Options
+
+### Option 1: Ignore pre-staging entirely
+
+Treat every cycle as equally actionable.
+
+**Pros:** Simplest classification rule.
+**Cons:** Floods the run summary with intentional cycles. A maintainer who adds an entry to `builder-pkg-preq.json` would see no behaviour change in the cycle report.
+
+### Option 2: Heuristic — mark cycle bootstrap-resolved if *any* member is pre-staged
+
+**Pros:** Catches more cycles as tolerated.
+**Cons:** Wrong. A single pre-staged node does not break a cycle: the others still need each other built first. Produces false negatives.
+
+### Option 3 (Chosen): Strict — bootstrap-resolved iff *every* SCC member is in `data/builder-pkg-preq.json`
+
+For each non-trivial SCC, read `data/builder-pkg-preq.json` from the same branch checkout. If every node in the SCC (by package name match) appears in the pre-stage list, mark the SCC — and every representative cycle in it — `bootstrap_resolved: true`. Otherwise `false`.
+
+**Pros:**
+- Faithful to the build system's actual behaviour.
+- Conservative: strictly fewer cycles are tolerated than would be by Option 2.
+- Updates automatically as `builder-pkg-preq.json` evolves — exactly the feedback loop the 2026-05-12 maintainer's amendment depended on.
+
+**Cons:**
+- Requires resolving package names between the graph nodes (which carry `name` plus optional sub-package suffix like `libselinux-python3`) and the pre-stage list (which references binary RPM names). Sub-package handling is captured in the feature spec.
+
+## Decision
+
+- The cycle pass reads `data/builder-pkg-preq.json` from the branch's sparse checkout. The schema is currently a flat list of package names; the pass tolerates structural variation (treats missing keys or empty lists as "no pre-staged packages").
+- An SCC is `bootstrap_resolved: true` iff *every* member's name (or its base-package name, for sub-packages of a pre-staged source) appears in the pre-stage set. Any member outside the set → `bootstrap_resolved: false`.
+- A cycle inherits `bootstrap_resolved` from its containing SCC.
+- `cycle_summary.bootstrap_resolved` and `cycle_summary.unresolved` count cycles, not SCCs, and partition the total.
+- If `data/builder-pkg-preq.json` is missing, unreadable, or fails to parse, the pass logs a warning to the step summary and defaults every SCC to `bootstrap_resolved: false`.
+- Sub-package name resolution: a graph node named `libselinux-python3` whose source RPM is `libselinux` is considered pre-staged if `libselinux` is in the list. Mapping is derived from `nodes[i].repo` (which already carries the `.spec` path).
+
+## Consequences
+
+- The 2026-05-12 amendment to `builder-pkg-preq.json` (libselinux/libsepol) immediately flips any residual libselinux ↔ python3 SCC from `unresolved` to `bootstrap_resolved` on the next scan — which is the intended end state for AC-1.
+- A maintainer can shift the workflow's attention by editing `builder-pkg-preq.json`. The cycle pass is a passive reader: every classification decision lives upstream in that file.
+- If a future Photon branch restructures the pre-stage list (e.g. moves it into a different file or adds nested structure), this ADR's defaulting rule keeps the workflow running while a follow-up ADR captures the new format.
+- The feature spec ([`../features/cycle-detection.md`](../features/cycle-detection.md)) is the authoritative reference for the sub-package name-resolution logic.

--- a/tdnf-depgraph/specs/adr/0006-fail-on-buildrequires-cycle-input.md
+++ b/tdnf-depgraph/specs/adr/0006-fail-on-buildrequires-cycle-input.md
@@ -1,0 +1,76 @@
+# ADR-0006: `fail_on_buildrequires_cycle` Workflow Input
+
+**Date**: 2026-05-13
+**Status**: Accepted
+
+## Context
+
+The cycle pass produces structured cycle output regardless of whether any cycle was found. The remaining question is: *when should the existence of cycles cause the workflow run itself to fail?*
+
+Two extremes:
+
+- Always fail when any cycle is found. Disruptive when scans run on schedule against the entire history of branches; would have failed every run between the workflow's deployment and the 2026-05-12 amendment, because `libselinux ↔ python3` was a real cycle and an intentional one (resolved by curated pre-staging — see [ADR-0005](0005-bootstrap-resolved-classification.md)).
+- Never fail. The cycle report stays informational; consumers must read the step summary or parse the artifact to act.
+
+The repo owner pre-locked the policy on 2026-05-13: the gate exists, defaults off, and `bootstrap_resolved: true` cycles never trip it. The point of this ADR is to specify the exact semantics so the implementer of T5 has no room to interpret.
+
+## Decision Drivers
+
+- **No surprise failures on the scheduled scan.** The existing weekly scan must continue to pass green for branches with curated, bootstrap-resolved cycles.
+- **Opt-in gating at PR-review time.** When the workflow is dispatched against a PR-style scenario, the operator wants the option of failing fast on a newly-introduced unresolved cycle.
+- **Bootstrap-resolved cycles do not fail.** Pre-locked decision. The point of `data/builder-pkg-preq.json` is that those cycles are accepted.
+- **Single, deterministic predicate.** No "warning" tier; no mixed pass/fail outcomes.
+
+## Considered Options
+
+### Option 1: Always fail on any cycle
+
+**Cons:** Breaks the scheduled scan against branches with curated `builder-pkg-preq.json` entries. Rejected.
+
+### Option 2: Always fail only on unresolved `buildrequires` cycles, no input
+
+**Pros:** Strong signal.
+**Cons:** Same scheduled-scan disruption when a transient cycle appears between a spec change and a `builder-pkg-preq.json` update. Removes the operator's ability to silence the gate during a known-broken window. Rejected.
+
+### Option 3 (Chosen): Workflow input, default `false`, applies only to unresolved buildrequires cycles
+
+A new boolean input `fail_on_buildrequires_cycle` is added to the workflow. When `true`, the job exits non-zero iff at least one cycle has both `category == "buildrequires"` and `bootstrap_resolved == false`. When `false` (default), the job always exits zero on completion — cycle status is reported but not enforced.
+
+**Pros:**
+- Defaults off — zero behaviour change for existing consumers.
+- Operator can flip the gate per-dispatch via the GitHub Actions UI without a code change.
+- Strictly aligned with the pre-locked rule.
+
+**Cons:**
+- A long-lived `fail_on_buildrequires_cycle: true` cron run would be disrupted by transient cycles. Mitigation: do not enable it on the scheduled trigger; reserve it for explicit dispatches.
+
+## Decision
+
+- Add to `.github/workflows/depgraph-scan.yml` under `workflow_dispatch.inputs`:
+  ```yaml
+  fail_on_buildrequires_cycle:
+    description: 'Fail the run if any unresolved buildrequires cycle is detected'
+    type: boolean
+    default: false
+  ```
+- After all artifacts are produced and the step summary is written, evaluate:
+  ```python
+  unresolved_br = [
+      c for c in all_cycles_across_files
+      if c["category"] == "buildrequires"
+      and not c["bootstrap_resolved"]
+  ]
+  if fail_on_buildrequires_cycle and unresolved_br:
+      sys.exit(1)
+  ```
+- The check explicitly *aggregates across (branch, flavor)*: a single unresolved cycle on any one scanned flavor fails the job.
+- `category: "mixed"` cycles are out of scope for this gate. A mixed cycle by definition contains at least one runtime edge in addition to buildrequires; the buildrequires-only portion is not necessarily a build-order problem and the gate stays conservative. A future ADR may revisit this if mixed cycles prove actionable.
+- `category: "requires"` and `category: "self-loop"` cycles never fail the gate.
+- The scheduled (`cron`) trigger does not set `fail_on_buildrequires_cycle`; it inherits the default `false`. Operators must explicitly opt in via `workflow_dispatch`.
+
+## Consequences
+
+- T5 (in the Phase 5 task breakdown) implements this input plus the exit-code logic.
+- The `cycle_summary` object emitted per file (per [ADR-0004](0004-schema-v2-additive.md)) includes both `bootstrap_resolved` and `unresolved` counters; consumers can replicate the gate's logic if they need to.
+- A maintainer who genuinely wants the gate on the scheduled scan would either flip the cron-triggered default or open a follow-up ADR — neither is in scope here.
+- If `category: "mixed"` cycles turn out to be a frequent actionable class, this ADR is superseded by a follow-up that broadens the gate predicate.


### PR DESCRIPTION
## Summary

Phase 3 of the cycle-detection initiative for `tdnf-depgraph/`. Six bundled ADRs covering every architectural decision implied by the PRD ([#69](https://github.com/dcasota/photonos-scripts/pull/69)).

| ADR | Decision |
|---|---|
| [0001](tdnf-depgraph/specs/adr/0001-cycle-detection-in-python-postprocess.md) | Detect cycles in a Python post-step, not in the C extension. |
| [0002](tdnf-depgraph/specs/adr/0002-subrelease-overlay-flavors.md) | Scan each `SPECS/[0-9]+/` as an overlay flavor (`SPECS/` + `SPECS/<N>/`, same-name wins). Dynamic discovery. |
| [0003](tdnf-depgraph/specs/adr/0003-tarjan-scc-plus-representative.md) | Tarjan SCC + one shortest representative cycle per SCC via BFS. Deterministic tie-breaks. |
| [0004](tdnf-depgraph/specs/adr/0004-schema-v2-additive.md) | Bump `metadata.schema_version` 1 → 2. Purely additive; every v1 key preserved. |
| [0005](tdnf-depgraph/specs/adr/0005-bootstrap-resolved-classification.md) | `bootstrap_resolved` iff every SCC member is in `data/builder-pkg-preq.json`. |
| [0006](tdnf-depgraph/specs/adr/0006-fail-on-buildrequires-cycle-input.md) | New `fail_on_buildrequires_cycle` workflow input (default `false`); only `bootstrap_resolved: false` BR cycles trip the gate. |

`ARCHITECTURE.md` also gains a *Cycle Detection Pipeline* section linking every ADR, and the Open Initiatives table is refreshed (phases 0/1/3 complete).

## Phase gating

This PR is the gate for Phase 4 (feature specs: `cycle-detection.md` schema/algorithm reference + `subrelease-flavors.md` overlay/filename rules).

## Test plan

- [x] All six ADRs follow the project's existing ADR template (Date, Status, Context, Decision Drivers, Considered Options, Decision, Consequences).
- [x] Cross-references between ADRs resolve (0003 → 0005, 0004 → 0001, 0005 → 0006).
- [x] No code paths touched; this PR is documentation-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)