### PR TITLE
workflows: enable -UpstreamsExclusionList firmware,chromium by default

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -20,6 +20,9 @@ on:
       snapshot_run_id:
         description: 'PS run id whose parity-snapshot-<id> artifact to consume'
         required: true
+      upstreams_exclusion_list:
+        description: 'Comma-separated substrings (case-insensitive). Must mirror the PS workflow value so both sides skip the same clones. See package-report.yml for semantics.'
+        default: 'firmware,chromium'
 
 permissions:
   contents: write   # commit the journal back to master
@@ -147,6 +150,15 @@ jobs:
           SCANS="$WDIR/scans"
           mkdir -p "$SCANS"
 
+          # Mirror the PS workflow's exclusion list so both sides skip
+          # the same clones (firmware ~55 GB, chromium ~67 GB per branch).
+          # On workflow_run (auto), inputs context is empty → fall back
+          # to the same baseline default as PS.
+          UPSTREAMS_EXCL="${{ github.event.inputs.upstreams_exclusion_list }}"
+          if [ -z "$UPSTREAMS_EXCL" ]; then
+            UPSTREAMS_EXCL="firmware,chromium"
+          fi
+
           # Run with -ThrottleLimit 1 per ADR-0009 to keep stderr ordering
           # byte-stable during the parity window.
           ./build/photonos-package-report \
@@ -155,6 +167,7 @@ jobs:
             -scansDir     "$SCANS" \
             -ThrottleLimit 1 \
             -github_token "$GITHUB_TOKEN" \
+            -UpstreamsExclusionList "$UPSTREAMS_EXCL" \
             -GeneratePh3URLHealthReport      "${{ steps.branches.outputs.ph3 }}" \
             -GeneratePh4URLHealthReport      "${{ steps.branches.outputs.ph4 }}" \
             -GeneratePh5URLHealthReport      "${{ steps.branches.outputs.ph5 }}" \

--- a/.github/workflows/package-report.yml
+++ b/.github/workflows/package-report.yml
@@ -28,8 +28,8 @@ on:
         description: 'Directory for .prn report output files (default: workingDir/scans)'
         default: ''
       upstreams_exclusion_list:
-        description: 'Comma-separated substrings; when an upstream download filename contains any (case-insensitive, matched on basename), the tarball fetch is skipped. Substitution + urlhealth still run. Example: "firmware,chromium"'
-        default: ''
+        description: 'Comma-separated substrings (case-insensitive). Matched against TWO keys: (1) leaf of $UpdateDownloadFile (skips tarball fetch into SOURCES_NEW); (2) $repoName from *.git URL (skips clone creation under clones/). Substitution + urlhealth still run; tag detection falls back to non-git path. Default skips firmware (~55 GB/branch) and chromium (~67 GB/branch).'
+        default: 'firmware,chromium'
   schedule:
     # Weekly scan on Sunday at 02:00 UTC
     - cron: '0 2 * * 0'
@@ -194,8 +194,15 @@ jobs:
           if [ -n "${{ github.event.inputs.scansDir }}" ]; then
             EXTRA_ARGS="$EXTRA_ARGS -scansDir \"${{ github.event.inputs.scansDir }}\""
           fi
-          if [ -n "${{ github.event.inputs.upstreams_exclusion_list }}" ]; then
-            EXTRA_ARGS="$EXTRA_ARGS -UpstreamsExclusionList \"${{ github.event.inputs.upstreams_exclusion_list }}\""
+          # On workflow_dispatch the input is filled in by the user
+          # (default in the inputs block). On schedule there is no
+          # inputs context, so apply the same baseline default here.
+          UPSTREAMS_EXCL="${{ github.event.inputs.upstreams_exclusion_list }}"
+          if [ -z "$UPSTREAMS_EXCL" ] && [ "${{ github.event_name }}" = "schedule" ]; then
+            UPSTREAMS_EXCL="firmware,chromium"
+          fi
+          if [ -n "$UPSTREAMS_EXCL" ]; then
+            EXTRA_ARGS="$EXTRA_ARGS -UpstreamsExclusionList \"$UPSTREAMS_EXCL\""
           fi
 
           # Propagate pwsh's exit code. Previously a trailing `echo "exit_code=$?"`


### PR DESCRIPTION
Re-opens PR #86 against master (closed when PR #87 deleted its base ref). Same commit `a4887af`; PRs #84 and #87 already merged, so this is now a clean diff of only the two workflow YAML edits.

## Summary

Activates the new dual-key exclusion in CI. PRs #84 (PS) and #87 (C) shipped the *capability*; this turns it *on*.

### package-report.yml (PS)
- Input default `''` → `'firmware,chromium'`; description updated to mention both match keys
- Schedule trigger shell-step fallback (cron has no inputs context)

### package-report-C.yml
- New input `upstreams_exclusion_list`, default `'firmware,chromium'`
- Run-step fallback for the `workflow_run` (auto) trigger
- `-UpstreamsExclusionList "$UPSTREAMS_EXCL"` forwarded to the C binary

## Disk reclaim (already done on the runner)

The runner was at 100% disk (6.1 GB free / 1.4 TB). The existing `firmware` + `chromium` clones on photon-4.0/5.0/6.0/dev/master were manually deleted — **610 GB reclaimed**, disk now at 55% (616 GB free). With this PR merged, future scheduled runs won't re-create them.

## Test plan

- [x] YAML syntactically valid.
- [x] Disk pre-reclaimed.
- [ ] After merge: next manual dispatch shows `firmware,chromium` pre-filled in both workflows.
- [ ] After merge: scheduled cron run on photon-{4.0,5.0,6.0,dev,master} does not re-create firmware/chromium clones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)