### PR TITLE
phase-M task M02: multi-branch dispatcher in main.c

### DIFF
--- a/photonos-package-report/photonos-package-report/CLAUDE.md
+++ b/photonos-package-report/photonos-package-report/CLAUDE.md
@@ -65,7 +65,7 @@ while the tool is live.
 | 7  | Cluster orchestrator + parallel runspace mirror (`-ThrottleLimit`) | done (#66) |
 | 8  | CI side-by-side parity gate                           | done (#67)  |
 | 9  | Retirement (PS → staging/legacy/, C-only)             | pending     |
-| M  | Maintainer ops & debug tooling — `docs/maintainer-runbook.md`, `.vscode/`; task M01 mirrors PS PR #84 (`-UpstreamsExclusionList` skips clone creation) | ongoing |
+| M  | Maintainer ops & debug tooling — `docs/maintainer-runbook.md`, `.vscode/`; M01 mirrors PS PR #84 (`-UpstreamsExclusionList` skips clone creation); M02 multi-branch dispatcher in `main.c` | ongoing |
 
 When you land a feature in a numeric phase that changes a workflow the
 maintainer cares about (new flag, new override mechanism, new generator),

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-015-generate-urlhealth-reports.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-015-generate-urlhealth-reports.md
@@ -19,6 +19,30 @@ This FRD specifies the 1:1 C port of the corresponding section of the PowerShell
 
 (To be expanded by the dev agent at the start of the phase that implements this FRD; the implementation must be a literal, line-ordered translation of the PS source range above. No reordering, no merging of cases.)
 
+### 2.1 Multi-branch dispatcher (Phase M task M02)
+
+When the hidden `--generate-urlhealth-report <branch>` flag is unset,
+the C binary MUST iterate the 7 `-GeneratePh*URLHealthReport` flags
+and call `generate_urlhealth_main(&params, "<branch>")` for each
+enabled branch:
+
+| Flag | Branch arg |
+|---|---|
+| `GeneratePh3URLHealthReport`      | `"3.0"`    |
+| `GeneratePh4URLHealthReport`      | `"4.0"`    |
+| `GeneratePh5URLHealthReport`      | `"5.0"`    |
+| `GeneratePh6URLHealthReport`      | `"6.0"`    |
+| `GeneratePhCommonURLHealthReport` | `"common"` |
+| `GeneratePhDevURLHealthReport`    | `"dev"`    |
+| `GeneratePhMasterURLHealthReport` | `"master"` |
+
+Mirrors PS `photonos-package-report.ps1` L 5040-5215 (cluster
+orchestrator loop). Per-branch failures (e.g. `parse_directory`
+on a missing SPECS tree) are soft — they emit `::warning::` and the
+loop continues to the next branch. The process exit code reflects
+the last non-zero return from `generate_urlhealth_main`. When no
+flag is enabled, exit code is 0 (no-op).
+
 ## 3. Bit-identical assertions
 
 - All non-volatile bytes of the implementation's outputs must match PS output exactly.

--- a/photonos-package-report/photonos-package-report/specs/tasks/README.md
+++ b/photonos-package-report/photonos-package-report/specs/tasks/README.md
@@ -165,6 +165,7 @@ amendment (or new FRD if scope warrants).
 | Task | Subject | FRD | ADR | PS-L | Parity |
 |---|---|---|---|---|---|
 | M01 | Mirror PS PR #84: extend `-UpstreamsExclusionList` to skip clone creation in C (`pr_should_skip_clone` + guard at `check_urlhealth.c:107-115`) | FRD-012 | 0001,0006 | 2369-2392, 3659-3679, 4014-4034 | strict |
+| M02 | Multi-branch dispatcher in `main.c` so the 7 `-GeneratePh*URLHealthReport` flags actually drive iteration (was silently dropped, causing parity-journal strict-fails) | FRD-015 | 0001 | 5040-5215 | strict |
 
 ---
 

--- a/photonos-package-report/photonos-package-report/src/main.c
+++ b/photonos-package-report/photonos-package-report/src/main.c
@@ -17,6 +17,7 @@
  */
 #include "photonos_package_report.h"
 
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -270,6 +271,44 @@ int main(int argc, char **argv)
 
     if (generate_urlhealth_branch != NULL && generate_urlhealth_branch[0] != '\0') {
         return generate_urlhealth_main(&params, generate_urlhealth_branch);
+    }
+
+    /* Phase M task M02: multi-branch dispatcher.
+     *
+     * When the hidden --generate-urlhealth-report flag is NOT given,
+     * fall through to PS-style behaviour: iterate the 7 GeneratePh*
+     * URL-health flags and call generate_urlhealth_main() for each
+     * enabled branch. Mirrors PS photonos-package-report.ps1 L 5040-5215
+     * (the cluster orchestrator loop).
+     *
+     * A failed branch (missing SPECS, parse_directory error, …) only
+     * sets the exit code; remaining branches still run. PS-side errors
+     * are similarly soft per-branch. */
+    {
+        static const struct { int enabled_offset; const char *branch; }
+            branch_dispatch[] = {
+                { offsetof(pr_params_t, GeneratePh3URLHealthReport),      "3.0"    },
+                { offsetof(pr_params_t, GeneratePh4URLHealthReport),      "4.0"    },
+                { offsetof(pr_params_t, GeneratePh5URLHealthReport),      "5.0"    },
+                { offsetof(pr_params_t, GeneratePh6URLHealthReport),      "6.0"    },
+                { offsetof(pr_params_t, GeneratePhCommonURLHealthReport), "common" },
+                { offsetof(pr_params_t, GeneratePhDevURLHealthReport),    "dev"    },
+                { offsetof(pr_params_t, GeneratePhMasterURLHealthReport), "master" },
+            };
+        int any_enabled = 0;
+        int rc          = 0;
+        for (size_t i = 0; i < sizeof branch_dispatch / sizeof branch_dispatch[0]; i++) {
+            int enabled = *(int *)((char *)&params + branch_dispatch[i].enabled_offset);
+            if (!enabled) continue;
+            any_enabled = 1;
+            int br_rc = generate_urlhealth_main(&params, branch_dispatch[i].branch);
+            if (br_rc != 0) {
+                fprintf(stderr, "::warning::generate_urlhealth_main(%s) returned %d\n",
+                        branch_dispatch[i].branch, br_rc);
+                rc = br_rc;
+            }
+        }
+        if (any_enabled) return rc;
     }
 
     return 0;


### PR DESCRIPTION
## Root cause

C runs 25995156167 and 25995330004 both completed in ~4 min producing **zero `.prn` files** and 7 strict-fail journal rows each — by construction, not by real diff.

Bug at `src/main.c:271-275`:

\`\`\`c
if (generate_urlhealth_branch != NULL && generate_urlhealth_branch[0] != '\0') {
    return generate_urlhealth_main(&params, generate_urlhealth_branch);
}
return 0;
\`\`\`

The 7 \`-GeneratePh*URLHealthReport\` flags were parsed and stored on \`params\` but never consulted. Only the hidden \`--generate-urlhealth-report <branch>\` test helper triggered any work. The CI workflow passes the public flags expecting them to drive iteration. They didn't.

## Fix

Add a multi-branch dispatcher in \`main()\` that, when \`--generate-urlhealth-report\` is unset, walks the 7 flags via an \`offsetof\`-indexed table and calls \`generate_urlhealth_main(&params, \"<branch>\")\` for each enabled one. Branch mapping per FRD-015 §2.1:

| Flag | Branch |
|---|---|
| GeneratePh3URLHealthReport      | 3.0 |
| GeneratePh4URLHealthReport      | 4.0 |
| GeneratePh5URLHealthReport      | 5.0 |
| GeneratePh6URLHealthReport      | 6.0 |
| GeneratePhCommonURLHealthReport | common |
| GeneratePhDevURLHealthReport    | dev |
| GeneratePhMasterURLHealthReport | master |

Per-branch failures are soft (\`::warning::\` and continue). Exit code reflects the last non-zero return from \`generate_urlhealth_main\`. When all flags are off, the dispatcher does nothing — preserves existing test/unit-harness behaviour which never sets these flags.

## Files

| File | Change |
|---|---|
| \`src/main.c\` | +39 lines: dispatcher loop after the existing \`generate_urlhealth_branch\` early-return; \`#include <stddef.h>\` for \`offsetof\` |
| \`specs/features/FRD-015-generate-urlhealth-reports.md\` | §2.1 documents the dispatcher contract |
| \`specs/tasks/README.md\` | Phase M task M02 row |
| \`CLAUDE.md\` | Phase tracker M row annotated |

## Test plan

- [x] \`ctest --test-dir build\` → 13/13 PASSED.
- [x] Smoke test: 3 enabled branches with empty workingDir → 3 parse_directory warnings + exit 1.
- [x] Smoke test: all-disabled → silent exit 0.
- [ ] After merge: next dispatched C workflow run produces actual \`.prn\` files (7 of them) under \`\$SCANS\`, and parity-journal rows reflect real C↔PS divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)