### PR TITLE
phase-M task M03: prefix photon- on SPECS path + clone_root in generate_urlhealth_main

### DIFF
--- a/photonos-package-report/photonos-package-report/specs/tasks/README.md
+++ b/photonos-package-report/photonos-package-report/specs/tasks/README.md
@@ -166,6 +166,7 @@ amendment (or new FRD if scope warrants).
 |---|---|---|---|---|---|
 | M01 | Mirror PS PR #84: extend `-UpstreamsExclusionList` to skip clone creation in C (`pr_should_skip_clone` + guard at `check_urlhealth.c:107-115`) | FRD-012 | 0001,0006 | 2369-2392, 3659-3679, 4014-4034 | strict |
 | M02 | Multi-branch dispatcher in `main.c` so the 7 `-GeneratePh*URLHealthReport` flags actually drive iteration (was silently dropped, causing parity-journal strict-fails) | FRD-015 | 0001 | 5040-5215 | strict |
+| M03 | `generate_urlhealth_main` prefixes `photon-` when constructing the on-disk SPECS path + clone_root (matches PS L 461, L 5304). Without this, M02's bare-tag branches hit `parse_directory: SPECS path not a directory`. | FRD-015 | 0001 | 461, 5304 | strict |
 
 ---
 

--- a/photonos-package-report/photonos-package-report/src/main.c
+++ b/photonos-package-report/photonos-package-report/src/main.c
@@ -429,9 +429,24 @@ static int dump_tasks_main(const char *working_dir, const char *branch)
 
 static int generate_urlhealth_main(const pr_params_t *params, const char *branch)
 {
+    /* `branch` is the bare PS-side tag — "3.0", "master", … — that names
+     * the output `.prn` and matches the `-GeneratePh*URLHealthReport`
+     * flag. The on-disk directory layout follows PS L 461:
+     *
+     *     $photonPath = Join-Path $WorkingDir "photon-$release"
+     *
+     * so SPECS lives under `<workingDir>/photon-<branch>/SPECS`. Compute
+     * that prefix once here. */
+    char photon_dir[64];
+    int n = snprintf(photon_dir, sizeof photon_dir, "photon-%s", branch);
+    if (n < 0 || (size_t)n >= sizeof photon_dir) {
+        fprintf(stderr, "generate_urlhealth: branch '%s' too long\n", branch);
+        return 1;
+    }
+
     pr_task_list_t list;
     pr_task_list_init(&list);
-    if (parse_directory(params->workingDir, branch, &list) != 0) {
+    if (parse_directory(params->workingDir, photon_dir, &list) != 0) {
         pr_task_list_free(&list);
         return 1;
     }
@@ -469,13 +484,15 @@ static int generate_urlhealth_main(const pr_params_t *params, const char *branch
         pr_prn_close(p); pr_source0_lookup_free(&lut); pr_task_list_free(&list);
         return 1;
     }
-    /* Phase 6d: pass upstreamsDir/photonDir as the clone root so the
-     * git-tag chain populates UpdateDownloadName / UpdateAvailable
-     * when PR_TEST_NETWORK=1 is set. */
+    /* Phase 6d: pass upstreamsDir/photon-<branch>/clones as the clone
+     * root so the git-tag chain populates UpdateDownloadName /
+     * UpdateAvailable when PR_TEST_NETWORK=1 is set. Same photon-
+     * prefix convention as parse_directory above (PS L 5304:
+     *   $cloneDir = Join-Path $upstreamsDir "photon-$($entry.Key)" "clones"). */
     char *clone_root = NULL;
     const char *up_dir = (params->upstreamsDir && params->upstreamsDir[0])
                          ? params->upstreamsDir : params->workingDir;
-    if (asprintf(&clone_root, "%s/%s/clones", up_dir, branch) < 0) {
+    if (asprintf(&clone_root, "%s/%s/clones", up_dir, photon_dir) < 0) {
         clone_root = NULL;
     }
 


### PR DESCRIPTION
Companion fix for #92 (M02 dispatcher). C run [25996798147](https://github.com/dcasota/photonos-scripts/actions/runs/25996798147) demonstrated the dispatcher now reaches all 7 branches, but each one hit:

```
parse_directory: SPECS path not a directory:
    /root/actions-runner/_work/_temp/parity-c-wd/3.0/SPECS
```

The on-disk layout from `parity-snapshot.sh` + `parity-reconstruct.sh` uses the PS convention `photon-<release>/` (per PS L 461). M02 passed bare branch tags (`3.0`, `master`, …) to `generate_urlhealth_main`, which used them directly as the `photon_dir` arg.

## Fix

`generate_urlhealth_main()` computes `photon_dir = "photon-" + branch` once and uses it for both:
- `parse_directory(workingDir, photon_dir, ...)` — PS L 461
- `clone_root = "<upstreamsDir>/<photon_dir>/clones"` — PS L 5304

The bare `branch` arg keeps its role for the output `.prn` filename (`photonos-urlhealth-<branch>_<ts>.prn`) and the `-GeneratePh*URLHealthReport` flag mapping. Two distinct namespaces with one source of truth.

## Test plan

- [x] `ctest --test-dir build` → 13/13 PASSED.
- [x] Smoke: `<wd>/photon-3.0/SPECS/` empty fixture → binary writes `scans/photonos-urlhealth-3.0_<ts>.prn`, exit 0.
- [ ] After merge: next C-side workflow run finds SPECS for all 7 enabled branches, writes 7 `.prn` files, `parity-diff` produces meaningful verdicts (not all strict-by-construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)