### PR TITLE
tdnf-depgraph phase-1b task 018: amend PRD AC-1 + task 016 per finding

### DIFF
--- a/tdnf-depgraph/specs/findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md
+++ b/tdnf-depgraph/specs/findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md
@@ -1,6 +1,6 @@
 # Finding 2026-05-13: libselinux ↔ python3 is not a graph-level cycle
 
-**Status**: Open — affects PRD AC-1 and task 016
+**Status**: Addressed — PRD v1.1 and task 016 amended on 2026-05-13. New open question Q4 opened in the PRD for the separate spec-source-coupling initiative.
 **Discovered while implementing**: [task 012 (cycle engine)](../tasks/012-task-cycle-engine.md)
 **Affects**: [prd.md §6 AC-1](../prd.md), [tasks/016-task-regression-fixture.md](../tasks/016-task-regression-fixture.md)
 
@@ -53,15 +53,18 @@ The spec-level "loop" the Photon team identified — *"to build libselinux you n
 2. **Task 016 (regression fixture)** as written cannot be satisfied; the unit test it specifies would fail on the real 2026-05-11 data.
 3. **Task 012's "AC-1 hook" acceptance criterion** is similarly unmet. Every other criterion in task 012 (AC-2 determinism, AC-5 schema, empty/self-loop/mixed cases, sub-package resolution, iterative-Tarjan depth) passes.
 
-## Recommended follow-up
+## Resolution (2026-05-13)
 
-A new SDD phase ("Phase 2 — Dev Lead review continued, post-implementation finding") should:
+PR `sdd/depgraph-phase-1b-amend-ac1` amended the PRD to v1.1 and rewrote task 016:
 
-1. Amend the PRD: rewrite AC-1 to anchor on a cycle that **does** exist in the fixture. Candidates:
-   - **cyc-010** `python3-attrs ↔ python3-pytest` (buildrequires, length 2) — small, clear, illustrates the buildrequires class.
-   - **cyc-002** the 37-node toolchain SCC — illustrates the typical "expected to be bootstrap_resolved once preq is loaded" case.
-2. Amend task 016's acceptance test to check for the chosen cycle. Once the real `data/builder-pkg-preq.json` is loaded into the test, assert that the toolchain SCC becomes `bootstrap_resolved: true` and the python3-attrs/pytest cycle (if not pre-staged) becomes the actionable signal.
-3. Open a separate finding/initiative: **does the C extension need to propagate source-level BuildRequires to subpackages?** If the answer is yes, a future extension would surface the libselinux ↔ python3 coupling as a real graph cycle. If no, this finding documents the limitation explicitly.
+1. **PRD AC-1 rewritten** to anchor on `path_names == ["python3-attrs", "python3-pytest", "python3-attrs"]` (the lone buildrequires cycle, length 2, `bootstrap_resolved: false`) plus a structural assertion that the fixture produces exactly 12 SCCs, one of size 37 containing `python3`, `gcc`, `bash`, `cmake`, `openssl`.
+2. **PRD G1 success metric rewritten** to match.
+3. **PRD G3 success metric rewritten** to anchor on the 37-node toolchain SCC flipping to `bootstrap_resolved: true` once the branch's real `builder-pkg-preq.json` loads — replacing the (incorrect) claim about a libselinux ↔ python3 SCC.
+4. **PRD G4 v1-key list corrected** to `metadata.{generator, timestamp, branch}` (the keys the C extension actually emits) rather than the aspirational `branch`/`specsdir`/`generated_at` of v1.0.
+5. **Task 016 rewritten** with three concrete test cases: `python3-attrs ↔ python3-pytest` cycle presence, structural 12-SCCs / one-size-37 assertion, and the bootstrap-resolved flip on the toolchain SCC.
+6. **New PRD Open Question Q4**: should the C `tdnf-depgraph` extension propagate source-level `BuildRequires` to subpackages, so that spec-source-couplings (like the original libselinux ↔ python3 incident) surface as graph cycles? Recommendation: separate initiative, its own PRD.
+
+This finding remains in `specs/findings/` as the empirical record of why the v1.0 PRD's AC-1 could not be satisfied.
 
 ## Pointer
 

--- a/tdnf-depgraph/specs/prd.md
+++ b/tdnf-depgraph/specs/prd.md
@@ -2,9 +2,9 @@
 
 ## tdnf-depgraph — Cycle Detection & Sub-Release Flavors
 
-**Version**: 1.0
+**Version**: 1.1
 **Last Updated**: 2026-05-13
-**Status**: Draft — Phase 1
+**Status**: Accepted — Active (amended 2026-05-13 per [findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md](findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md))
 
 ---
 
@@ -12,18 +12,18 @@
 
 The *Dependency Graph Scan* workflow exports an RPM dependency graph for every Photon OS branch and commits it to `tdnf-depgraph/scans/`. The graph captures `Requires`, `BuildRequires`, and `Conflicts` edges over every spec and binary node, and is consumed by downstream initiatives (Snyk classifier, package report, gating-conflict detector, the PQC QUBO formulation in `upstream-source-code-dependency-scanner`).
 
-The graph contains everything needed to detect circular dependencies between packages — but the workflow itself never analyses it. On 2026-04-15 the Photon team identified a build-time loop, `libselinux ↔ python3`: `libselinux.spec` carried a `python3` sub-package, which required `python3` to be already built, while `python3-pip` / `python3-setuptools` / `python3-devel` build-required `libselinux`. The fix landed on `vmware/photon@8fb8549c` on 2026-05-12, splitting the python3 bindings into a separate `libselinux-python3.spec` and adding `libselinux`/`libsepol` to `data/builder-pkg-preq.json` so the bootstrap can pre-stage them.
+The graph contains everything needed to detect circular dependencies between packages — but the workflow itself never analyses it. The motivating incident is the `libselinux ↔ python3` build-time coupling that landed as `vmware/photon@8fb8549c` on 2026-05-12: `libselinux.spec` carried a `python3` sub-package, while `libselinux` build-required `python3-pip` / `python3-setuptools` / `python3-devel`. The fix split the python3 bindings into a separate `libselinux-python3.spec` and added `libselinux`/`libsepol` to `data/builder-pkg-preq.json` so the bootstrap can pre-stage them.
 
-The latest *Dependency Graph Scan* run prior to the fix (`25661049895`, 2026-05-11 09:10 UTC) emitted a graph whose edges encode exactly this cycle:
+> **Note (amended 2026-05-13).** The libselinux ↔ python3 coupling is a **spec-source-coupling**, not a graph-level cycle. The C extension records `BuildRequires` against source-package nodes only and does not propagate them to subpackages, so the coupling does not surface as a directed SCC in the exported binary-package edge graph. See [findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md](findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md) for the empirical analysis. Acceptance criteria below are anchored on cycles that **do** exist in the 2026-05-11 master fixture; whether to extend the C extension to propagate source-level BuildRequires to subpackages is a separate initiative.
+
+The latest *Dependency Graph Scan* run prior to the fix (`25661049895`, 2026-05-11 09:10 UTC) emitted a graph that, when analysed by the cycle engine, contains **twelve** strongly-connected components. The most concrete actionable cycle is:
 
 ```
-libselinux (id 1155) --buildrequires--> python3-pip       (466)
-libselinux (id 1155) --buildrequires--> python3-setuptools(462)
-libselinux (id 1155) --buildrequires--> python3-devel     (458)
-libselinux-python3   (1158) --requires--> libselinux       (1155)
+python3-attrs (id …) --buildrequires--> python3-pytest
+python3-pytest        --buildrequires--> python3-attrs
 ```
 
-The cycle was present in the data, ~27 hours before the manual fix, but the workflow neither flagged it in the Actions summary nor failed the run. The same gap will hide the next cycle.
+The largest entanglement is a 37-node toolchain SCC (`autogen, bash, cmake, curl, gcc, openssl, python3, readline, tcl, util-linux, …`) which is expected to flip to `bootstrap_resolved: true` once the branch's `data/builder-pkg-preq.json` is loaded.
 
 This PRD specifies adding **cycle detection** to the artifact, and — as a prerequisite — **first-class sub-release flavors** so that Photon 5.0's `SPECS/`, `SPECS/90`, `SPECS/91`, `SPECS/92` overlays are scanned independently rather than collapsed into a single "5.0" graph.
 
@@ -40,7 +40,7 @@ This PRD specifies adding **cycle detection** to the artifact, and — as a prer
 - Augment the existing artifact JSON schema additively: bump `metadata.schema_version` 1 → 2; add `sccs[]`, `cycles[]`, `cycle_summary{}`, and `metadata.flavor`. All v1 keys preserved.
 - Optional fail-on-cycle gate: a new workflow input `fail_on_buildrequires_cycle` (default `false`). When `true`, the job exits non-zero if any `bootstrap_resolved: false` `buildrequires` cycle is found.
 - Update the GitHub Actions step summary table to surface cycle counts per (branch, flavor), plus a fenced block listing up to the first ten representative cycles per scan.
-- Regression coverage on the 2026-05-11 master snapshot to prove the detector finds the documented libselinux ↔ python3 cycle.
+- Regression coverage on the 2026-05-11 master snapshot to prove the detector finds the cycles documented in this PRD (specifically `python3-attrs ↔ python3-pytest` for the actionable buildrequires class, and the 37-node toolchain SCC for the `bootstrap_resolved` transition once the real `builder-pkg-preq.json` loads).
 
 ### Out of Scope
 
@@ -69,7 +69,7 @@ This PRD specifies adding **cycle detection** to the artifact, and — as a prer
 
 Every JSON the workflow emits has a `cycles[]` array and a `cycle_summary{}` counter. If the input graph is acyclic, both are empty / zero. If it contains cycles, every non-trivial SCC contributes at least one representative cycle.
 
-**Success metric:** Re-running the detector on the saved 2026-05-11 master JSON produces a cycle entry whose `path_names` contains both `libselinux` and a `python3-*` node, `category: "buildrequires"`, `bootstrap_resolved: false`.
+**Success metric:** Re-running the detector on the saved 2026-05-11 master JSON produces a cycle entry with `path_names == ["python3-attrs", "python3-pytest", "python3-attrs"]`, `category: "buildrequires"`, `length: 2`, and (with empty preq) `bootstrap_resolved: false`. The same scan also yields a 37-member SCC whose members include `python3`, `gcc`, `bash`, `cmake`, `openssl`.
 
 ### G2 — First-class sub-release flavors
 
@@ -79,13 +79,13 @@ The workflow discovers `SPECS/[0-9]+/` overlay directories after sparse-checkout
 
 ### G3 — Distinguish actionable from bootstrap-resolved cycles
 
-Every cycle carries a `bootstrap_resolved` boolean derived from the branch's `data/builder-pkg-preq.json`. Cycles where every member is pre-staged are reported but never trip `fail_on_buildrequires_cycle`. The 2026-05-12 amendment to `builder-pkg-preq.json` (libselinux/libsepol) is the canonical example: post-fix, any residual `libselinux ↔ python3` cycle becomes `bootstrap_resolved: true` and falls below the action threshold.
+Every cycle carries a `bootstrap_resolved` boolean derived from the branch's `data/builder-pkg-preq.json`. Cycles where every member is pre-staged are reported but never trip `fail_on_buildrequires_cycle`. The toolchain SCC (37 members: gcc, openssl, python3, bash, cmake, …) is the canonical example: every member is part of the bootstrap pre-stage list, so the SCC reports `bootstrap_resolved: true` and falls below the action threshold.
 
-**Success metric:** On a post-fix master scan, the libselinux ↔ python3 SCC — if any edges still exist — is reported with `bootstrap_resolved: true` and excluded from the `unresolved` summary counter.
+**Success metric:** On the 2026-05-11 master scan with the branch's real `data/builder-pkg-preq.json` loaded, the 37-node toolchain SCC reports `bootstrap_resolved: true` and is excluded from the `unresolved` summary counter. The `python3-attrs ↔ python3-pytest` cycle remains `bootstrap_resolved: false` (those packages are not in the bootstrap pre-stage list).
 
 ### G4 — Backwards-compatible artifact schema
 
-`metadata.schema_version` bumps from 1 to 2. All v1 keys (`metadata.{branch,specsdir,generated_at}`, `node_count`, `edge_count`, `nodes`, `edges`) are preserved unchanged. Consumers branch on `schema_version` to opt into the new fields.
+`metadata.schema_version` bumps from 1 to 2. All v1 keys (`metadata.{generator,timestamp,branch}`, `node_count`, `edge_count`, `nodes`, `edges`) are preserved unchanged. Consumers branch on `schema_version` to opt into the new fields. *(Amended 2026-05-13: the v1 metadata keys are `generator` / `timestamp` / `branch` as actually emitted by the C extension, not `branch` / `specsdir` / `generated_at` as the v1.0 draft asserted; the engine preserves whatever v1 keys are present.)*
 
 **Success metric:** Downstream consumers `gating-conflict-detection`, `package-classifier`, `snyk-analysis`, and `upstream-source-code-dependency-scanner` continue to parse v2 JSONs without modification.
 
@@ -113,7 +113,7 @@ The cycle-detection initiative is complete when all of the following hold:
 
 | # | Criterion | Verifier |
 |---|-----------|----------|
-| AC-1 | Regression scan on `vmware/photon` at the 2026-05-11 commit produces a cycle whose `path_names` contains both `libselinux` and a `python3-*` node, with `category: "buildrequires"` and `bootstrap_resolved: false`. | `specs/tasks/0001-task-cycles-post-step.md` T6 |
+| AC-1 | Regression scan on `tdnf-depgraph/scans/dependency-graph-master-20260511_091039.json` produces a cycle with `path_names == ["python3-attrs", "python3-pytest", "python3-attrs"]`, `category: "buildrequires"`, `length: 2`, and (with empty preq) `bootstrap_resolved: false`. The same scan also produces exactly 12 SCCs, one of which has size 37 and includes the names `python3`, `gcc`, `bash`, `cmake`, `openssl`. *(Amended 2026-05-13: original AC-1 anchored on `libselinux ↔ python3` which is a spec-source coupling, not a graph cycle — see [findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md](findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md).)* | `specs/tasks/016-task-regression-fixture.md` |
 | AC-2 | Re-running the detector on the same input JSON twice produces byte-identical `cycles[]` and `sccs[]` arrays (deterministic ordering). | T1 unit test |
 | AC-3 | Workflow_dispatch on Photon 5.0 produces four artifact files: `dependency-graph-5.0-<datetime>.json` (base) and `dependency-graph-5.0-{90,91,92}-<datetime>.json` (overlays). | T3 |
 | AC-4 | Workflow_dispatch on Photon 3.0/4.0/6.0/common/master/dev produces files whose names are unchanged from v1 (`dependency-graph-<branch>-<datetime>.json`). | T3 |
@@ -149,16 +149,25 @@ Decisions agreed before ADR drafting; ADRs in Phase 3 document the rationale:
 
 ### Open questions for Dev Lead review
 
-- **Q1.** Should the 2026-05-11 snapshot live permanently as `tdnf-depgraph/tests/fixtures/` for ongoing regression coverage, or be rebuilt on demand? Recommendation: check in (small file, anchors AC-1).
-- **Q2.** When a non-trivial SCC has only `requires` edges (runtime cycle, no build-time edges), should we still emit a `cycles[]` entry with `category: "requires"`? Recommendation: yes — informational, no failure impact.
-- **Q3.** Should `metadata.flavor` be `""` or `null` for the base scan (no overlay)? Recommendation: `""` for consistent string typing.
+- **Q1.** Should the 2026-05-11 snapshot live permanently as `tdnf-depgraph/tests/fixtures/` for ongoing regression coverage, or be rebuilt on demand? Recommendation: check in (small file, anchors AC-1). *(Resolved 2026-05-13: yes — task 016 checks it in.)*
+- **Q2.** When a non-trivial SCC has only `requires` edges (runtime cycle, no build-time edges), should we still emit a `cycles[]` entry with `category: "requires"`? Recommendation: yes — informational, no failure impact. *(Resolved 2026-05-13: yes — engine in task 012 emits them; see cyc-001/004/005/006-009/011/012 on the master fixture.)*
+- **Q3.** Should `metadata.flavor` be `""` or `null` for the base scan (no overlay)? Recommendation: `""` for consistent string typing. *(Resolved 2026-05-13: `""` — implemented in task 012's engine.)*
+- **Q4 (new, opened 2026-05-13 by finding).** Should the C `tdnf-depgraph` extension propagate source-level `BuildRequires` from a `.spec` to its subpackages, so that spec-source-couplings (like the libselinux ↔ python3 incident) surface as graph cycles? Recommendation: separate initiative — its own PRD. Not in scope for the current cycle-detection work.
 
 ---
 
 ## 9. References
 
-- Photon commit fixing the libselinux ↔ python3 loop: `vmware/photon@8fb8549c`
-- The workflow run that captured the cycle in data but didn't flag it: [`actions/runs/25661049895`](https://github.com/dcasota/photonos-scripts/actions/runs/25661049895)
+- Motivating Photon commit (`libselinux ↔ python3` spec-source coupling fix): `vmware/photon@8fb8549c`
+- The workflow run that captured the source-level edges but didn't flag any graph cycle: [`actions/runs/25661049895`](https://github.com/dcasota/photonos-scripts/actions/runs/25661049895)
 - Workflow source: [`.github/workflows/depgraph-scan.yml`](../../.github/workflows/depgraph-scan.yml)
 - Subproject architecture: [`../ARCHITECTURE.md`](../ARCHITECTURE.md)
+- Empirical finding amending AC-1: [`findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md`](findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md)
 - Related SDD initiatives following the same pattern: [`../../upstream-source-code-dependency-scanner/specs/prd.md`](../../upstream-source-code-dependency-scanner/specs/prd.md), [`../../vCenter-CVE-drift-analyzer/specs/prd.md`](../../vCenter-CVE-drift-analyzer/specs/prd.md)
+
+---
+
+## Changelog
+
+- **1.1 (2026-05-13)** — AC-1 and G1/G3 success metrics re-anchored on cycles that exist in the binary-package edge graph (`python3-attrs ↔ python3-pytest` for the actionable buildrequires class; 37-node toolchain SCC for the `bootstrap_resolved` transition). Q1–Q3 resolved. New Q4 opened: should the C extension propagate source-level `BuildRequires` to subpackages? G4 v1-key list corrected (`generator`/`timestamp`/`branch`, not `branch`/`specsdir`/`generated_at` — the engine preserves whatever v1 keys are present regardless). See [`findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md`](findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md).
+- **1.0 (2026-05-13)** — Initial draft.

--- a/tdnf-depgraph/specs/tasks/016-task-regression-fixture.md
+++ b/tdnf-depgraph/specs/tasks/016-task-regression-fixture.md
@@ -3,57 +3,95 @@
 **Complexity**: Low
 **Dependencies**: [012](012-task-cycle-engine.md)
 **Status**: Pending
-**Requirement**: PRD AC-1
+**Requirement**: PRD AC-1 (amended 2026-05-13, v1.1)
 **ADR**: N/A (testing infrastructure)
+
+> **Amended 2026-05-13** per [`../findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md`](../findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md). The original acceptance test anchored on a `libselinux ↔ python3` cycle that does not exist as a graph-level SCC in the fixture. Replaced with a `python3-attrs ↔ python3-pytest` anchor (the lone buildrequires cycle on the master fixture) plus a structural assertion on the 37-node toolchain SCC.
 
 ---
 
 ## Description
 
-Check in the pre-fix `vmware/photon` master dependency-graph JSON from 2026-05-11 (workflow run [`25661049895`](https://github.com/dcasota/photonos-scripts/actions/runs/25661049895)) as a permanent regression fixture. Add a unit test that runs the cycle engine on this fixture and asserts the presence of the libselinux ↔ python3 cycle.
+Check in the 2026-05-11 `vmware/photon` master dependency-graph JSON (workflow run [`25661049895`](https://github.com/dcasota/photonos-scripts/actions/runs/25661049895)) as a permanent regression fixture. Add unit tests that run the cycle engine on this fixture and assert the cycles documented in PRD AC-1 v1.1.
 
 This task answers PRD §8 Open Question Q1 affirmatively: check in the fixture.
 
 ## Scope
 
-- New file: `tdnf-depgraph/tests/fixtures/dependency-graph-master-20260511_091039.v1.json`. The byte-identical content downloaded from the run's `dependency-graphs` artifact.
-- New file: `tdnf-depgraph/tests/fixtures/builder-pkg-preq.20260511.json`. The `data/builder-pkg-preq.json` content from `vmware/photon@<commit-of-2026-05-11>` *before* the libselinux/libsepol amendment. This is what makes AC-1 produce `bootstrap_resolved: false` — without it, the post-fix amendment masks the cycle.
-- New test case in `tdnf-depgraph/tests/test_depgraph_cycles.py`:
+- New file: `tdnf-depgraph/tests/fixtures/dependency-graph-master-20260511_091039.v1.json`. The byte-identical content currently sitting at `tdnf-depgraph/scans/dependency-graph-master-20260511_091039.json` *as of the pre-task-012 master tree* — that is, the v1 JSON, before any cycle pass has run. (A copy is needed because the production `scans/` location is the workflow's write target; tests must not depend on the live commit-back state.)
+- New file: `tdnf-depgraph/tests/fixtures/builder-pkg-preq.20260511.json`. The `data/builder-pkg-preq.json` content from `vmware/photon@<commit-of-2026-05-11>`. Used to verify the `bootstrap_resolved: true` flip on the 37-node toolchain SCC (G3 success metric).
+- New test class in `tdnf-depgraph/tests/test_depgraph_cycles.py`:
   ```python
-  def test_libselinux_python3_cycle_2026_05_11(self):
-      out = run_cycles_pass(
-          input="tests/fixtures/dependency-graph-master-20260511_091039.v1.json",
-          preq="tests/fixtures/builder-pkg-preq.20260511.json",
-      )
-      cycles = out["cycles"]
-      assert any(
-          c["category"] == "buildrequires"
-          and not c["bootstrap_resolved"]
-          and "libselinux" in c["path_names"]
-          and any(n.startswith("python3") for n in c["path_names"])
-          for c in cycles
-      )
+  class TestRegression20260511(unittest.TestCase):
+      FIXTURE = "tests/fixtures/dependency-graph-master-20260511_091039.v1.json"
+      PREQ    = "tests/fixtures/builder-pkg-preq.20260511.json"
+
+      def test_python3_attrs_pytest_buildrequires_cycle(self):
+          """AC-1 anchor: the lone buildrequires cycle on the master fixture."""
+          out = run_pass(self.FIXTURE, preq=None)
+          cycles = out["cycles"]
+          self.assertTrue(any(
+              c["category"] == "buildrequires"
+              and c["length"] == 2
+              and not c["bootstrap_resolved"]
+              and c["path_names"] == [
+                  "python3-attrs", "python3-pytest", "python3-attrs"
+              ]
+              for c in cycles
+          ), f"expected python3-attrs <-> python3-pytest buildrequires cycle; "
+             f"got cycles: {[c['path_names'] for c in cycles]}")
+
+      def test_twelve_sccs_one_of_size_37(self):
+          """AC-1 structural anchor: 12 SCCs, one toolchain SCC of size 37."""
+          out = run_pass(self.FIXTURE, preq=None)
+          self.assertEqual(len(out["sccs"]), 12)
+          big = [s for s in out["sccs"] if s["size"] == 37]
+          self.assertEqual(len(big), 1)
+          names = set(big[0]["names"])
+          for required in {"python3", "gcc", "bash", "cmake", "openssl"}:
+              self.assertIn(required, names)
+
+      def test_toolchain_scc_bootstrap_resolved_with_preq(self):
+          """G3 success metric: with the real preq file, the 37-node toolchain
+          SCC flips to bootstrap_resolved: true, while python3-attrs/pytest
+          remains unresolved (those packages are not in builder-pkg-preq.json)."""
+          out = run_pass(self.FIXTURE, preq=self.PREQ)
+          toolchain = next(s for s in out["sccs"] if s["size"] == 37)
+          self.assertTrue(toolchain["bootstrap_resolved"])
+          attrs_pytest = next(
+              c for c in out["cycles"]
+              if c["path_names"] == [
+                  "python3-attrs", "python3-pytest", "python3-attrs"
+              ]
+          )
+          self.assertFalse(attrs_pytest["bootstrap_resolved"])
   ```
+
+  `run_pass(fixture, preq=None)` is a thin wrapper around
+  `depgraph_cycles.run(input_path, preq_path, flavor="", specsdir_meta="SPECS")`
+  that resolves fixture paths relative to the test file.
 
 ## Implementation Notes
 
-- The fixture file is ~660 KB; well within reasonable repository size limits.
-- The pre-fix `builder-pkg-preq.json` must be sourced from the commit on `vmware/photon` master that was current on 2026-05-11 (not today's tip). A short header comment in the fixture identifies the source commit.
+- The dependency-graph fixture file is ~660 KB; well within reasonable repository size limits.
+- The pre-fix `builder-pkg-preq.json` must be sourced from the commit on `vmware/photon` master that was current on 2026-05-11 (not today's tip). A short header comment in the fixture file identifies the source commit SHA.
 - Both fixtures live under `tests/fixtures/` to keep them out of any `scans/`-targeted glob in downstream workflows.
-- The unit test must not depend on network access or on `vmware/photon` cloning — it reads only the checked-in fixtures.
+- The unit tests must not depend on network access or on `vmware/photon` cloning — they read only the checked-in fixtures.
+- The fixture is **frozen in time**: it anchors the cycle engine's behaviour at the 2026-05-11 master state. It will not be refreshed when later master scans land. This is by design — the test guarantees the engine continues to find the same 12 SCCs on the same input forever.
 
 ## Acceptance Criteria
 
-- [ ] **AC-1.** Running `python3 -m unittest tdnf-depgraph.tests.test_depgraph_cycles.TestRegression.test_libselinux_python3_cycle_2026_05_11` passes.
-- [ ] The fixture file is byte-identical to the artifact downloaded from run 25661049895. SHA-256 recorded in a comment at the top of the test.
-- [ ] The pre-fix `builder-pkg-preq.json` is documented in the file header with its source commit SHA.
-- [ ] The test asserts both presence of `libselinux` and presence of at least one `python3*` node in the same cycle's `path_names`.
+- [ ] **AC-1 (v1.1).** All three tests in `TestRegression20260511` pass: `python3-attrs ↔ python3-pytest` buildrequires cycle is present and `bootstrap_resolved: false` without preq; `len(sccs) == 12` and one SCC has size 37 with the required toolchain members.
+- [ ] **G3 success metric.** With the real preq file, the 37-node toolchain SCC reports `bootstrap_resolved: true`; the python3-attrs/pytest cycle remains `bootstrap_resolved: false`.
+- [ ] The dependency-graph fixture file is byte-identical to the v1 content of `tdnf-depgraph/scans/dependency-graph-master-20260511_091039.json` at the master commit immediately preceding task 012. SHA-256 recorded in the test file's docstring.
+- [ ] The pre-fix `builder-pkg-preq.json` fixture is documented at the top of the file with its source commit SHA.
 
 ## Testing Requirements
 
-- [ ] CI runs the regression test on every PR touching `tdnf-depgraph/tools/depgraph_cycles.py` or `tdnf-depgraph/tests/`.
+- [ ] CI runs the regression tests on every PR touching `tdnf-depgraph/tools/depgraph_cycles.py` or `tdnf-depgraph/tests/`.
 
 ## Out of Scope
 
 - Regression fixtures for branches other than master.
-- Periodic refresh of the fixture (it is anchored to a specific historic state — the libselinux ↔ python3 incident — by design).
+- Periodic refresh of the fixture (frozen by design).
+- Surfacing the `libselinux ↔ python3` spec-source coupling as a graph cycle. Tracked separately by PRD §8 Q4 (whether the C extension should propagate source-level `BuildRequires` to subpackages).


### PR DESCRIPTION
## Summary

Follow-up to [PR #73 (task 012)](https://github.com/dcasota/photonos-scripts/pull/73). Aligns the spec set with what the cycle engine actually finds on the 2026-05-11 master fixture, per `specs/findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md`.

The original v1.0 PRD asserted that the libselinux ↔ python3 loop named in `vmware/photon@8fb8549c` would surface as a graph cycle in the artifact. Empirically it does not — the C extension records `BuildRequires` against source-package nodes only and does not propagate to subpackages, so the coupling exists at the spec-source level but is not a directed SCC.

## PRD v1.1 changes

- **AC-1** re-anchored on `path_names == ["python3-attrs", "python3-pytest", "python3-attrs"]` (the lone buildrequires cycle on the master fixture, length 2) + structural check on the 12-SCC count and the 37-node toolchain SCC.
- **G1 success metric** matches AC-1.
- **G3 success metric** rewritten to anchor on the toolchain SCC flipping `bootstrap_resolved: true` once the branch's real `data/builder-pkg-preq.json` loads.
- **G4 v1-key list** corrected to `metadata.{generator, timestamp, branch}` (what the C extension actually emits) — replaces the aspirational `branch`/`specsdir`/`generated_at`.
- **Q1–Q3** marked Resolved. **New Q4** opened: should the C extension propagate source-level `BuildRequires` to subpackages? Separate initiative.
- **Changelog** section added.
- **Status** updated: Draft → Accepted — Active.

## Task 016 changes

Three concrete test cases replace the (unsatisfiable) libselinux/python3 assertion:

```python
test_python3_attrs_pytest_buildrequires_cycle    # AC-1 anchor
test_twelve_sccs_one_of_size_37                   # AC-1 structural
test_toolchain_scc_bootstrap_resolved_with_preq   # G3 anchor
```

libselinux/python3 graph-cycle question moved to Out of Scope with a pointer to PRD Q4.

## Finding marked Addressed

Resolution section appended to `specs/findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md` enumerating the six PRD/task changes this PR makes. Finding stays in `specs/findings/` as the empirical record.

## Phase gating

This PR unblocks task 013 (workflow flavor matrix) and the rest of Phase 6 — task implementation no longer references stale acceptance criteria. No code touched.

## Test plan

- [x] PRD renders correctly; internal links resolve.
- [x] Task 016 test snippet refers to symbols that exist in `tdnf-depgraph/tools/depgraph_cycles.py` (`depgraph_cycles.run`).
- [x] Finding doc status flipped to *Addressed*; resolution enumerates this PR's six changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)