### PR TITLE
parity-C: set PR_TEST_NETWORK=1 so urlhealth + clone probes actually run

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -145,7 +145,13 @@ jobs:
       - name: Run C binary
         id: c_run
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
+          # check_urlhealth() gates all network work (urlhealth HEAD
+          # probes + pr_clone_ensure tag-detect chain) on this env var
+          # so ctest stays offline-hermetic by default. CI parity NEEDS
+          # the network paths to run — without it, cols 4/5/6/7/10 are
+          # all empty on the C side and every row diffs strict.
+          PR_TEST_NETWORK: "1"
         run: |
           cd repo/photonos-package-report/photonos-package-report
           WDIR="${{ steps.reconstruct.outputs.wdir }}"


### PR DESCRIPTION
## Root cause of yesterday's 7 strict-fail journal rows

C run [25995156167](https://github.com/dcasota/photonos-scripts/actions/runs/25995156167) completed in **4 minutes** (not the expected multi-hour duration) and produced 7 strict-fail journal rows — one per branch, `strict_rows=1` each.

Diagnosis: `check_urlhealth.c:97-98` gates **all** network work on env var `PR_TEST_NETWORK`:

```c
const char *netenv = getenv("PR_TEST_NETWORK");
int allow_network = (netenv && strcmp(netenv, "1") == 0);
if (allow_network) {
    health = urlhealth(state.Source0);
}
// ...
if (allow_network && clone_root && ... && row->gitSource && ...) {
    // pr_clone_ensure + tag detection + UpdateURL probe
}
```

Added in Phase 5 (ADR-0006 hermetic-ctest requirement) so unit tests don't hit the network. The CI workflow never set the variable, so every column the network paths populate (col 4 `UrlHealth`, col 5 `UpdateAvailable`, col 6 `UpdateURL`, col 7 `HealthUpdateURL`, col 10 `UpdateDownloadName`) was empty on the C side. PS-side had real values from its own probes, so `parity-diff.sh` saw a non-volatile diff on every spec → strict.

## Fix

One-line env addition in `.github/workflows/package-report-C.yml` Run-C-binary step:

```yaml
env:
  GITHUB_TOKEN:    ${{ secrets.GITHUB_TOKEN }}
  PR_TEST_NETWORK: "1"   # ← new
```

Plus the comment explaining why.

`ctest` keeps default-off (env var unset → `allow_network=0`).

## Expected outcome of next run

- Run time: hours not minutes (real probes happen).
- With `-ThrottleLimit 8` (PR #90) the on-demand clones parallelise — should fit comfortably under the 8-hour timeout.
- Journal verdicts will reflect *actual* C↔PS divergence, not env-var artefact.

## Existing journal rows

The 7 strict rows are real journal entries and start the ADR-0009 clock. We're in the 0–30 day soft window — they're informational only, no PR gating yet. After this PR lands and a clean paired run produces green/soft rows, those become the meaningful signal. No journal reset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)