### PR TITLE
tdnf-depgraph phase-6 task 013-fix: portable flavor discovery

### DIFF
--- a/.github/workflows/depgraph-scan.yml
+++ b/.github/workflows/depgraph-scan.yml
@@ -182,11 +182,19 @@ jobs:
             # Discover sub-release flavors per FRD-subrelease-flavors §2.1:
             # base (empty token) + each SPECS/[0-9]+/ subdir found.
             # Per ADR-0002 the list is dynamic -- no hardcoded 90/91/92.
+            # Use a pure-bash glob instead of `find -regex -printf`: the
+            # self-hosted runner ships a toybox/bfs `find` that rejects
+            # GNU-style -regex (`find: bad arg '.*/SPECS/[0-9]+'`).
             FLAVORS=("")
-            mapfile -t -O 1 FLAVORS < <(
-              find "${CLONE_DIR}/SPECS" -maxdepth 1 -mindepth 1 -type d \
-                   -regex '.*/SPECS/[0-9]+' -printf '%f\n' | sort
+            mapfile -t _NUMERIC < <(
+              shopt -s nullglob
+              for _entry in "${CLONE_DIR}/SPECS"/*/; do
+                _name="${_entry%/}"; _name="${_name##*/}"
+                [[ "$_name" =~ ^[0-9]+$ ]] && printf '%s\n' "$_name"
+              done | sort
             )
+            FLAVORS+=("${_NUMERIC[@]}")
+            unset _NUMERIC
             echo "  Flavors: [${FLAVORS[*]}]  (${#FLAVORS[@]} total)"
 
             for FLAVOR in "${FLAVORS[@]}"; do

--- a/tdnf-depgraph/specs/features/subrelease-flavors.md
+++ b/tdnf-depgraph/specs/features/subrelease-flavors.md
@@ -34,12 +34,21 @@ See PRD acceptance criteria AC-3 and AC-4. In brief:
 After the branch's sparse checkout completes (the existing `git sparse-checkout set SPECS` step), enumerate flavors as follows:
 
 ```bash
-FLAVORS=("")     # element 1: empty token = base scan
-mapfile -t -O 1 FLAVORS < <(
-  find "${CLONE_DIR}/SPECS" -maxdepth 1 -mindepth 1 -type d \
-       -regex '.*/SPECS/[0-9]+' -printf '%f\n' | sort
+FLAVORS=("")     # element 0: empty token = base scan
+mapfile -t _NUMERIC < <(
+  shopt -s nullglob
+  for _entry in "${CLONE_DIR}/SPECS"/*/; do
+    _name="${_entry%/}"; _name="${_name##*/}"
+    [[ "$_name" =~ ^[0-9]+$ ]] && printf '%s\n' "$_name"
+  done | sort
 )
+FLAVORS+=("${_NUMERIC[@]}")
+unset _NUMERIC
 ```
+
+Pure bash + `shopt -s nullglob`: the `find -regex`/`-printf` form is a GNU
+extension and not portable to the toybox/bfs `find` shipped on the self-hosted
+runner (see [finding 2026-05-13b](../findings/2026-05-13-find-regex-portability.md)).
 
 Result examples:
 

--- a/tdnf-depgraph/specs/findings/2026-05-13-find-regex-portability.md
+++ b/tdnf-depgraph/specs/findings/2026-05-13-find-regex-portability.md
@@ -1,0 +1,88 @@
+# Finding 2026-05-13b: `find -regex/-printf` not portable on self-hosted runner
+
+**Status**: Addressed — fix landed on `sdd/depgraph-phase-6-task013-fix-flavor-discovery`.
+**Discovered while verifying**: [task 013 (workflow flavor matrix)](../tasks/013-task-workflow-flavor-matrix.md), AC-3 verification on workflow run `25772831806` (2026-05-13).
+**Affects**: [tasks/013-task-workflow-flavor-matrix.md](../tasks/013-task-workflow-flavor-matrix.md), [features/subrelease-flavors.md](../features/subrelease-flavors.md) §2.1.
+
+## Summary
+
+The first cut of task 013 used GNU-style `find -regex … -printf '%f\n'` to enumerate `SPECS/[0-9]+/` overlay directories. On the self-hosted runner this produced
+
+```
+find: bad arg '.*/SPECS/[0-9]+'
+```
+
+so the `mapfile` body returned zero rows and `FLAVORS` stayed at its base-only initialisation `("")`. The job completed with conclusion `success` (the failing command's exit status was swallowed inside the `< <( … )` process substitution), but emitted only **one** artifact (`dependency-graph-5.0-<datetime>.json`) instead of the four required by PRD AC-3.
+
+## Root cause
+
+`/usr/bin/find` and `/bin/find` on the runner are symlinks into `toybox` (and `bfs` as the secondary). Neither implementation accepts the GNU-`find` extensions `-regex` and `-printf` in combination — `-regex` is parsed as an unknown flag and rejected with `bad arg`. The published recipe in FRD-subrelease-flavors §2.1 v1 assumed GNU `find`, which is not part of the runner image.
+
+## Symptom on the failing run
+
+From the `Clone vmware/photon branches and generate dependency graphs` step of run `25772831806`:
+
+```
+find: bad arg '.*/SPECS/[0-9]+'
+  Flavors: []  (1 total)
+  - Flavor -: 1622 specs -> dependency-graph-5.0-20260513_024825.json
+```
+
+Process substitution's failure does not abort `set -e`, so the job kept running and committed the single base artifact to `tdnf-depgraph/scans/`.
+
+## Resolution
+
+Replace the GNU-specific call with a portable pure-bash glob:
+
+```bash
+FLAVORS=("")
+mapfile -t _NUMERIC < <(
+  shopt -s nullglob
+  for _entry in "${CLONE_DIR}/SPECS"/*/; do
+    _name="${_entry%/}"; _name="${_name##*/}"
+    [[ "$_name" =~ ^[0-9]+$ ]] && printf '%s\n' "$_name"
+  done | sort
+)
+FLAVORS+=("${_NUMERIC[@]}")
+unset _NUMERIC
+```
+
+Properties:
+
+1. Only relies on `bash` (already required by every other step in the workflow) and POSIX `sort`.
+2. `shopt -s nullglob` keeps the loop body silent when no entry matches `*/`.
+3. The `[[ … =~ ^[0-9]+$ ]]` test excludes non-numeric subdirs (`kernel/`, `glibc/`, `01-special/`).
+4. Output is sorted ascending, preserving the deterministic ordering contract from [FRD-cycle-detection §2.5](../features/cycle-detection.md).
+
+## Test evidence
+
+Local smoke test with a synthetic `SPECS/{90,91,92,abc,kernel,01-special,README}` tree:
+
+```
+Flavors discovered: [ 90 91 92]  (4 total)
+PASS
+```
+
+Local smoke test with a base-only tree (no numeric subdirs, mimics `master`/`common`/`3.0`/`4.0`/`6.0`):
+
+```
+Count: 1
+Contents: []        # element 0 = empty string (base)
+PASS: base-only branch preserved
+```
+
+## Specs updated alongside this finding
+
+- `tdnf-depgraph/specs/tasks/013-task-workflow-flavor-matrix.md` — Status note + scope recipe replaced.
+- `tdnf-depgraph/specs/features/subrelease-flavors.md` — §2.1 recipe replaced + portability rationale added.
+- `.github/workflows/depgraph-scan.yml` — discovery snippet at lines 185-196 replaced.
+
+## Follow-up
+
+AC-3 must be re-verified after this fix lands. The verification command is unchanged:
+
+```
+gh workflow run depgraph-scan.yml --repo dcasota/photonos-scripts --field branches=5.0
+```
+
+Expected artifacts on the run: four files matching `dependency-graph-5.0[-90|-91|-92|]-<datetime>.json`.

--- a/tdnf-depgraph/specs/tasks/013-task-workflow-flavor-matrix.md
+++ b/tdnf-depgraph/specs/tasks/013-task-workflow-flavor-matrix.md
@@ -2,7 +2,7 @@
 
 **Complexity**: Medium
 **Dependencies**: [012](012-task-cycle-engine.md)
-**Status**: Complete
+**Status**: Complete (with fix-up: see [finding 2026-05-13b](../findings/2026-05-13-find-regex-portability.md))
 **Requirement**: PRD G2 (AC-3, AC-4)
 **Feature**: [FRD-subrelease-flavors](../features/subrelease-flavors.md)
 **ADR**: [ADR-0002](../adr/0002-subrelease-overlay-flavors.md)
@@ -16,13 +16,17 @@ Extend `.github/workflows/depgraph-scan.yml` so that, per branch, the workflow d
 ## Scope
 
 - Modify `.github/workflows/depgraph-scan.yml` (the active workflow at the repo root).
-- After the existing `git sparse-checkout set SPECS` step, enumerate flavors per [FRD-subrelease-flavors §2.1](../features/subrelease-flavors.md):
+- After the existing `git sparse-checkout set SPECS` step, enumerate flavors per [FRD-subrelease-flavors §2.1](../features/subrelease-flavors.md). The published recipe uses a portable pure-bash glob — `find -regex`/`-printf` are GNU extensions and were rejected by the self-hosted runner's `find` (see [finding 2026-05-13b](../findings/2026-05-13-find-regex-portability.md)):
   ```bash
   FLAVORS=("")
-  mapfile -t -O 1 FLAVORS < <(
-    find "${CLONE_DIR}/SPECS" -maxdepth 1 -mindepth 1 -type d \
-         -regex '.*/SPECS/[0-9]+' -printf '%f\n' | sort
+  mapfile -t _NUMERIC < <(
+    shopt -s nullglob
+    for _entry in "${CLONE_DIR}/SPECS"/*/; do
+      _name="${_entry%/}"; _name="${_name##*/}"
+      [[ "$_name" =~ ^[0-9]+$ ]] && printf '%s\n' "$_name"
+    done | sort
   )
+  FLAVORS+=("${_NUMERIC[@]}")
   ```
 - Wrap the existing per-branch body in an inner `for FLAVOR in "${FLAVORS[@]}"` loop per [FRD-subrelease-flavors §2.4](../features/subrelease-flavors.md).
 - Assemble the overlay per [§2.2](../features/subrelease-flavors.md) for numeric flavors only; base flavor uses `SPECS/` directly.


### PR DESCRIPTION
## Summary

- Run [25772831806](https://github.com/dcasota/photonos-scripts/actions/runs/25772831806) verified AC-3 failed: the 5.0 dispatch produced 1 artifact instead of 4. Root cause: the self-hosted runner's `find` (toybox/bfs) does not accept GNU `-regex` + `-printf`, so the flavor discovery silently collapsed to `FLAVORS=("")`.
- Replace the call with a pure-bash glob + `[[ =~ ^[0-9]+$ ]]` filter (same deterministic sort, same FLAVORS contract).
- Update SDD specs to match: `tasks/013`, `features/subrelease-flavors.md §2.1`, plus a new finding `findings/2026-05-13-find-regex-portability.md` documenting the root cause and evidence.

## What changed

| File | Change |
|---|---|
| `.github/workflows/depgraph-scan.yml` | Lines 185-196 — replaced `find -regex … -printf` with bash glob + regex test |
| `tdnf-depgraph/specs/tasks/013-task-workflow-flavor-matrix.md` | Status note + Scope recipe replaced |
| `tdnf-depgraph/specs/features/subrelease-flavors.md` | §2.1 recipe replaced + portability rationale |
| `tdnf-depgraph/specs/findings/2026-05-13-find-regex-portability.md` | New — finding doc |

## Test plan

- [x] Local smoke test on synthetic `SPECS/{90,91,92,abc,kernel,01-special,README}` → `FLAVORS == ("" "90" "91" "92")`.
- [x] Local smoke test on numeric-free `SPECS/{kernel,glibc,openssl}` → `FLAVORS == ("")` (base preserved).
- [ ] Post-merge: `workflow_dispatch branches=5.0` → expect 4 artifacts (`dependency-graph-5.0[-90|-91|-92|]-<datetime>.json`) — this verifies PRD AC-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)