### PR TITLE
docs(CLAUDE): tracker hygiene — add Phase 8.5, enumerate M01-M04

### DIFF
--- a/photonos-package-report/photonos-package-report/CLAUDE.md
+++ b/photonos-package-report/photonos-package-report/CLAUDE.md
@@ -64,8 +64,9 @@ while the tool is live.
 | 6f | SHA helpers + cross-branch diff (col 9 wired)         | done (#65)  |
 | 7  | Cluster orchestrator + parallel runspace mirror (`-ThrottleLimit`) | done (#66) |
 | 8  | CI side-by-side parity gate                           | done (#67)  |
-| 9  | Retirement (PS → staging/legacy/, C-only)             | pending     |
-| M  | Maintainer ops & debug tooling — `docs/maintainer-runbook.md`, `.vscode/`; M01 mirrors PS PR #84 (`-UpstreamsExclusionList` skips clone creation); M02 multi-branch dispatcher in `main.c` | ongoing |
+| 8.5 | Parity convergence loop — per-bucket PS↔C diff fixes (TODO §3) | in progress |
+| 9  | Retirement (PS → staging/legacy/, C-only)             | pending (gated on 90d green journal) |
+| M  | Maintainer ops & debug tooling — `docs/maintainer-runbook.md`, `.vscode/`; M01 PR #84 mirror (`-UpstreamsExclusionList` clone-skip); M02 multi-branch dispatcher; M03 `photon-` prefix on SPECS path; M04 partial-clone speedup + token-leak hardening | ongoing |
 
 When you land a feature in a numeric phase that changes a workflow the
 maintainer cares about (new flag, new override mechanism, new generator),


### PR DESCRIPTION
Two small fixes to the Phase tracker in `photonos-package-report/photonos-package-report/CLAUDE.md`.

1. **Add Phase 8.5** — "Parity convergence loop". The tracker jumped from Phase 8 (gate exists, PR #67) to Phase 9 (retirement, 90-day-green gated) with the actual per-bucket PS↔C diff-fix work hidden in the gap. Make it explicit.

2. **Refresh Phase M row** — was stale at `M01+M02` since the CLAUDE.md edit predated M03 and M04 landings. Now lists all four shipped Phase-M tasks.

Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)