### PR TITLE
tdnf-depgraph phase-1c task 019: amend AC-3 per finding (no upstream SPECS/92)

### DIFF
--- a/tdnf-depgraph/specs/adr/0002-subrelease-overlay-flavors.md
+++ b/tdnf-depgraph/specs/adr/0002-subrelease-overlay-flavors.md
@@ -1,11 +1,11 @@
 # ADR-0002: Sub-Release Overlay Flavors
 
 **Date**: 2026-05-13
-**Status**: Accepted
+**Status**: Accepted (amended 2026-05-13 per [findings/2026-05-13-find-regex-portability.md](../findings/2026-05-13-find-regex-portability.md) and [findings/2026-05-13-upstream-no-spec92.md](../findings/2026-05-13-upstream-no-spec92.md))
 
 ## Context
 
-Photon 5.0's `vmware/photon` checkout contains a top-level `SPECS/` tree and additional sub-release directories `SPECS/90/`, `SPECS/91/`, `SPECS/92/`. The latter hold per-flavor overrides — most commonly the kernel and kernel-adjacent specs — while everything else comes from the base `SPECS/` tree. The 2026-05-12 fix at `vmware/photon@8fb8549c` was applied to *both* `SPECS/libselinux/libselinux.spec` *and* `SPECS/91/libselinux/libselinux.spec` because each flavor is built independently from its own merged view.
+Photon 5.0's `vmware/photon` checkout contains a top-level `SPECS/` tree and additional sub-release directories under it. As of 2026-05-13 those are `SPECS/90/` and `SPECS/91/` only; the original v1 draft of this ADR also listed `SPECS/92/`, but empirical verification (run `25795445195`, plus the GitHub Contents API on `vmware/photon@5.0`) confirmed no `SPECS/92/` exists today — see [findings/2026-05-13-upstream-no-spec92.md](../findings/2026-05-13-upstream-no-spec92.md). The sub-release directories hold per-flavor overrides — most commonly the kernel and kernel-adjacent specs — while everything else comes from the base `SPECS/` tree. The 2026-05-12 fix at `vmware/photon@8fb8549c` was applied to *both* `SPECS/libselinux/libselinux.spec` *and* `SPECS/91/libselinux/libselinux.spec` because each flavor is built independently from its own merged view.
 
 Today's *Dependency Graph Scan* emits a single graph per branch by pointing `tdnf depgraph --setopt specsdir=` at `SPECS/`. Sub-release content is therefore ignored: scans of 5.0 do not see what builds for 5.0.91 actually depend on. The PRD requires per-flavor visibility (G2) so that flavor-specific cycles do not hide behind the base view.
 
@@ -14,7 +14,7 @@ The question is not whether to scan sub-releases — it is what *flavor* means w
 ## Decision Drivers
 
 - **Match build reality.** When the Photon build system constructs a 5.0.91 image, it composes `SPECS/` with `SPECS/91/` on top. The graph we emit for the `91` flavor should reflect what is actually built.
-- **Discoverability.** The sub-release directory layout is conventional but not centrally declared. Hardcoding `90/91/92` will silently misbehave when 6.0 or `dev` grow their own sub-releases.
+- **Discoverability.** The sub-release directory layout is conventional but not centrally declared. Hardcoding a flavor list will silently misbehave when upstream adds, removes, or renames sub-releases — and demonstrably did mislead earlier drafts of this PRD into asserting that `SPECS/92` existed when it does not.
 - **Stability of consumer contracts.** Downstream consumers parse filenames; the existing per-branch filenames must not change for branches that have no sub-releases.
 
 ## Considered Options
@@ -51,7 +51,7 @@ Maintain a JSON file (or workflow input) enumerating the flavors per branch.
 For each (branch, flavor) pair:
 
 1. Sparse-checkout `SPECS/` from the target branch.
-2. Discover flavors dynamically: `find SPECS -maxdepth 1 -mindepth 1 -type d -regex 'SPECS/[0-9]+' -printf '%f\n' | sort`.
+2. Discover flavors dynamically with a portable bash glob — iterate `SPECS/*/`, keep basenames matching `^[0-9]+$`, sort. (The v1 draft of this ADR prescribed `find -regex … -printf`, but those are GNU-find extensions that the self-hosted runner's `find` rejects with `bad arg`; see [findings/2026-05-13-find-regex-portability.md](../findings/2026-05-13-find-regex-portability.md). The canonical recipe lives in [FRD-subrelease-flavors §2.1](../features/subrelease-flavors.md).)
 3. For the empty (base) flavor, run `tdnf depgraph --setopt specsdir=SPECS`.
 4. For each numeric flavor `N`, materialize an overlay at `/tmp/photon-overlay-<branch>-<N>/` by:
    - `cp -a SPECS/. overlay/`
@@ -62,7 +62,7 @@ For each (branch, flavor) pair:
 
 ## Consequences
 
-- Photon 5.0 emits four files per run: base + 90 + 91 + 92. Branches 3.0/4.0/6.0/common/master/dev emit one file each with names unchanged.
+- Photon 5.0 emits `N+1` files per run, where `N` is the number of `SPECS/[0-9]+/` subdirectories present on the cloned upstream HEAD. As of 2026-05-13 that is three files (base + `90` + `91`). Branches 3.0/4.0/6.0/common/master/dev emit one file each with names unchanged.
 - A future Photon 6.0 or `dev` sub-release directory is picked up automatically with no code change.
 - Workflow cleanup must delete `/tmp/photon-overlay-*` between runs; covered as part of the existing `cleanup` step.
 - Consumers that today iterate `tdnf-depgraph/scans/dependency-graph-5.0-*.json` will see new files matching the same glob. They must guard on `metadata.flavor` if they want only the base view. This is documented in the feature spec and the v2 schema notes.

--- a/tdnf-depgraph/specs/features/subrelease-flavors.md
+++ b/tdnf-depgraph/specs/features/subrelease-flavors.md
@@ -11,7 +11,7 @@
 
 ### Purpose
 
-Scan Photon sub-release directories (`SPECS/[0-9]+/` overlays) as first-class flavors. Photon 5.0's `SPECS/90`, `SPECS/91`, `SPECS/92` produce distinct dependency graphs that reflect how the build system actually composes spec trees for each sub-release; the base `SPECS/` continues to produce a single non-flavored scan.
+Scan Photon sub-release directories (`SPECS/[0-9]+/` overlays) as first-class flavors. Photon 5.0's discoverable overlays (today: `SPECS/90` and `SPECS/91`; the original v1 draft also claimed `SPECS/92` but that does not exist upstream — see [findings/2026-05-13-upstream-no-spec92.md](../findings/2026-05-13-upstream-no-spec92.md)) produce distinct dependency graphs that reflect how the build system actually composes spec trees for each sub-release; the base `SPECS/` continues to produce a single non-flavored scan.
 
 ### Value Proposition
 
@@ -21,7 +21,7 @@ Today's single-graph-per-branch model collapses flavor-specific differences. The
 
 See PRD acceptance criteria AC-3 and AC-4. In brief:
 
-- Workflow_dispatch on Photon 5.0 produces four output files (base + 90 + 91 + 92).
+- Workflow_dispatch on Photon 5.0 produces `N+1` output files, where `N` is the count of `SPECS/[0-9]+/` subdirectories on the cloned upstream HEAD. As of 2026-05-13, `N=2` (overlays `90`, `91`) → three files.
 - Workflow_dispatch on Photon 3.0/4.0/6.0/common/master/dev produces output files whose names are unchanged from v1.
 - Adding (or removing) a `SPECS/<N>/` directory on any branch is picked up automatically, with no code change.
 
@@ -52,16 +52,16 @@ runner (see [finding 2026-05-13b](../findings/2026-05-13-find-regex-portability.
 
 Result examples:
 
-| Branch | Discovered `FLAVORS` |
+| Branch (state on 2026-05-13) | Discovered `FLAVORS` |
 |---|---|
-| 5.0 | `("" "90" "91" "92")` |
-| 6.0 | `("")`  *(if no SPECS/[0-9]+ dirs exist today)* |
+| 5.0 | `("" "90" "91")` *(verified by run [25795445195](https://github.com/dcasota/photonos-scripts/actions/runs/25795445195))* |
+| 6.0 | `("")` |
 | 4.0 | `("")` |
 | common | `("")` |
 | master | `("")` |
 | dev | `("")` |
 
-A future Photon 6.0 sub-release directory (say `SPECS/95`) is picked up automatically on the next workflow run. No hardcoded list of numeric tokens exists anywhere in the workflow or in the cycle pass.
+A future Photon 5.0 sub-release directory (say `SPECS/92`) or a 6.0 sub-release is picked up automatically on the next workflow run. No hardcoded list of numeric tokens exists anywhere in the workflow or in the cycle pass.
 
 ### 2.2 Overlay assembly
 
@@ -101,7 +101,7 @@ The `<datetime>` token uses the existing format `YYYYMMDD_HHMMSS` (UTC). The `<b
 | 5.0 | `""` | `dependency-graph-5.0-20260518_030000.json` |
 | 5.0 | `90` | `dependency-graph-5.0-90-20260518_030000.json` |
 | 5.0 | `91` | `dependency-graph-5.0-91-20260518_030000.json` |
-| 5.0 | `92` | `dependency-graph-5.0-92-20260518_030000.json` |
+| 5.0 | `92` *(hypothetical — not currently in upstream)* | `dependency-graph-5.0-92-20260518_030000.json` |
 | master | `""` | `dependency-graph-master-20260518_030000.json` |
 | 6.0 | `""` | `dependency-graph-6.0-20260518_030000.json` |
 

--- a/tdnf-depgraph/specs/findings/2026-05-13-upstream-no-spec92.md
+++ b/tdnf-depgraph/specs/findings/2026-05-13-upstream-no-spec92.md
@@ -1,0 +1,61 @@
+# Finding 2026-05-13c: `vmware/photon@5.0` has no `SPECS/92/` overlay
+
+**Status**: Addressed — PRD v1.2, ADR-0002, FRD-subrelease-flavors, and task 013 amended on 2026-05-13.
+**Discovered while verifying**: AC-3 of [task 013](../tasks/013-task-workflow-flavor-matrix.md) on workflow run [`25795445195`](https://github.com/dcasota/photonos-scripts/actions/runs/25795445195) (2026-05-13, the first run after [finding 2026-05-13b](2026-05-13-find-regex-portability.md) fixed the portable flavor discovery).
+**Affects**: [prd.md](../prd.md) §1 / G2 / AC-3, [adr/0002-subrelease-overlay-flavors.md](../adr/0002-subrelease-overlay-flavors.md), [features/subrelease-flavors.md](../features/subrelease-flavors.md), [tasks/013-task-workflow-flavor-matrix.md](../tasks/013-task-workflow-flavor-matrix.md).
+
+## Summary
+
+PRD v1.0/v1.1 anchored AC-3 on a hardcoded enumeration: workflow_dispatch on Photon 5.0 must produce **four** artifact files — base + `90` + `91` + `92`. After fixing the portable flavor discovery in PR #76, run `25795445195` produced only **three** artifacts:
+
+```
+Flavors: [ 90 91]  (3 total)
+  - Flavor -:  1622 specs -> dependency-graph-5.0-20260513_111151.json
+  - Flavor 90: 1642 specs -> dependency-graph-5.0-90-20260513_111151.json
+  - Flavor 91: 1671 specs -> dependency-graph-5.0-91-20260513_111151.json
+```
+
+Cross-checking with the GitHub Contents API:
+
+```
+$ gh api repos/vmware/photon/contents/SPECS?ref=5.0 \
+    --jq '.[] | select(.type=="dir") | .name' | grep -E '^[0-9]+$' | sort
+90
+91
+```
+
+`SPECS/92` does not exist on `vmware/photon@5.0`. The PRD's "5.0: 90, 91, 92" enumeration was speculative — there is no historical commit on `vmware/photon@5.0` introducing `SPECS/92`, and no upstream announcement of a 5.0.92 sub-release.
+
+The engine and workflow are correct per ADR-0002 (dynamic discovery; no hardcoded flavor list). Only the acceptance criteria — which baked in the wrong upstream-state assumption — needed amendment.
+
+## Resolution
+
+Phase-1c PR amended the following specs in lockstep:
+
+1. **PRD §1 Purpose** — replaced the `"SPECS/90, SPECS/91, SPECS/92"` enumeration with a parenthetical noting today's state (`90`, `91`) and pointing at this finding.
+2. **PRD G2 success metric** — re-anchored on dynamic `N+1` (`N` = count of `SPECS/[0-9]+/` at run time).
+3. **PRD AC-3** — re-anchored on dynamic `N+1`; explicitly recorded today's state (`N=2`, three files) and the verifying run ID. The hardcoded `{90,91,92}` is gone.
+4. **PRD §7 Pre-locked Design Knob #2** — updated the discovery recipe to match the portable bash glob actually used after PR #76, with a cross-reference to [finding 2026-05-13b](2026-05-13-find-regex-portability.md).
+5. **PRD Changelog** — new v1.2 entry.
+6. **ADR-0002 Context** — replaced the `"SPECS/90, SPECS/91, SPECS/92"` enumeration with a description of what's actually present.
+7. **ADR-0002 Decision step 2** — recipe replaced (portable glob).
+8. **ADR-0002 Consequences** — "four files" → "`N+1` files (today: 3)".
+9. **FRD-subrelease-flavors §1 Purpose + §1 Success Criteria** — same dynamic framing.
+10. **FRD-subrelease-flavors §2.1 result table** — today's verified state; `92` listed only as a hypothetical row (annotated as such).
+11. **Task 013 AC-3** — re-anchored on dynamic `N+1`; checked off; cross-referenced this finding.
+
+## Why this approach over alternatives
+
+- **Alternative A: wait for `SPECS/92/` to appear upstream.** Rejected — `vmware/photon` has no announced 5.0.92 milestone; AC-3 could remain red indefinitely with no actionable work.
+- **Alternative B: keep AC-3 as written but mark it "deferred".** Rejected — accepting AC drift conflicts with SDD discipline.
+- **Alternative C (chosen): re-anchor AC-3 on dynamic state.** Aligns AC with the actual design intent of ADR-0002 (dynamic discovery). Re-verifying after upstream changes requires zero spec edits.
+
+## Re-verification
+
+Re-running `workflow_dispatch branches=5.0` after this amendment lands should continue to satisfy the amended AC-3:
+
+```
+gh workflow run depgraph-scan.yml --repo dcasota/photonos-scripts --field branches=5.0
+```
+
+Expected: `N+1` files at run time, with one base file plus one file per `SPECS/[0-9]+/` overlay present on the cloned upstream HEAD. As of 2026-05-13 that is three files.

--- a/tdnf-depgraph/specs/prd.md
+++ b/tdnf-depgraph/specs/prd.md
@@ -2,9 +2,9 @@
 
 ## tdnf-depgraph — Cycle Detection & Sub-Release Flavors
 
-**Version**: 1.1
+**Version**: 1.2
 **Last Updated**: 2026-05-13
-**Status**: Accepted — Active (amended 2026-05-13 per [findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md](findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md))
+**Status**: Accepted — Active (amended 2026-05-13 per [findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md](findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md) and [findings/2026-05-13-upstream-no-spec92.md](findings/2026-05-13-upstream-no-spec92.md))
 
 ---
 
@@ -25,7 +25,7 @@ python3-pytest        --buildrequires--> python3-attrs
 
 The largest entanglement is a 37-node toolchain SCC (`autogen, bash, cmake, curl, gcc, openssl, python3, readline, tcl, util-linux, …`) which is expected to flip to `bootstrap_resolved: true` once the branch's `data/builder-pkg-preq.json` is loaded.
 
-This PRD specifies adding **cycle detection** to the artifact, and — as a prerequisite — **first-class sub-release flavors** so that Photon 5.0's `SPECS/`, `SPECS/90`, `SPECS/91`, `SPECS/92` overlays are scanned independently rather than collapsed into a single "5.0" graph.
+This PRD specifies adding **cycle detection** to the artifact, and — as a prerequisite — **first-class sub-release flavors** so that Photon 5.0's `SPECS/` plus each `SPECS/[0-9]+/` overlay is scanned independently rather than collapsed into a single "5.0" graph. (Today, on `vmware/photon@5.0`, the overlays are `SPECS/90` and `SPECS/91`; the discovery is dynamic so additional overlays such as `SPECS/92` would be picked up automatically if/when they appear — see [findings/2026-05-13-upstream-no-spec92.md](findings/2026-05-13-upstream-no-spec92.md).)
 
 ---
 
@@ -73,9 +73,9 @@ Every JSON the workflow emits has a `cycles[]` array and a `cycle_summary{}` cou
 
 ### G2 — First-class sub-release flavors
 
-The workflow discovers `SPECS/[0-9]+/` overlay directories after sparse-checkout and emits one JSON per (branch, flavor) pair. Discovery is dynamic (no hardcoded `90/91/92`), so when Photon 6.0 or `dev` grow sub-release dirs they pick up automatically.
+The workflow discovers `SPECS/[0-9]+/` overlay directories after sparse-checkout and emits one JSON per (branch, flavor) pair. Discovery is dynamic (no hardcoded flavor list), so when Photon 6.0 or `dev` grow sub-release dirs they pick up automatically.
 
-**Success metric:** A workflow_dispatch on Photon 5.0 produces four artifact files (base + 90 + 91 + 92). Each contains `metadata.flavor` matching its overlay. The base 5.0 file keeps its existing filename `dependency-graph-5.0-<datetime>.json`; non-base flavors gain a `-<flavor>` suffix.
+**Success metric:** A workflow_dispatch on Photon 5.0 produces `N+1` artifact files, where `N` = the number of `SPECS/[0-9]+/` subdirectories present on the cloned `vmware/photon@5.0` HEAD. As of 2026-05-13 `N=2` (overlays: `90`, `91`), yielding three files. Each contains `metadata.flavor` matching its overlay. The base 5.0 file keeps its existing filename `dependency-graph-5.0-<datetime>.json`; non-base flavors gain a `-<flavor>` suffix.
 
 ### G3 — Distinguish actionable from bootstrap-resolved cycles
 
@@ -115,7 +115,7 @@ The cycle-detection initiative is complete when all of the following hold:
 |---|-----------|----------|
 | AC-1 | Regression scan on `tdnf-depgraph/scans/dependency-graph-master-20260511_091039.json` produces a cycle with `path_names == ["python3-attrs", "python3-pytest", "python3-attrs"]`, `category: "buildrequires"`, `length: 2`, and (with empty preq) `bootstrap_resolved: false`. The same scan also produces exactly 12 SCCs, one of which has size 37 and includes the names `python3`, `gcc`, `bash`, `cmake`, `openssl`. *(Amended 2026-05-13: original AC-1 anchored on `libselinux ↔ python3` which is a spec-source coupling, not a graph cycle — see [findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md](findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md).)* | `specs/tasks/016-task-regression-fixture.md` |
 | AC-2 | Re-running the detector on the same input JSON twice produces byte-identical `cycles[]` and `sccs[]` arrays (deterministic ordering). | T1 unit test |
-| AC-3 | Workflow_dispatch on Photon 5.0 produces four artifact files: `dependency-graph-5.0-<datetime>.json` (base) and `dependency-graph-5.0-{90,91,92}-<datetime>.json` (overlays). | T3 |
+| AC-3 | Workflow_dispatch on Photon 5.0 produces `N+1` artifact files, where `N` is the count of `SPECS/[0-9]+/` subdirectories on the cloned `vmware/photon@5.0` HEAD at run time. Filenames: `dependency-graph-5.0-<datetime>.json` (base) + one `dependency-graph-5.0-<flavor>-<datetime>.json` per discovered overlay. *(Today: `N=2`, overlays `{90,91}`, three files — verified by run `25795445195`. Amended 2026-05-13: original AC-3 anchored on a hardcoded `{90,91,92}` enumeration, but upstream has no `SPECS/92/` — see [findings/2026-05-13-upstream-no-spec92.md](findings/2026-05-13-upstream-no-spec92.md). The AC is now state-anchored on whatever upstream actually exposes.)* | T3 |
 | AC-4 | Workflow_dispatch on Photon 3.0/4.0/6.0/common/master/dev produces files whose names are unchanged from v1 (`dependency-graph-<branch>-<datetime>.json`). | T3 |
 | AC-5 | `metadata.schema_version == 2` in every emitted file; every v1 key preserved unchanged in field name and semantics. | T2 |
 | AC-6 | `fail_on_buildrequires_cycle=true` causes the job to exit non-zero when any `bootstrap_resolved: false`, `category: "buildrequires"` cycle exists, and to exit zero otherwise. `bootstrap_resolved: true` cycles never trip the gate. | T5 |
@@ -129,7 +129,7 @@ The cycle-detection initiative is complete when all of the following hold:
 Decisions agreed before ADR drafting; ADRs in Phase 3 document the rationale:
 
 1. **Cycle pass runs in Python, post-process to the C binary's JSON output** — not in the `tdnf depgraph` C extension. Cheaper iteration; the artifact contains everything needed.
-2. **Subrelease scanning uses overlay merge** — for flavor `N`, the spec tree is `SPECS/` with `SPECS/<N>/` files copied on top. Same-name wins. Discovery is dynamic (`find SPECS -maxdepth 1 -mindepth 1 -type d -regex 'SPECS/[0-9]+'`).
+2. **Subrelease scanning uses overlay merge** — for flavor `N`, the spec tree is `SPECS/` with `SPECS/<N>/` files copied on top. Same-name wins. Discovery is dynamic (portable bash glob: iterate `SPECS/*/`, keep entries whose basename matches `^[0-9]+$`). *(The original draft prescribed `find -regex … -printf`; that's a GNU extension the self-hosted runner's `find` rejects — see [findings/2026-05-13-find-regex-portability.md](findings/2026-05-13-find-regex-portability.md).)*
 3. **Cycle algorithm = Tarjan SCC + shortest representative cycle per SCC via BFS** — not Johnson's full enumeration. `scc_size` field tells consumers when the representative is one of many.
 4. **Schema bump 1 → 2 is purely additive.** No v1 field changes name, position, or semantics.
 5. **Filename compatibility.** Unflavored branches keep `dependency-graph-<branch>-<datetime>.json`. Only Photon 5.0's non-base flavors gain a `-<flavor>` suffix. Confirmed by repo owner on 2026-05-13.
@@ -169,5 +169,6 @@ Decisions agreed before ADR drafting; ADRs in Phase 3 document the rationale:
 
 ## Changelog
 
+- **1.2 (2026-05-13)** — AC-3 and the G2 success metric re-anchored on dynamic `N+1` (where `N` is the count of `SPECS/[0-9]+/` subdirs on the cloned upstream HEAD) instead of a hardcoded `{90,91,92}`. The verification run `25795445195` proved the workflow's dynamic discovery is correct, while empirically demonstrating that `vmware/photon@5.0` carries only `SPECS/90` and `SPECS/91` today (no `SPECS/92`). The §1 Purpose statement was updated likewise. ADR-0002 and FRD-subrelease-flavors brought into line. See [`findings/2026-05-13-upstream-no-spec92.md`](findings/2026-05-13-upstream-no-spec92.md).
 - **1.1 (2026-05-13)** — AC-1 and G1/G3 success metrics re-anchored on cycles that exist in the binary-package edge graph (`python3-attrs ↔ python3-pytest` for the actionable buildrequires class; 37-node toolchain SCC for the `bootstrap_resolved` transition). Q1–Q3 resolved. New Q4 opened: should the C extension propagate source-level `BuildRequires` to subpackages? G4 v1-key list corrected (`generator`/`timestamp`/`branch`, not `branch`/`specsdir`/`generated_at` — the engine preserves whatever v1 keys are present regardless). See [`findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md`](findings/2026-05-13-libselinux-python3-not-a-graph-cycle.md).
 - **1.0 (2026-05-13)** — Initial draft.

--- a/tdnf-depgraph/specs/tasks/013-task-workflow-flavor-matrix.md
+++ b/tdnf-depgraph/specs/tasks/013-task-workflow-flavor-matrix.md
@@ -44,11 +44,12 @@ Extend `.github/workflows/depgraph-scan.yml` so that, per branch, the workflow d
 
 ## Acceptance Criteria
 
-- [ ] **AC-3.** Workflow_dispatch on `branches: 5.0` produces four files in the `dependency-graphs` artifact:
-  - `dependency-graph-5.0-<datetime>.json`
+- [x] **AC-3.** Workflow_dispatch on `branches: 5.0` produces `N+1` files in the `dependency-graphs` artifact, where `N` = the count of `SPECS/[0-9]+/` subdirectories on the cloned `vmware/photon@5.0` HEAD. As of 2026-05-13 `N=2` (overlays `90`, `91`), so three files:
+  - `dependency-graph-5.0-<datetime>.json` (base)
   - `dependency-graph-5.0-90-<datetime>.json`
   - `dependency-graph-5.0-91-<datetime>.json`
-  - `dependency-graph-5.0-92-<datetime>.json`
+
+  *Amended 2026-05-13: original AC enumerated a fourth file `dependency-graph-5.0-92-<datetime>.json`; that overlay does not exist in upstream — see [findings/2026-05-13-upstream-no-spec92.md](../findings/2026-05-13-upstream-no-spec92.md). Verified by run [25795445195](https://github.com/dcasota/photonos-scripts/actions/runs/25795445195).*
 - [ ] **AC-4.** Workflow_dispatch on `branches: 3.0,4.0,6.0,common,master,dev` produces six files whose names match the v1 convention (no `-<flavor>-` suffix).
 - [ ] Each emitted file's `metadata.flavor` matches the flavor it represents (`""` for base, numeric string otherwise). *(Set by `--setopt flavor=`; the field will be visible after task 014 lands.)*
 - [ ] `metadata.specsdir` reads `SPECS` for base and `SPECS+SPECS/<F>` for numeric flavors. *(Same caveat as above.)*


### PR DESCRIPTION
## Summary

Re-anchor PRD AC-3 + task 013 AC-3 on **dynamic** `N+1` (where `N` = count of `SPECS/[0-9]+/` subdirs on the cloned upstream HEAD) instead of the hardcoded `{90,91,92}` enumeration in v1.0/v1.1.

Verification run [25795445195](https://github.com/dcasota/photonos-scripts/actions/runs/25795445195) after PR #76 produced **three** artifacts for branch 5.0, not the four AC-3 demanded. Cross-checking the GitHub Contents API confirmed: `vmware/photon@5.0` carries only `SPECS/90` and `SPECS/91` today — `SPECS/92` does not exist upstream. The PRD's "5.0: 90, 91, 92" enumeration was speculative.

Same pattern as the AC-1 amendment in PR #74: the engine and workflow are correct per ADR-0002 (dynamic discovery); only the AC, baked in with a wrong upstream-state assumption, needed amendment.

## What changed

| File | Change |
|---|---|
| `tdnf-depgraph/specs/prd.md` | Bumped to v1.2. §1 Purpose, G2 success metric, AC-3, §7 design-knob #2 recipe, changelog. |
| `tdnf-depgraph/specs/adr/0002-subrelease-overlay-flavors.md` | Status (amended), Context, Decision step 2 (portable recipe), Consequences (`N+1` framing). |
| `tdnf-depgraph/specs/features/subrelease-flavors.md` | §1 Purpose, Success Criteria, §2.1 result table (verified state on 2026-05-13), §2.3 filename example annotated. |
| `tdnf-depgraph/specs/tasks/013-task-workflow-flavor-matrix.md` | AC-3 rewritten + checked off; cross-reference to the new finding. |
| `tdnf-depgraph/specs/findings/2026-05-13-upstream-no-spec92.md` | New finding doc: empirical evidence, alternatives weighed, re-verification recipe. |

## Test plan

- [x] Empirical verification — run `25795445195` produced exactly the 3 artifacts the amended AC-3 now demands.
- [x] Upstream Contents API check — `gh api repos/vmware/photon/contents/SPECS?ref=5.0 --jq '.[]|select(.type=="dir")|.name' | grep -E '^[0-9]+$'` returns `90` and `91` only.
- [ ] No re-run is required for this PR (spec-only amendment).

## Side note

This amendment is purely textual — engine and workflow code is unchanged. The whole AC-3 follow-up (PR #76 + this PR) closed inside a single day with two findings filed for the trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)