### PR TITLE
phase-8 task 086: fix nested paths in parity workflows + flip tracker

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build C binary
         run: |
-          cd repo/photonos-package-report
+          cd repo/photonos-package-report/photonos-package-report
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
           cmake --build build --parallel
           ls -lh build/photonos-package-report
@@ -141,7 +141,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cd repo/photonos-package-report
+          cd repo/photonos-package-report/photonos-package-report
           WDIR="${{ steps.reconstruct.outputs.wdir }}"
           UPSTREAMS="${{ steps.reconstruct.outputs.upstreams }}"
           SCANS="$WDIR/scans"
@@ -173,9 +173,9 @@ jobs:
           SNAP="${{ steps.extract.outputs.dir }}"
           PS_DIR="$SNAP/prn-snapshot"
           C_DIR="${{ steps.c_run.outputs.scans }}"
-          DIFF="repo/photonos-package-report/tools/parity-diff.sh"
-          JNL="repo/photonos-package-report/tools/parity-journal.tsv"
-          APPEND="repo/photonos-package-report/tools/parity-journal-append.sh"
+          DIFF="repo/photonos-package-report/photonos-package-report/tools/parity-diff.sh"
+          JNL="repo/photonos-package-report/photonos-package-report/tools/parity-journal.tsv"
+          APPEND="repo/photonos-package-report/photonos-package-report/tools/parity-journal-append.sh"
           PS_RID="${{ steps.ps_run.outputs.id }}"
           C_RID="${{ github.run_id }}"
 
@@ -233,7 +233,7 @@ jobs:
           cd repo
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add photonos-package-report/tools/parity-journal.tsv
+          git add photonos-package-report/photonos-package-report/tools/parity-journal.tsv
           if git diff --cached --quiet; then
             echo "No journal changes to commit"
           else

--- a/.github/workflows/parity-check.yml
+++ b/.github/workflows/parity-check.yml
@@ -29,9 +29,13 @@ jobs:
         id: gate
         run: |
           set -e
-          JNL="photonos-package-report/tools/parity-journal.tsv"
-          GATE="photonos-package-report/tools/parity-gate.sh"
-          chmod +x "$GATE" || true
+          JNL="photonos-package-report/photonos-package-report/tools/parity-journal.tsv"
+          GATE="photonos-package-report/photonos-package-report/tools/parity-gate.sh"
+          if [ ! -f "$GATE" ]; then
+            echo "::error::parity-gate script missing: $GATE"
+            exit 1
+          fi
+          chmod +x "$GATE"
 
           # Tolerate exit codes for the verdict capture; we want the
           # state/window strings even on a fail verdict.
@@ -43,6 +47,14 @@ jobs:
           window=$(echo "$result"  | awk '{print $3}')
           latest=$(echo "$result"  | awk '{print $4}')
           rows=$(echo "$result"    | awk '{print $5}')
+
+          # Guard against silent-empty captures (e.g. script absent, bad
+          # shell, broken upstream). Without this, an empty $state would
+          # flow through and post a bogus "error" commit status on every PR.
+          if [ -z "$state" ]; then
+            echo "::error::parity-gate produced empty stdout (rc=$rc) — refusing to post bogus status"
+            exit 1
+          fi
 
           {
             echo "state=$state"

--- a/photonos-package-report/photonos-package-report/CLAUDE.md
+++ b/photonos-package-report/photonos-package-report/CLAUDE.md
@@ -63,7 +63,7 @@ while the tool is live.
 | 6e | Heap-sort JDK URLs                                    | done (#64)  |
 | 6f | SHA helpers + cross-branch diff (col 9 wired)         | done (#65)  |
 | 7  | Cluster orchestrator + parallel runspace mirror (`-ThrottleLimit`) | done (#66) |
-| 8  | CI side-by-side parity gate                           | pending     |
+| 8  | CI side-by-side parity gate                           | done (#67)  |
 | 9  | Retirement (PS → staging/legacy/, C-only)             | pending     |
 | M  | Maintainer ops & debug tooling — `docs/maintainer-runbook.md`, `.vscode/` | ongoing |
 


### PR DESCRIPTION
## Summary

Fixes the silent bug that caused PR #67's parity-gate to post a bogus `state=error` commit status with description `parity gate produced unknown state ` (trailing space).

Root cause: the C project lives at `photonos-package-report/photonos-package-report/` (double-nested), but `parity-check.yml` and `package-report-C.yml` referenced `photonos-package-report/tools/...` (single-nested). On the runner the `chmod +x` printed "No such file or directory" (suppressed by `|| true`), the gate-script invocation captured empty stdout (suppressed by `|| rc=$? && rc=0`), and the empty `$state` flowed through to the post-status step, which mapped the empty value to `cs=error`.

## Changes

- `.github/workflows/parity-check.yml`:
  - Correct `$JNL` / `$GATE` paths to the actual double-nested layout.
  - Add fail-loud guard: if the gate script isn't found, the step errors out immediately (no more silent `chmod || true`).
  - Add empty-state guard: if the captured stdout is empty (script absent, shell broken, upstream regression), the step errors instead of posting a bogus commit status.
- `.github/workflows/package-report-C.yml`: correct `cd` targets for build + C-run steps, and the `$DIFF` / `$JNL` / `$APPEND` paths in the parity-diff step, and the `git add` path in the commit-journal step.
- `photonos-package-report/photonos-package-report/CLAUDE.md`: flip the phase-8 row from "pending" to "done (#67)" now that the gate is actually wired correctly.

## Test plan

- [x] YAML syntax check passes for both workflows
- [x] Confirmed no residual single-nested `photonos-package-report/(tools|build|scans)` refs remain in either phase-8 workflow file
- [x] Hardened guards smoke-tested locally:
  - missing-script case → exit 1 with `::error::parity-gate script missing: ...`
  - empty-stdout case   → exit 1 with `::error::parity-gate produced empty stdout (rc=0)`
- [ ] Next PR's parity-check run posts `parity-gate` commit status with non-error state (will verify once this lands)
- [ ] Next successful PS workflow run triggers `package-report-C.yml` and that workflow completes the C build + diff + journal append without path errors (external; observed on the next scheduled Sunday run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)