### PR TITLE
workflows: enable -UpstreamsExclusionList firmware,chromium by default

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -20,6 +20,9 @@ on:
       snapshot_run_id:
         description: 'PS run id whose parity-snapshot-<id> artifact to consume'
         required: true
+      upstreams_exclusion_list:
+        description: 'Comma-separated substrings (case-insensitive). Must mirror the PS workflow value so both sides skip the same clones. See package-report.yml for semantics.'
+        default: 'firmware,chromium'
 
 permissions:
   contents: write   # commit the journal back to master
@@ -147,6 +150,15 @@ jobs:
           SCANS="$WDIR/scans"
           mkdir -p "$SCANS"
 
+          # Mirror the PS workflow's exclusion list so both sides skip
+          # the same clones (firmware ~55 GB, chromium ~67 GB per branch).
+          # On workflow_run (auto), inputs context is empty → fall back
+          # to the same baseline default as PS.
+          UPSTREAMS_EXCL="${{ github.event.inputs.upstreams_exclusion_list }}"
+          if [ -z "$UPSTREAMS_EXCL" ]; then
+            UPSTREAMS_EXCL="firmware,chromium"
+          fi
+
           # Run with -ThrottleLimit 1 per ADR-0009 to keep stderr ordering
           # byte-stable during the parity window.
           ./build/photonos-package-report \
@@ -155,6 +167,7 @@ jobs:
             -scansDir     "$SCANS" \
             -ThrottleLimit 1 \
             -github_token "$GITHUB_TOKEN" \
+            -UpstreamsExclusionList "$UPSTREAMS_EXCL" \
             -GeneratePh3URLHealthReport      "${{ steps.branches.outputs.ph3 }}" \
             -GeneratePh4URLHealthReport      "${{ steps.branches.outputs.ph4 }}" \
             -GeneratePh5URLHealthReport      "${{ steps.branches.outputs.ph5 }}" \

--- a/.github/workflows/package-report.yml
+++ b/.github/workflows/package-report.yml
@@ -28,8 +28,8 @@ on:
         description: 'Directory for .prn report output files (default: workingDir/scans)'
         default: ''
       upstreams_exclusion_list:
-        description: 'Comma-separated substrings; when an upstream download filename contains any (case-insensitive, matched on basename), the tarball fetch is skipped. Substitution + urlhealth still run. Example: "firmware,chromium"'
-        default: ''
+        description: 'Comma-separated substrings (case-insensitive). Matched against TWO keys: (1) leaf of $UpdateDownloadFile (skips tarball fetch into SOURCES_NEW); (2) $repoName from *.git URL (skips clone creation under clones/). Substitution + urlhealth still run; tag detection falls back to non-git path. Default skips firmware (~55 GB/branch) and chromium (~67 GB/branch).'
+        default: 'firmware,chromium'
   schedule:
     # Weekly scan on Sunday at 02:00 UTC
     - cron: '0 2 * * 0'
@@ -194,8 +194,15 @@ jobs:
           if [ -n "${{ github.event.inputs.scansDir }}" ]; then
             EXTRA_ARGS="$EXTRA_ARGS -scansDir \"${{ github.event.inputs.scansDir }}\""
           fi
-          if [ -n "${{ github.event.inputs.upstreams_exclusion_list }}" ]; then
-            EXTRA_ARGS="$EXTRA_ARGS -UpstreamsExclusionList \"${{ github.event.inputs.upstreams_exclusion_list }}\""
+          # On workflow_dispatch the input is filled in by the user
+          # (default in the inputs block). On schedule there is no
+          # inputs context, so apply the same baseline default here.
+          UPSTREAMS_EXCL="${{ github.event.inputs.upstreams_exclusion_list }}"
+          if [ -z "$UPSTREAMS_EXCL" ] && [ "${{ github.event_name }}" = "schedule" ]; then
+            UPSTREAMS_EXCL="firmware,chromium"
+          fi
+          if [ -n "$UPSTREAMS_EXCL" ]; then
+            EXTRA_ARGS="$EXTRA_ARGS -UpstreamsExclusionList \"$UPSTREAMS_EXCL\""
           fi
 
           # Propagate pwsh's exit code. Previously a trailing `echo "exit_code=$?"`


### PR DESCRIPTION
**Stacked on PR #85 (which is stacked on PR #84).** Base auto-retargets to master after #85 merges.

## Summary

Activates the new dual-key exclusion in CI. PR #84 (PS) and PR #85 (C) ship the *capability*; this PR turns it *on* for the production workflows.

## package-report.yml (PS)

| Change | Effect |
|---|---|
| Input default `''` → `'firmware,chromium'` | Manual dispatches show the new default in the form |
| Schedule trigger shell-step fallback | Cron-triggered runs (Sunday 02:00 UTC) pick up the same value (`workflow_dispatch` defaults don't reach the `schedule` event) |
| Description updated | Now mentions both match keys (tarball leaf + `$repoName` from `.git` URL) |

## package-report-C.yml

| Change | Effect |
|---|---|
| New input `upstreams_exclusion_list`, default `'firmware,chromium'` | Manual replays inherit the PS default |
| Run-step fallback for `workflow_run` (auto) trigger | When fired by PS success, same baseline applies |
| `-UpstreamsExclusionList "$UPSTREAMS_EXCL"` added to the C binary invocation | Honoured by `pr_should_skip_clone()` from PR #85 |

The two workflows must stay in lockstep — both default to the same value so PS and C see byte-identical skip behaviour. The maintainer can override per-run via manual dispatch on both workflows independently.

## Disk reclaim (already done on the runner)

The actions-runner was at 100% disk (6.1 GB free / 1.4 TB). The existing `firmware` + `chromium` clones on photon-4.0/5.0/6.0/dev/master have been deleted manually — **610 GB reclaimed**, disk now at 55% (616 GB free). Without this PR's workflow change, the next run would re-clone them; with this PR they stay empty.

## Test plan

- [x] YAML syntactically valid.
- [x] Disk pre-reclaimed (610 GB).
- [ ] After merge: next manual dispatch shows `firmware,chromium` pre-filled in both workflows.
- [ ] After merge: scheduled cron run on photon-{4.0,5.0,6.0,dev,master} does not re-create firmware/chromium clones.
- [ ] Parity-journal entry from that run = `green` (both sides skip identically; rows for `linux-firmware.spec` / `chromium.spec` use the non-git fallback path on both sides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)