### PR TITLE
phase-M task M04: partial-clone + token leak hardening

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -182,12 +182,16 @@ jobs:
             THROTTLE="8"
           fi
 
+          # Token is read from $GITHUB_TOKEN env (env_or() default in
+          # main.c L101). Passing it as -github_token would leak the
+          # value into the runner's ps(1) output for the lifetime of
+          # the binary — env vars are scoped to the process and not
+          # visible in argv.
           ./build/photonos-package-report \
             -workingDir   "$WDIR" \
             -upstreamsDir "$UPSTREAMS" \
             -scansDir     "$SCANS" \
             -ThrottleLimit "$THROTTLE" \
-            -github_token "$GITHUB_TOKEN" \
             -UpstreamsExclusionList "$UPSTREAMS_EXCL" \
             -GeneratePh3URLHealthReport      "${{ steps.branches.outputs.ph3 }}" \
             -GeneratePh4URLHealthReport      "${{ steps.branches.outputs.ph4 }}" \

--- a/photonos-package-report/photonos-package-report/specs/tasks/README.md
+++ b/photonos-package-report/photonos-package-report/specs/tasks/README.md
@@ -167,6 +167,7 @@ amendment (or new FRD if scope warrants).
 | M01 | Mirror PS PR #84: extend `-UpstreamsExclusionList` to skip clone creation in C (`pr_should_skip_clone` + guard at `check_urlhealth.c:107-115`) | FRD-012 | 0001,0006 | 2369-2392, 3659-3679, 4014-4034 | strict |
 | M02 | Multi-branch dispatcher in `main.c` so the 7 `-GeneratePh*URLHealthReport` flags actually drive iteration (was silently dropped, causing parity-journal strict-fails) | FRD-015 | 0001 | 5040-5215 | strict |
 | M03 | `generate_urlhealth_main` prefixes `photon-` when constructing the on-disk SPECS path + clone_root (matches PS L 461, L 5304). Without this, M02's bare-tag branches hit `parse_directory: SPECS path not a directory`. | FRD-015 | 0001 | 461, 5304 | strict |
+| M04 | `do_clone` switches to `--no-checkout --filter=blob:none` partial clone (10-100× speedup for big repos: llvm-project, dotnet/runtime, elasticsearch). Mask `github_token` / `gitlab_freedesktop_org_token` in main.c param echo, drop `-github_token` CLI arg in workflow (was leaking to ps(1) on the runner). | FRD-012 | 0001,0006 | n/a | strict |
 
 ---
 

--- a/photonos-package-report/photonos-package-report/src/clone.c
+++ b/photonos-package-report/photonos-package-report/src/clone.c
@@ -139,11 +139,22 @@ static int do_clone(const char *clone_root,
                     const char *git_branch,
                     const char *repo_name)
 {
+    /* Partial clone: --no-checkout skips populating the working tree;
+     * --filter=blob:none defers blob fetches. The C binary only ever
+     * calls `git tag -l` on the result (see pr_clone_list_tags), so
+     * blobs are never demanded and tags resolve from the lightweight
+     * commit/tree object set. For big repos (llvm-project, dotnet/
+     * runtime, elasticsearch, …) this cuts clone time 10–100×.
+     *
+     * Parity impact: zero. `.prn` columns 5/6/10 depend only on the
+     * tag list, which is identical between full and partial clones. */
     char *args = NULL;
     if (git_branch && git_branch[0]) {
-        if (asprintf(&args, "clone %s -b %s %s", git_url, git_branch, repo_name) < 0) return -1;
+        if (asprintf(&args, "clone --no-checkout --filter=blob:none %s -b %s %s",
+                     git_url, git_branch, repo_name) < 0) return -1;
     } else {
-        if (asprintf(&args, "clone %s %s", git_url, repo_name) < 0) return -1;
+        if (asprintf(&args, "clone --no-checkout --filter=blob:none %s %s",
+                     git_url, repo_name) < 0) return -1;
     }
     char *stdout_buf = NULL;
     int rc = invoke_git_with_timeout(args, clone_root, 0, &stdout_buf);

--- a/photonos-package-report/photonos-package-report/src/main.c
+++ b/photonos-package-report/photonos-package-report/src/main.c
@@ -239,9 +239,14 @@ int main(int argc, char **argv)
      * When --dump-tasks <branch> is specified, the param echo is skipped:
      * the parity harness compares ONLY the JSON dump on stdout. */
     if (dump_tasks_branch == NULL) {
-    printf("github_token=%s\n",                                                 params.github_token);
+    /* Mask secret values in the param echo. CI runners mask via the
+     * `***` substitution on workflow log lines, but local invocations
+     * (gdb, smoke tests) emit the raw value otherwise. Keep a non-empty
+     * "(set)" marker so operators can still tell whether a token was
+     * supplied. */
+    printf("github_token=%s\n",                                                 (params.github_token && params.github_token[0]) ? "(set)" : "");
     printf("gitlab_freedesktop_org_username=%s\n",                              params.gitlab_freedesktop_org_username);
-    printf("gitlab_freedesktop_org_token=%s\n",                                 params.gitlab_freedesktop_org_token);
+    printf("gitlab_freedesktop_org_token=%s\n",                                 (params.gitlab_freedesktop_org_token && params.gitlab_freedesktop_org_token[0]) ? "(set)" : "");
     printf("workingDir=%s\n",                                                   params.workingDir);
     printf("upstreamsDir=%s\n",                                                 params.upstreamsDir);
     printf("scansDir=%s\n",                                                     params.scansDir);


### PR DESCRIPTION
Bundles two related fixes uncovered diagnosing C run [25997123006](https://github.com/dcasota/photonos-scripts/actions/runs/25997123006).

## Part 1 — Partial clones (the throughput fix)

That run had 5 of 8 worker slots pinned on multi-GB repos (`llvm-project`, `dotnet/runtime`, `elasticsearch`, `aufs-linux`, …). Network was at 14 MB/s — not saturated. The bottleneck was per-connection pack-server speed × repo size.

C binary only ever calls `git tag -l` on the clone (see `pr_clone_list_tags`). Blobs are never demanded. Switch `do_clone` to:

```
git clone --no-checkout --filter=blob:none <url> <repo>
```

Fetches commits + trees + tag refs, defers blobs. For `llvm-project` this drops the clone from gigabytes to tens of MB. Expected 10-100× speedup for big repos.

**Parity impact: zero.** `.prn` cols 5/6/10 depend only on the tag list, identical between full and partial clones.

## Part 2 — Token leak hardening

Two distinct leak paths surfaced during today's smoke tests:

| Path | Description | Severity |
|---|---|---|
| `main.c` L242 param echo | Printed `github_token=<raw>` in plaintext. CI masks via Actions `***` substitution, but local invocations (gdb, ad-hoc) emitted the raw value. A `ghp_*` PAT leaked through this into a session transcript earlier today (already rotated). | High |
| Workflow `-github_token "$GITHUB_TOKEN"` | The value appeared in argv, visible to `ps -ef` for the binary's lifetime. Run 25997123006 exposed the run-scoped `ghs_*` token via this path. | Medium (run-scoped, expires) |

Fixes:
- `main.c` L242 + L244: emit `(set)` instead of raw value for `github_token` and `gitlab_freedesktop_org_token`. Operators can still tell whether a token was supplied.
- Workflow drops `-github_token` from the CLI. Binary already reads `\$GITHUB_TOKEN` from env via `env_or()` at `main.c:101`. Env vars are process-scoped — not visible in argv, not echoed by `ps`.

## Test plan

- [x] `ctest --test-dir build` → 13/13 PASSED.
- [x] Smoke: `-github_token foo` arg → echo prints `github_token=(set)`. Env unset + no arg → `github_token=` (empty).
- [ ] After merge: re-dispatch C workflow. Expect:
  - Token NOT in `ps -ef` of the C binary
  - Run completes well under 8h (vs ~7h projected on previous pace)
  - `.prn` files for all 7 branches; parity-journal rows reflect real C↔PS divergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)