### PR TITLE
package-report: extend -UpstreamsExclusionList to skip clone creation

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -87,11 +87,13 @@ param (
     [string]$workingDir = $(if ($env:PUBLIC) { $env:PUBLIC } else { $HOME }),
     [string]$upstreamsDir = "",
     [string]$scansDir = "",
-    # Comma-separated substrings. If the LEAF (filename) of $UpdateDownloadFile
-    # contains any of these (case-insensitive), the tarball-build/fetch block
-    # in CheckURLHealth is skipped — substitution + urlhealth still run.
-    # Use case: avoid expensive re-downloads of huge sources (e.g.
-    # "firmware,chromium") on every package-report run.
+    # Comma-separated substrings (case-insensitive). Applied against TWO keys:
+    #   1. LEAF of $UpdateDownloadFile — skips tarball build/fetch into SOURCES_NEW.
+    #   2. $repoName from *.git URL    — skips git-clone creation under clones/.
+    # When a filter matches, that step is bypassed; substitution + urlhealth
+    # still run downstream (tag detection falls back to the non-git path).
+    # Use case: avoid expensive re-downloads + 50–70 GB clones of huge sources
+    # (e.g. "firmware,chromium") on every package-report run.
     [string]$UpstreamsExclusionList = "",
     [Parameter(Mandatory = $false)][ValidateNotNull()]$GeneratePh3URLHealthReport=$true,
     [Parameter(Mandatory = $false)][ValidateNotNull()]$GeneratePh4URLHealthReport=$true,
@@ -2367,12 +2369,27 @@ function CheckURLHealth {
                     # override with special cases
                     if ($currentTask.spec -ilike 'gstreamer-plugins-base.spec') {$repoName="gst-plugins-base-"}
 
+                    # Optional skip: when -UpstreamsExclusionList contains a substring of
+                    # $repoName (case-insensitive), do NOT clone the repo into clones/.
+                    # Companion to the tarball-fetch skip in CheckURLHealth's SOURCES_NEW
+                    # block. Typical: skip 55 GB `firmware` + 67 GB `chromium` clones.
+                    $skipClone = $false
+                    if (-not [string]::IsNullOrWhiteSpace($UpstreamsExclusionList)) {
+                        foreach ($filter in ($UpstreamsExclusionList -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })) {
+                            if ($repoName.IndexOf($filter, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+                                Write-Host "Skipping upstream clone for $($currentTask.Spec): filter '$filter' matches repo '$repoName'"
+                                $skipClone = $true
+                                break
+                            }
+                        }
+                    }
+
                     $SourceClonePath=[System.String](join-path -path $ClonePath -childpath $repoName)
 
                     # Poll-based completion detection: first thread fetches, others wait and observe FETCH_HEAD
                     $fetchState = Wait-ForFetchCompletion -SourceClonePath $SourceClonePath -RepoName $repoName -ScriptStartTime $ScriptStartTime
 
-                    if (-not $fetchState.AlreadyFetched) {
+                    if ((-not $fetchState.AlreadyFetched) -and (-not $skipClone)) {
                         if (-not (Test-DiskSpace -Path $ClonePath -RequiredMB 512 -Operation "clone $repoName")) {
                             Write-Warning "DISK SPACE LOW: Skipping clone of $repoName - insufficient space"
                         } else {
@@ -3642,10 +3659,24 @@ function CheckURLHealth {
 
                     $SourceClonePath=[System.String](join-path -path $ClonePath -childpath $repoName)
 
+                    # Optional skip: when -UpstreamsExclusionList contains a substring of
+                    # $repoName (case-insensitive), do NOT clone the repo into clones/.
+                    # See parameter doc at top of script.
+                    $skipClone = $false
+                    if (-not [string]::IsNullOrWhiteSpace($UpstreamsExclusionList)) {
+                        foreach ($filter in ($UpstreamsExclusionList -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })) {
+                            if ($repoName.IndexOf($filter, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+                                Write-Host "Skipping upstream clone for $($currentTask.Spec): filter '$filter' matches repo '$repoName'"
+                                $skipClone = $true
+                                break
+                            }
+                        }
+                    }
+
                     # Poll-based completion detection: first thread fetches, others wait and observe FETCH_HEAD
                     $fetchState = Wait-ForFetchCompletion -SourceClonePath $SourceClonePath -RepoName $repoName -ScriptStartTime $ScriptStartTime
 
-                    if (-not $fetchState.AlreadyFetched) {
+                    if ((-not $fetchState.AlreadyFetched) -and (-not $skipClone)) {
                         if (-not (Test-DiskSpace -Path $ClonePath -RequiredMB 512 -Operation "clone $repoName")) {
                             Write-Warning "DISK SPACE LOW: Skipping clone of $repoName - insufficient space"
                         } else {
@@ -3983,10 +4014,24 @@ function CheckURLHealth {
 
                     $SourceClonePath=[System.String](join-path -path $ClonePath -childpath $repoName)
 
+                    # Optional skip: when -UpstreamsExclusionList contains a substring of
+                    # $repoName (case-insensitive), do NOT clone the repo into clones/.
+                    # See parameter doc at top of script.
+                    $skipClone = $false
+                    if (-not [string]::IsNullOrWhiteSpace($UpstreamsExclusionList)) {
+                        foreach ($filter in ($UpstreamsExclusionList -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ })) {
+                            if ($repoName.IndexOf($filter, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+                                Write-Host "Skipping upstream clone for $($currentTask.Spec): filter '$filter' matches repo '$repoName'"
+                                $skipClone = $true
+                                break
+                            }
+                        }
+                    }
+
                     # Poll-based completion detection: first thread fetches, others wait and observe FETCH_HEAD
                     $fetchState = Wait-ForFetchCompletion -SourceClonePath $SourceClonePath -RepoName $repoName -ScriptStartTime $ScriptStartTime
 
-                    if (-not $fetchState.AlreadyFetched) {
+                    if ((-not $fetchState.AlreadyFetched) -and (-not $skipClone)) {
                         if (-not (Test-DiskSpace -Path $ClonePath -RequiredMB 512 -Operation "clone $repoName")) {
                             Write-Warning "DISK SPACE LOW: Skipping clone of $repoName - insufficient space"
                         } else {

--- a/photonos-package-report/photonos-package-report/docs/maintainer-runbook.md
+++ b/photonos-package-report/photonos-package-report/docs/maintainer-runbook.md
@@ -179,18 +179,69 @@ hard error via the env var `PR_HOOKS_PS_ONLY_FATAL=1`.
 
 ## 3. Excluding a package entirely (`UpstreamsExclusionList`)
 
-If a package is breaking the upstream clone phase (firmware blobs,
-chromium, etc.) you can short-circuit it with the existing
-`-UpstreamsExclusionList` argument. Mirrored 1:1 in the C port.
+If a package's upstream clone is large enough to push the runner against
+disk limits (firmware blobs, chromium, etc.), short-circuit it with
+`-UpstreamsExclusionList`.
 
 ```sh
-./build/photonos-package-report \
+pwsh -File ./photonos-package-report.ps1 \
     -workingDir   /var/photonos \
     -UpstreamsExclusionList 'firmware,chromium,my-broken-pkg'
 ```
 
-Comma-separated, case-sensitive, no spaces. Matched against `Name` (the
-directory leaf under `SPECS/`).
+Comma-separated, **case-insensitive substring match**, no spaces around
+the commas. The list is applied against **two** keys, each independently:
+
+| # | Key                                       | What gets skipped                  | PS site             |
+|---|-------------------------------------------|------------------------------------|---------------------|
+| 1 | `repoName` (leaf of `*.git` URL)          | `git clone` into `clones/<repo>`   | L 2392 / 3679 / 4034 |
+| 2 | leaf of `$UpdateDownloadFile` (tarball)   | tarball build/fetch into `SOURCES_NEW` | L 4790            |
+
+When key 1 fires, `$repoName/.git` is never created → the downstream
+`git tag -l` block falls through cleanly and version detection uses
+the non-git heuristic path (Source0 parent + `customRegex`). When key 2
+fires, the tarball block is bypassed; substitution + urlhealth still run.
+
+Default (empty list): both keys are no-ops; behaviour matches pre-flag
+runs byte-for-byte.
+
+### Disk-space recovery on the runner
+
+Activating the exclusion **does not delete existing clones** — it only
+prevents future creation. After the flag is in your operator config,
+free space manually:
+
+```sh
+# Example: actions-runner installation. ~122 GB recovered per branch.
+for b in 3.0 4.0 5.0 6.0 common dev master; do
+    rm -rf "/root/actions-runner/_work/photonos-scripts/photonos-scripts/reports/photon-upstreams/photon-$b/clones/firmware"
+    rm -rf "/root/actions-runner/_work/photonos-scripts/photonos-scripts/reports/photon-upstreams/photon-$b/clones/chromium"
+done
+```
+
+Without the flag, the very next run re-clones both (`firmware` ≈ 55 GB,
+`chromium` ≈ 67 GB per branch — measured 2026-05-17). With the flag, the
+slots stay empty.
+
+### Parity-gate interaction
+
+The C port currently honours `-UpstreamsExclusionList` only for the
+tarball half (key 2). Until the C side also honours key 1, passing
+`firmware,chromium` to the PS workflow without also passing it to the
+C workflow will diverge on rows where git-tag detection ran on one
+side and the non-git fallback ran on the other → **strict-fail** on
+columns 5/6 of those spec rows.
+
+Operational rule until the C-side migration lands:
+
+* **Do not** set `-UpstreamsExclusionList` on the production PS
+  workflow (`package-report.yml`) yet. The flag is safe in ad-hoc
+  manual runs and in any C-side workflow that explicitly forwards
+  the same value.
+* The dual-key matching is already wired in `package-report.ps1` so
+  the symmetric C-side change (Phase 9 follow-on or its own SDD spec
+  under Phase M) is a straight port; no PS-side rework needed when
+  the C side catches up.
 
 ---
 


### PR DESCRIPTION
## Summary

`-UpstreamsExclusionList` previously skipped only the **tarball build/fetch** into `SOURCES_NEW`. The huge git clones — `firmware` (~55 GB) and `chromium` (~67 GB) per branch — were still created on every run regardless, eating **~366 GB across photon-4.0/5.0/6.0** on the actions-runner.

This PR extends the flag to also skip clone creation. The same comma-separated list is now matched against **two** keys, case-insensitive substring:

| # | Key                                       | What gets skipped                       |
|---|-------------------------------------------|-----------------------------------------|
| 1 | `$repoName` (leaf of `*.git` URL)         | `git clone` into `clones/<repo>` (new)  |
| 2 | leaf of `$UpdateDownloadFile` (tarball)   | tarball build/fetch into `SOURCES_NEW` (existing) |

Default empty list → both keys are no-ops → byte-identical to prior runs.

## Code changes

All three identical clone-blocks in `CheckURLHealth` (PS L 2364, L 3640, L 3981) gain the same guard:

```powershell
$skipClone = $false   # set from -UpstreamsExclusionList vs $repoName
...
if ((-not $fetchState.AlreadyFetched) -and (-not $skipClone)) {
    # existing clone-or-fetch + retry block, unchanged
}
```

When `$skipClone = $true`, `$SourceClonePath/.git` is never created → the existing `if ((Test-Path $SourceClonePath) -and (Test-Path (Join-Path $SourceClonePath ".git")))` downstream cleanly short-circuits, and tag detection falls through to the non-git heuristic path.

## Runbook

Section 3 of `docs/maintainer-runbook.md` rewritten:
- Correct description of **both** match keys (the old text said "Matched against `Name` under `SPECS/`" which was never accurate).
- New **Disk-space recovery** subsection with the explicit `rm -rf` snippet operators run after enabling the flag.
- New **Parity-gate interaction** subsection: do not set `-UpstreamsExclusionList` on the production PS workflow yet — the C port currently honours only key 2, so the PS↔C asymmetry on cols 5/6 of `firmware`/`chromium` rows would strict-fail the gate. Default-off keeps parity green.

## Step 2 (separate, not in this PR)

The mirror change to the C port will be its own SDD spec under Phase M. CLAUDE.md invariant 2 (PS → spec → C) requires this PR to land + stabilise first.

## Test plan

- [x] `pwsh` tokenizer parse-ok on the modified script.
- [x] `git diff` shows only the intended 3 clone-block guards + doc-comment + runbook edits (+110 / -14).
- [ ] Run with default `-UpstreamsExclusionList ""` on one branch → confirm byte-identical `.prn` vs baseline.
- [ ] Run with `-UpstreamsExclusionList "firmware,chromium"` on a throw-away clones tree → confirm no `clones/firmware` / `clones/chromium` directories are created; `linux-firmware.spec` / `chromium.spec` rows still present in `.prn`.
- [ ] Confirm existing tarball-skip path at L 4790 still fires for the same filters (now both halves listen to the same list — independent guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)