### PR TITLE
parity-C: expose -ThrottleLimit as workflow input; default 8 not 1

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -23,6 +23,9 @@ on:
       upstreams_exclusion_list:
         description: 'Comma-separated substrings (case-insensitive). Must mirror the PS workflow value so both sides skip the same clones. See package-report.yml for semantics.'
         default: 'firmware,chromium'
+      throttle_limit:
+        description: 'Concurrency for CheckURLHealth (sequential clones on-demand at -ThrottleLimit 1 take many hours for full multi-branch snapshots). Drop to 1 when chasing a strict-diff that needs byte-stable stderr ordering.'
+        default: '8'
 
 permissions:
   contents: write   # commit the journal back to master
@@ -139,7 +142,7 @@ jobs:
             echo "master=$MASTER"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Run C binary (-ThrottleLimit 1)
+      - name: Run C binary
         id: c_run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -159,13 +162,25 @@ jobs:
             UPSTREAMS_EXCL="firmware,chromium"
           fi
 
-          # Run with -ThrottleLimit 1 per ADR-0009 to keep stderr ordering
-          # byte-stable during the parity window.
+          # ADR-0009 originally pinned -ThrottleLimit 1 for byte-stable
+          # stderr ordering. In practice the snapshot manifest carries
+          # ~4000 specs with .git Source0 — on-demand clones serially
+          # exceed the 8-hour workflow timeout. parity-diff.sh only
+          # compares .prn output (which is already byte-stable via
+          # FRD-013 sort + single-writer regardless of throttle), so
+          # we can safely parallelise the runtime. Drop back to 1 via
+          # workflow_dispatch input when chasing a strict-diff that
+          # needs deterministic stderr.
+          THROTTLE="${{ github.event.inputs.throttle_limit }}"
+          if [ -z "$THROTTLE" ]; then
+            THROTTLE="8"
+          fi
+
           ./build/photonos-package-report \
             -workingDir   "$WDIR" \
             -upstreamsDir "$UPSTREAMS" \
             -scansDir     "$SCANS" \
-            -ThrottleLimit 1 \
+            -ThrottleLimit "$THROTTLE" \
             -github_token "$GITHUB_TOKEN" \
             -UpstreamsExclusionList "$UPSTREAMS_EXCL" \
             -GeneratePh3URLHealthReport      "${{ steps.branches.outputs.ph3 }}" \


### PR DESCRIPTION
**Held — do not merge yet.** Prepped per discussion in https://github.com/dcasota/photonos-scripts/actions/runs/25995156167. Merge after the in-flight C run confirms the on-demand clone bottleneck, or pre-emptively if we want to spare an 8-hour wait.

## Background

ADR-0009 pinned the parity workflow to `-ThrottleLimit 1` for byte-stable **stderr** ordering during strict-diff investigation. `.prn` output is already byte-stable regardless of throttle (FRD-013: sort + single-writer thread with `setlocale(LC_ALL, "C")`).

PR #89 made `parity-reconstruct.sh` skip upstream pre-cloning by default — the C binary now clones on-demand. With `-ThrottleLimit 1`, that's ~4000 serial clones, which is the same time-budget problem reconstruct used to have, just relocated.

## Change

Two-line workflow YAML edit:

| Before | After |
|---|---|
| Step name hardcoded `(-ThrottleLimit 1)` | Step name `Run C binary` |
| `-ThrottleLimit 1` hardcoded | `-ThrottleLimit "$THROTTLE"` from new workflow_dispatch input `throttle_limit`, default `'8'`, fallback `8` when triggered by `workflow_run` |

Drop back to 1 on a manual dispatch when chasing a strict-fail.

## Why default 8

- Self-hosted runner has plenty of CPU and 1.4 T disk (now 586 G free).
- PS workflow runs at the PS-default ThrottleLimit=20; the C side at 8 would still be slower per-spec but with hours-not-day runtime.
- 8 keeps the GitHub API requests-per-second well under the authenticated 5000/h cap.

## Why not 20

`-ThrottleLimit 20` mirrors PS exactly but tail-latency on parallel clones can saturate the runner's network. 8 is a conservative midpoint; the new input lets us tune later without another PR.

## Test plan

- [x] YAML syntactically valid.
- [ ] After merge: dispatch C workflow against snapshot from PS run `25991871716`. Expect:
  - reconstruct skips upstream pre-cloning (PR #89)
  - C binary clones in parallel × 8, completes in 1–2 hours not 8+
  - `parity-diff.sh` per branch → verdicts written to journal → first row appended → ADR-0009 clock starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)