### PR TITLE
tdnf-depgraph phase-6 task 014: wire cycle engine + step-summary cycles

### DIFF
--- a/.github/workflows/depgraph-scan.yml
+++ b/.github/workflows/depgraph-scan.yml
@@ -61,7 +61,7 @@ jobs:
 
           rc=0
           for pkg in cmake gcc libsolv-devel rpm-devel curl-devel openssl-devel \
-                     sqlite-devel tdnf-devel libxml2-devel gpgme-devel; do
+                     sqlite-devel tdnf-devel libxml2-devel gpgme-devel jq; do
             install_with_fallback "$pkg" || rc=$?
           done
           exit $rc
@@ -157,8 +157,14 @@ jobs:
 
           echo "## Dependency Graph Scan" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Branch | Flavor | Specs | Nodes | Edges | Requires | BuildRequires | Conflicts | File |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|--------|--------|-------|-------|-------|----------|---------------|-----------|------|" >> "$GITHUB_STEP_SUMMARY"
+          # Per FRD-cycle-detection §2.6 (task 014). Edge-type counts
+          # (Requires/BuildRequires/Conflicts) are now derivable from the
+          # v2 artifact JSON; the summary surfaces actionable cycle counts
+          # instead so reviewers see status without opening artifacts.
+          echo "| Branch | Flavor | Specs | Nodes | Edges | Cycles | BR-Cycles | Self-loops | Unresolved | Bootstrap-Resolved | File |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|--------|-------|-------|-------|--------|-----------|------------|------------|--------------------|------|" >> "$GITHUB_STEP_SUMMARY"
+          # Cycle-block accumulator (rendered after the table at end of step).
+          : > /tmp/cycle-blocks.md
 
           for BRANCH in $(echo "$BRANCHES" | tr ',' ' '); do
             SAFE_BRANCH=$(echo "$BRANCH" | tr '/' '-')
@@ -175,7 +181,7 @@ jobs:
 
             if [ ! -d "${CLONE_DIR}/SPECS" ]; then
               echo "  No SPECS/ dir on this branch"
-              echo "| ${BRANCH} | - | 0 | - | - | - | - | - | skipped |" >> "$GITHUB_STEP_SUMMARY"
+              echo "| ${BRANCH} | - | 0 | - | - | - | - | - | - | - | skipped |" >> "$GITHUB_STEP_SUMMARY"
               continue
             fi
 
@@ -228,7 +234,7 @@ jobs:
               echo "  - Flavor ${FLAVOR_LABEL}: ${SPEC_COUNT} specs -> ${FILENAME}"
 
               if [ "$SPEC_COUNT" -eq 0 ]; then
-                echo "| ${BRANCH} | ${FLAVOR_LABEL} | 0 | - | - | - | - | - | skipped |" >> "$GITHUB_STEP_SUMMARY"
+                echo "| ${BRANCH} | ${FLAVOR_LABEL} | 0 | - | - | - | - | - | - | - | skipped |" >> "$GITHUB_STEP_SUMMARY"
                 continue
               fi
 
@@ -245,28 +251,90 @@ jobs:
                 tail -20 "$ERR_LOG"
               }
 
-              # Validate and extract stats
+              # Validate and extract base node/edge counts from the v1 JSON.
               STATS=$(python3 -c "
           import json
-          from collections import Counter
           with open('${OUTPATH}') as f:
               d = json.load(f)
-          c = Counter(e['type'] for e in d['edges'])
-          req = c.get('requires', 0)
-          breq = c.get('buildrequires', 0)
-          conf = c.get('conflicts', 0)
-          print(f\"{d['node_count']} {d['edge_count']} {req} {breq} {conf}\")
+          print(f\"{d['node_count']} {d['edge_count']}\")
           " 2>/dev/null)
 
-              if [ -n "$STATS" ]; then
-                read NODES EDGES REQ BREQ CONF <<< "$STATS"
-                echo "    -> ${NODES} nodes, ${EDGES} edges"
-                echo "| ${BRANCH} | ${FLAVOR_LABEL} | ${SPEC_COUNT} | ${NODES} | ${EDGES} | ${REQ} | ${BREQ} | ${CONF} | \`${FILENAME}\` |" >> "$GITHUB_STEP_SUMMARY"
-              else
+              if [ -z "$STATS" ]; then
                 echo "    -> FAILED to parse output"
-                echo "| ${BRANCH} | ${FLAVOR_LABEL} | ${SPEC_COUNT} | - | - | - | - | - | failed |" >> "$GITHUB_STEP_SUMMARY"
+                echo "| ${BRANCH} | ${FLAVOR_LABEL} | ${SPEC_COUNT} | - | - | - | - | - | - | - | failed |" >> "$GITHUB_STEP_SUMMARY"
                 rm -f "$OUTPATH"
+                continue
               fi
+              read NODES EDGES <<< "$STATS"
+              echo "    -> ${NODES} nodes, ${EDGES} edges"
+
+              # --- Cycle pass (task 014) -------------------------------------
+              # Run depgraph_cycles.py in-place: rewrites the JSON to schema v2
+              # with sccs[], cycles[], cycle_summary{}. The engine is preq-aware:
+              # missing data/builder-pkg-preq.json is logged WARN and treated as
+              # empty (every cycle conservatively classified bootstrap_resolved
+              # = false per ADR-0005). Engine never propagates a non-zero exit
+              # for the empty-graph or missing-preq cases; only argparse or I/O
+              # errors fail. Per task 014 IN: surface those as ::error::
+              # annotations but do NOT fail the job (task 015 owns the gate).
+              PREQ_PATH="${CLONE_DIR}/data/builder-pkg-preq.json"
+              CYCLES_LOG="/tmp/depgraph-cycles-${FILE_TOKEN}.err"
+              CYCLES_OK=1
+              PREQ_ARGS=()
+              [ -f "$PREQ_PATH" ] && PREQ_ARGS=(--preq "$PREQ_PATH")
+              if ! python3 "${GITHUB_WORKSPACE}/tdnf-depgraph/tools/depgraph_cycles.py" \
+                   --input "$OUTPATH" "${PREQ_ARGS[@]}" \
+                   --flavor "$FLAVOR" --specsdir-meta "$SPECSDIR_META" \
+                   2>"$CYCLES_LOG"; then
+                echo "::error::cycle engine failed for ${BRANCH}/${FLAVOR_LABEL}"
+                tail -20 "$CYCLES_LOG" || true
+                CYCLES_OK=0
+              fi
+              # Engine WARNs to stderr if the preq file is missing; promote to
+              # a one-shot workflow annotation per AC of task 014.
+              if grep -q '^WARN: preq file' "$CYCLES_LOG" 2>/dev/null; then
+                echo "::warning::data/builder-pkg-preq.json missing for ${BRANCH}/${FLAVOR_LABEL}; cycles classified conservatively (bootstrap_resolved=false)"
+              fi
+
+              # Parse the engine's one-line stderr summary into table values.
+              CYC="-"; BRC="-"; SLF="-"; UNR="-"; BST="-"
+              SUMMARY_LINE=$(grep '^cyc-engine:' "$CYCLES_LOG" 2>/dev/null | tail -1 || true)
+              if [ -n "$SUMMARY_LINE" ]; then
+                CYC=$(sed -n 's/.* cycles=\([0-9]*\).*/\1/p' <<<"$SUMMARY_LINE")
+                BRC=$(sed -n 's/.* br=\([0-9]*\).*/\1/p'     <<<"$SUMMARY_LINE")
+                SLF=$(sed -n 's/.* self=\([0-9]*\).*/\1/p'   <<<"$SUMMARY_LINE")
+                UNR=$(sed -n 's/.* unresolved=\([0-9]*\).*/\1/p' <<<"$SUMMARY_LINE")
+                BST=$(sed -n 's/.* bootstrap=\([0-9]*\).*/\1/p'  <<<"$SUMMARY_LINE")
+              fi
+              if [ "$CYCLES_OK" = "0" ]; then
+                CYC="?"; BRC="?"; SLF="?"; UNR="?"; BST="?"
+              fi
+              echo "    -> cycles=${CYC} br=${BRC} self=${SLF} unresolved=${UNR} bootstrap=${BST}"
+              echo "| ${BRANCH} | ${FLAVOR_LABEL} | ${SPEC_COUNT} | ${NODES} | ${EDGES} | ${CYC} | ${BRC} | ${SLF} | ${UNR} | ${BST} | \`${FILENAME}\` |" >> "$GITHUB_STEP_SUMMARY"
+
+              # Per-(branch,flavor) representative-cycles block (up to 10).
+              # Path truncation per FRD §2.6: when path_names has more than 9
+              # elements (i.e. cycle length > 8 hops), render as
+              # "first-3 → … → last-2". jq is now a build-deps prerequisite.
+              if [ "$CYCLES_OK" = "1" ] && [ "${CYC:-0}" != "0" ] && [ "$CYC" != "-" ] && [ "$CYC" != "?" ]; then
+                TOTAL=$(jq '.cycles | length' "$OUTPATH")
+                SHOWING=$(( TOTAL < 10 ? TOTAL : 10 ))
+                {
+                  echo ""
+                  echo "#### ${BRANCH} / ${FLAVOR_LABEL} — representative cycles (${TOTAL} found, showing ${SHOWING})"
+                  jq -r '
+                    def fmt_path:
+                      if length > 9 then
+                        (.[0:3] | join(" → ")) + " → … → " + (.[-2:] | join(" → "))
+                      else
+                        join(" → ")
+                      end;
+                    .cycles[:10][]
+                    | "- \(.id) (\(.category), \(if .bootstrap_resolved then "bootstrap-resolved" else "unresolved" end)): \(.path_names | fmt_path)"
+                  ' "$OUTPATH"
+                } >> /tmp/cycle-blocks.md
+              fi
+              # --------------------------------------------------------------
             done
           done
 
@@ -274,6 +342,12 @@ jobs:
           echo "file_count=$FILE_COUNT" >> "$GITHUB_OUTPUT"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Total**: ${FILE_COUNT} graphs generated at ${DATETIME}" >> "$GITHUB_STEP_SUMMARY"
+          # Per FRD §2.6: cycle blocks rendered after the summary table.
+          if [ -s /tmp/cycle-blocks.md ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Representative cycles" >> "$GITHUB_STEP_SUMMARY"
+            cat /tmp/cycle-blocks.md >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload artifacts
         if: steps.generate.outputs.file_count != '0'
@@ -308,4 +382,4 @@ jobs:
 
       - name: Cleanup
         if: always()
-        run: rm -rf tdnf-src /tmp/depgraph-scans /tmp/photon-clone-* /tmp/photon-overlay-*
+        run: rm -rf tdnf-src /tmp/depgraph-scans /tmp/photon-clone-* /tmp/photon-overlay-* /tmp/depgraph-cycles-*.err /tmp/cycle-blocks.md


### PR DESCRIPTION
## Summary

Wire the Python cycle engine from PR #73 (`tools/depgraph_cycles.py`) into the workflow so every artifact JSON is rewritten in place as schema v2 before upload, and surface cycle status in the GitHub Actions step summary per [FRD-cycle-detection §2.6](../tdnf-depgraph/specs/features/cycle-detection.md).

- Replaces the `Requires | BuildRequires | Conflicts` columns with `Cycles | BR-Cycles | Self-loops | Unresolved | Bootstrap-Resolved` — the edge-type counts remain trivially derivable from the v2 JSON, and reviewers care about cycle counts.
- After the table, appends one block per (branch, flavor) listing up to 10 representative cycles. Paths > 8 hops truncate as `first-3 → … → last-2`.
- Missing `data/builder-pkg-preq.json` → single `::warning::` annotation + conservative bootstrap classification (every cycle reported `unresolved`) per [ADR-0005](../tdnf-depgraph/specs/adr/0005-bootstrap-resolved-classification.md).
- Cycle-engine I/O / argparse errors → `::error::` annotation, but **job does not fail** — the fail-on-cycle gate is task 015's scope.
- Adds `jq` to the runner install list for the cycle-block renderer.

## What changed

| File | Change |
|---|---|
| `.github/workflows/depgraph-scan.yml` | (1) `jq` added to install list; (2) summary table header swapped; (3) skipped/failed rows widened to 11 columns; (4) cycle pass inserted after `tdnf depgraph`; (5) `cyc-engine:` summary parsed into table values; (6) per-(branch,flavor) jq-rendered cycle blocks accumulated to `/tmp/cycle-blocks.md` and appended after the table; (7) Cleanup step extended. |

## Test plan

- [x] Local smoke test against the committed 2026-05-11 master fixture:
  - Engine rewrites in place to `schema_version=2`.
  - `cyc-engine: branch=master flavor= sccs=12 cycles=12 br=1 self=0 unresolved=12 bootstrap=0`.
  - jq block produces the FRD-spec'd lines, including the actionable `python3-attrs ↔ python3-pytest` buildrequires cycle.
- [ ] Post-merge: `workflow_dispatch branches=5.0` to verify AC-5 (every emitted JSON has `metadata.schema_version == 2`) and AC-7 (step summary table + cycle block visible on the run page).

## Acceptance criteria mapped

- **AC-5** (every JSON `schema_version == 2`) → engine rewrites in place; will verify by inspecting any post-merge artifact.
- **AC-7** (step summary + cycle blocks) → new header, new row format, cycle block accumulator; will verify on the post-merge run.
- **Empty case** → `cycles=0` row, no cycle block (gated by `[ "$CYC" != "0" ]`).
- **Truncation** → jq `if length > 9` branch; unit-tested by inspection on the 8-hop toolchain SCC (rendered full) — a synthetic 10-hop case will be added in task 016.
- **Missing preq** → grep-based detection; one annotation per affected pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)