### PR TITLE
tdnf-depgraph phase-6 task 014-fix: correct depgraph_cycles.py path

### DIFF
--- a/.github/workflows/depgraph-scan.yml
+++ b/.github/workflows/depgraph-scan.yml
@@ -282,7 +282,11 @@ jobs:
               CYCLES_OK=1
               PREQ_ARGS=()
               [ -f "$PREQ_PATH" ] && PREQ_ARGS=(--preq "$PREQ_PATH")
-              if ! python3 "${GITHUB_WORKSPACE}/tdnf-depgraph/tools/depgraph_cycles.py" \
+              # The workflow's sparse checkout puts tdnf-depgraph at ci/ (see
+              # the "Checkout CI tooling (sparse)" step). $GITHUB_WORKSPACE's
+              # root has no tdnf-depgraph/ directly -- run 25797494578
+              # failed with "No such file or directory" by using that path.
+              if ! python3 ci/tdnf-depgraph/tools/depgraph_cycles.py \
                    --input "$OUTPATH" "${PREQ_ARGS[@]}" \
                    --flavor "$FLAVOR" --specsdir-meta "$SPECSDIR_META" \
                    2>"$CYCLES_LOG"; then


### PR DESCRIPTION
## Summary

Run [25797494578](https://github.com/dcasota/photonos-scripts/actions/runs/25797494578) verified the task 014 wiring but failed on every per-flavor cycle pass:

\`\`\`
python3: can't open file
'/root/actions-runner/_work/photonos-scripts/photonos-scripts/tdnf-depgraph/tools/depgraph_cycles.py':
[Errno 2] No such file or directory
\`\`\`

Root cause: the workflow's sparse-checkout step (\`Checkout CI tooling (sparse)\`) places the subproject at \`\$GITHUB_WORKSPACE/ci/tdnf-depgraph/\`, not at \`\$GITHUB_WORKSPACE/tdnf-depgraph/\` as the task 014 commit assumed. Existing references on lines 77 and 97 already use the \`ci/\` prefix correctly; only the new cycle-pass invocation got it wrong.

One-line fix: swap to \`ci/tdnf-depgraph/tools/depgraph_cycles.py\` — same convention as the rest of the workflow.

## Test plan

- [ ] Post-merge: re-run \`workflow_dispatch branches=5.0\`. Expect each artifact to have \`metadata.schema_version == 2\` (AC-5), the step-summary table to populate numeric cycle counts (not \`?\`), and the cycle-block section to render per-(branch,flavor) (AC-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)