### PR TITLE
tdnf-depgraph phase-6 task 015: fail_on_buildrequires_cycle gate

### DIFF
--- a/.github/workflows/depgraph-scan.yml
+++ b/.github/workflows/depgraph-scan.yml
@@ -6,8 +6,14 @@ on:
       branches:
         description: 'Photon OS branches to scan (comma-separated)'
         default: '3.0,4.0,5.0,6.0,common,master,dev'
+      fail_on_buildrequires_cycle:
+        description: 'Fail the run if any unresolved buildrequires cycle is detected'
+        type: boolean
+        default: false
   schedule:
-    # Weekly scan on Monday at 03:00 UTC
+    # Weekly scan on Monday at 03:00 UTC. The cron trigger never sets the
+    # fail_on_buildrequires_cycle input, so the scheduled scan stays in
+    # observational mode regardless of cycle status.
     - cron: '0 3 * * 1'
 
 jobs:
@@ -383,6 +389,37 @@ jobs:
             git pull --rebase origin master
             git push
           fi
+
+      # Fail-on-cycle gate per task 015 / ADR-0006. Runs AFTER Upload +
+      # Commit so the artifacts (the evidence behind the failure) are
+      # preserved even on a red run, and BEFORE Cleanup so /tmp/depgraph-scans
+      # is still intact. Aggregates across every emitted (branch, flavor)
+      # JSON; only `category=="buildrequires" && bootstrap_resolved==false`
+      # cycles trip the gate (mixed/requires/self-loop never fail it,
+      # bootstrap_resolved=true cycles never fail it).
+      - name: Fail on unresolved buildrequires cycle (gate)
+        if: github.event.inputs.fail_on_buildrequires_cycle == 'true' && steps.generate.outputs.file_count != '0'
+        run: |
+          UNRESOLVED_BR=$(jq -s '
+            [ .[] | .cycles[] |
+              select(.category == "buildrequires" and .bootstrap_resolved == false) ]
+            | length' /tmp/depgraph-scans/*.json)
+          echo "Unresolved buildrequires cycles across all (branch, flavor): ${UNRESOLVED_BR}"
+          if [ "${UNRESOLVED_BR:-0}" -gt 0 ]; then
+            # Surface the first few offending cycles so the reviewer sees
+            # the cause in the Actions UI without opening the summary or
+            # downloading the artifact.
+            jq -s -r '
+              [ .[] | .cycles[] |
+                select(.category == "buildrequires" and .bootstrap_resolved == false)
+                | {id, scc_id, length, path: (.path_names | join(" → "))} ]
+              | .[0:5][]
+              | "  - \(.id) (scc=\(.scc_id), len=\(.length)): \(.path)"
+            ' /tmp/depgraph-scans/*.json
+            echo "::error::Found ${UNRESOLVED_BR} unresolved buildrequires cycle(s); failing per fail_on_buildrequires_cycle=true"
+            exit 1
+          fi
+          echo "::notice::No unresolved buildrequires cycles; fail-gate satisfied."
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
## Summary

Add an operator-driven fail gate: a `workflow_dispatch.inputs.fail_on_buildrequires_cycle` boolean (default `false`). When set `true`, a new "Fail on unresolved buildrequires cycle (gate)" step jq-slurps every emitted `/tmp/depgraph-scans/*.json` and counts entries with `category == "buildrequires" && bootstrap_resolved == false`. If the count is > 0, an `::error::` annotation lists up to 5 offending cycles (id, scc, length, path) and the step `exit 1`s.

Per [ADR-0006](../tdnf-depgraph/specs/adr/0006-fail-on-buildrequires-cycle-input.md) and task 015 IN:

- Gate runs **after** artifact upload + scans-commit, so the evidence behind a red run is preserved.
- Gate runs **before** Cleanup so `/tmp/depgraph-scans` is still intact.
- Scheduled cron never sets the input → stays observational by default; no disruption to the weekly Monday 03:00 UTC run.
- `mixed` / `requires` / `self-loop` categories never fail the gate.
- `bootstrap_resolved == true` cycles never fail the gate (informational only).

## What changed

| File | Change |
|---|---|
| `.github/workflows/depgraph-scan.yml` | (1) Added `fail_on_buildrequires_cycle` boolean input + comment that cron stays observational; (2) inserted `Fail on unresolved buildrequires cycle (gate)` step between `Commit to scans directory` and `Cleanup`, guarded on `inputs.fail_on_buildrequires_cycle == 'true'`. |

## Test plan

- [x] Local jq aggregator smoke test against the three task-014-fixed 5.0 v2 artifacts (PR #80 output): returns 1 unresolved BR (`python3-py ↔ python3-pytest` in flavor 91), matching the engine's `br=1` line. Against the base flavor only: 0.
- [ ] Post-merge: `workflow_dispatch branches=5.0 fail_on_buildrequires_cycle=true` → expect job **failure** with the `python3-py ↔ python3-pytest` cycle cited.
- [ ] Post-merge: `workflow_dispatch branches=5.0 fail_on_buildrequires_cycle=false` → expect job **success**.

## Acceptance criteria mapped

- **AC-6** (BR cycles trip when input=true; bootstrap-resolved cycles do not) → guarded on `select(.category == "buildrequires" and .bootstrap_resolved == false)`.
- Input=false default → step `if:` doesn't fire.
- mixed/requires/self-loop never trip → excluded by `.category == "buildrequires"`.
- Artifact + scans commit before exit-code → step order: Upload → Commit → Gate → Cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)