### PR TITLE
parity-reconstruct: skip upstream pre-cloning by default; parallel opt-in

### DIFF
--- a/.github/scripts/parity-reconstruct.sh
+++ b/.github/scripts/parity-reconstruct.sh
@@ -11,12 +11,21 @@
 # Restores:
 #   <out-working-dir>/<branch>/              — Photon branch clone @ SHA
 #   <out-upstreams-dir>/<branch>/clones/<sub>/ — upstream repo clone @ SHA
+#                                                (skipped unless PARITY_PRECLONE_UPSTREAMS=1)
 #
-# Upstream clones are best-effort: a failed clone is logged as a warning
-# but does not abort the script. The C binary's phase 6d local-clone
-# fetch will re-create any missing clone on first use.
+# Branch clones are REQUIRED: a failed branch clone aborts.
+# Upstream clones are SKIPPED by default — there are typically thousands
+# per snapshot and pre-cloning them all serially exceeds practical
+# workflow timeouts. The C binary's phase 6d local-clone fetch
+# (pr_clone_ensure) re-creates each clone on first use, so correctness
+# is preserved.
 #
-# Branch clones are required: a failed branch clone aborts.
+# Opt-in eager pre-cloning for byte-stable SHA-pinned parity:
+#   PARITY_PRECLONE_UPSTREAMS=1    enable pre-cloning
+#   PARITY_PRECLONE_JOBS=N         parallel workers (default 8, max 32)
+#
+# Both knobs are best-effort: a failed clone is logged as a warning
+# but does not abort. The C binary still re-clones what's missing.
 #
 # Usage:
 #   parity-reconstruct.sh <snapshot-dir> <out-working-dir> <out-upstreams-dir>
@@ -69,32 +78,70 @@ else
     exit 1
 fi
 
-# ---- Upstream clones (best-effort) -------------------------------------
+# ---- Upstream clones ---------------------------------------------------
+# Default: SKIP. The C binary re-clones what it needs on first use, so
+# correctness is preserved. Opt in for SHA-pinned byte-stable parity.
 UP_MAN="$SNAP/upstream-clones-manifest.tsv"
 n_upstream=0
 n_upstream_failed=0
+n_upstream_total=0
 if [ -s "$UP_MAN" ]; then
-    while IFS="$(printf '\t')" read -r branch sub url sha; do
-        [ -n "$branch" ] && [ -n "$sub" ] && [ -n "$url" ] || continue
-        dest="$UPSTREAMS/$branch/clones/$sub"
-        mkdir -p "$(dirname "$dest")"
-        if [ ! -d "$dest/.git" ] && [ ! -f "$dest/HEAD" ]; then
-            if git clone --quiet "$url" "$dest" 2>/dev/null; then
-                :
-            else
-                echo "::warning::reconstruct: upstream clone failed for $url" >&2
-                n_upstream_failed=$((n_upstream_failed + 1))
-                continue
-            fi
-        fi
-        # Best-effort fetch + checkout at recorded SHA; tolerate failure.
-        git -C "$dest" fetch --quiet origin 2>/dev/null || true
-        if [ "$sha" != "unknown" ] && [ -n "$sha" ]; then
-            git -C "$dest" -c advice.detachedHead=false checkout --quiet "$sha" 2>/dev/null || true
-        fi
-        n_upstream=$((n_upstream + 1))
-    done < "$UP_MAN"
+    n_upstream_total=$(wc -l < "$UP_MAN")
 fi
 
-printf 'parity-reconstruct: branch-clones=%d  upstream-clones=%d  upstream-failed=%d\n' \
-    "$n_branch" "$n_upstream" "$n_upstream_failed"
+if [ "${PARITY_PRECLONE_UPSTREAMS:-0}" != "1" ]; then
+    echo "  upstream-preclone: SKIPPED ($n_upstream_total entries in manifest; C binary will clone on-demand)"
+    echo "  (set PARITY_PRECLONE_UPSTREAMS=1 to enable eager SHA-pinned reconstruction)"
+else
+    JOBS="${PARITY_PRECLONE_JOBS:-8}"
+    case "$JOBS" in
+        ''|*[!0-9]*) JOBS=8 ;;
+        0)           JOBS=1 ;;
+    esac
+    if [ "$JOBS" -gt 32 ]; then JOBS=32; fi
+    echo "  upstream-preclone: ENABLED ($n_upstream_total entries, $JOBS parallel workers)"
+
+    work_dir=$(mktemp -d -t parity-recon.XXXXXX)
+    trap 'rm -rf "$work_dir"' EXIT
+    log_file="$work_dir/log"
+    : > "$log_file"
+
+    # Bounded-concurrency batching: launch up to $JOBS background
+    # workers, then `wait` for the whole batch before starting the
+    # next. Simpler than a fifo semaphore; tail latency per batch is
+    # bounded by the slowest clone in that batch, which is acceptable
+    # for snapshot-replay use.
+    running=0
+    while IFS="$(printf '\t')" read -r branch sub url sha; do
+        [ -n "$branch" ] && [ -n "$sub" ] && [ -n "$url" ] || continue
+        (
+            dest="$UPSTREAMS/$branch/clones/$sub"
+            mkdir -p "$(dirname "$dest")"
+            if [ ! -d "$dest/.git" ] && [ ! -f "$dest/HEAD" ]; then
+                if ! git clone --quiet "$url" "$dest" 2>/dev/null; then
+                    echo "FAILED $branch/$sub $url" >> "$log_file"
+                    echo "::warning::reconstruct: upstream clone failed for $url" >&2
+                    exit 0
+                fi
+            fi
+            git -C "$dest" fetch --quiet origin 2>/dev/null || true
+            if [ "${sha:-unknown}" != "unknown" ]; then
+                git -C "$dest" -c advice.detachedHead=false checkout --quiet "$sha" 2>/dev/null || true
+            fi
+            echo "DONE $branch/$sub" >> "$log_file"
+        ) &
+        running=$((running + 1))
+        if [ "$running" -ge "$JOBS" ]; then
+            wait
+            running=0
+        fi
+    done < "$UP_MAN"
+    wait  # drain the final partial batch
+
+    # awk counters tolerate set -eu without grep-exit-1 noise.
+    n_upstream=$(awk '/^DONE /   {c++} END {print c+0}' "$log_file")
+    n_upstream_failed=$(awk '/^FAILED / {c++} END {print c+0}' "$log_file")
+fi
+
+printf 'parity-reconstruct: branch-clones=%d  upstream-clones=%d  upstream-failed=%d  upstream-total=%d\n' \
+    "$n_branch" "$n_upstream" "$n_upstream_failed" "$n_upstream_total"

--- a/photonos-package-report/photonos-package-report/docs/maintainer-runbook.md
+++ b/photonos-package-report/photonos-package-report/docs/maintainer-runbook.md
@@ -459,7 +459,18 @@ gh run download <PS_RUN_ID> -n parity-snapshot-<PS_RUN_ID> -D /tmp/snap
 cd /tmp/snap && tar -xzf parity-snapshot-*.tar.gz
 
 # Reconstruct working tree from manifests.
+# Default: branch clones only; upstream clones are NOT pre-created
+# (the C binary recreates them on-demand via pr_clone_ensure). The
+# snapshot's upstream manifest commonly contains thousands of entries
+# — pre-cloning them serially would exceed the workflow timeout.
 .github/scripts/parity-reconstruct.sh /tmp/snap /tmp/wd /tmp/wd/photon-upstreams
+
+# Opt-in: SHA-pin every upstream clone for byte-stable parity. Slow.
+# Useful when chasing a strict-diff and you need both sides locked to
+# the exact upstream commits the PS run saw. Bounded parallelism via
+# PARITY_PRECLONE_JOBS (default 8, max 32).
+# PARITY_PRECLONE_UPSTREAMS=1 PARITY_PRECLONE_JOBS=16 \
+#     .github/scripts/parity-reconstruct.sh /tmp/snap /tmp/wd /tmp/wd/photon-upstreams
 
 # Build + run C with the same -ThrottleLimit 1 the workflow uses.
 cmake --build build


### PR DESCRIPTION
## Root cause

The first paired-green parity run (PS #25991871716 → C #25993738785) hit a wall in `parity-reconstruct.sh`:

- Snapshot manifest carries **4037 upstream clones** (one per spec with a `.git` `Source0`, across 7 branches).
- Reconstruct cloned them **sequentially** with no concurrency.
- The C-side workflow's 8-hour timeout would expire long before the C binary even started.
- Run 25993738785 spent 30+ minutes stuck on photon-3.0's `elasticsearch` clone with 4036 to go.

The script's own header already documented that the C binary's `pr_clone_ensure` recreates missing upstreams on first use, so pre-cloning is **not load-bearing for correctness** — only for byte-stable SHA-pinned parity (useful when chasing a strict-diff later, not for getting the first row in the journal).

## Fix

Change default behaviour to **skip upstream pre-cloning** and add two env-var opt-ins for the slow SHA-pinned path:

| Env var | Default | Effect |
|---|---|---|
| `PARITY_PRECLONE_UPSTREAMS` | unset (skip) | `=1` enables eager pre-cloning |
| `PARITY_PRECLONE_JOBS` | 8 | parallel workers when eager mode on; clamped to [1, 32] |

Eager-mode implementation: bounded-batch background jobs in pure POSIX shell — launch up to `$JOBS` clones in parallel, `wait` on the whole batch before starting the next. No GNU xargs / fifo tricks.

## Files

| File | Change |
|---|---|
| `.github/scripts/parity-reconstruct.sh` | Header rewritten; upstream loop replaced with default-skip + opt-in parallel batches; `awk` counters tolerate `set -eu` |
| `docs/maintainer-runbook.md` §9 | Replay example annotated with the new env vars + when to use eager mode |

## What this unblocks

After merge the next workflow_run-triggered C-side replay:
1. Branch clones only (7 small repos, takes ~1 min).
2. C binary runs `-ThrottleLimit 1`, on-demand clones what it needs.
3. parity-diff runs, journal row appended, ADR-0009 clock starts.

## Test plan

- [x] `sh -n parity-reconstruct.sh` syntax OK.
- [x] Dry-run with default env: branch clone done, 2 upstream-manifest entries reported skipped, summary line correct.
- [ ] Next paired C-side run completes in < 8 hours and appends a row to `tools/parity-journal.tsv`.
- [ ] If/when a strict diff appears: re-run locally with `PARITY_PRECLONE_UPSTREAMS=1` to chase the offending spec's exact SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)