### PR TITLE
specs: scaffold M05/M06/M07 + FRD-017 + ADR-0012/0013 drafts

### DIFF
--- a/photonos-package-report/photonos-package-report/specs/adr/0012-subrelease-output-layout.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0012-subrelease-output-layout.md
@@ -1,0 +1,97 @@
+# ADR-0012 — Subrelease output layout
+
+**Status**: Draft
+
+**Date**: 2026-05-17
+
+**Deciders**: TBD (user gate per TODO §4 checkpoint)
+
+## Context
+
+Photon 5.0 carries vendor-pinned subrelease trees:
+
+- `SPECS/91/` — 16 packages, marker `vendor-pinned (subrelease 91)`
+- `SPECS/90/` — 53 packages (added 2026-05-12, not yet in the parity snapshot)
+- main `SPECS/` — ~1100 default packages
+
+Today the PS workflow emits ONE `.prn` per branch
+(`photonos-urlhealth-5.0_<ts>.prn`) that contains both default rows and
+subrelease rows mixed together. Subrelease rows are identified by:
+
+- col 4 `UrlHealth` = literal `pinned`
+- col 11 `warning` = `vendor-pinned (subrelease N)`
+
+The same basename (e.g. `dbus.spec`) can appear twice in the same
+`.prn` — once for `SPECS/dbus/dbus.spec` (with full pipeline result)
+and once for `SPECS/91/dbus/dbus.spec` (with pinned sentinel).
+
+## Problem
+
+Disambiguating rows by spec basename alone is impossible at the `.prn`
+level. Tooling that consumes `.prn` (parity-diff, journal, downstream
+report generators) cannot tell which `dbus.spec` row is which without
+inspecting cols 4 + 11.
+
+When SPECS/90 lands in a future snapshot, the same problem doubles.
+
+## Options
+
+### A. Status quo
+
+Single `.prn` per branch. Disambiguation via cols 4 + 11.
+
+- **Pros:** zero tooling change. Backward-compat with all existing
+  parity-diff / journal logic.
+- **Cons:** consumers must know the sentinel encoding. Hard to slice
+  reports "show me only main SPECS for 5.0".
+
+### B. Per-subrelease `.prn` filename
+
+Three files per branch: `photonos-urlhealth-5.0_<ts>.prn`,
+`photonos-urlhealth-5.0-90_<ts>.prn`, `photonos-urlhealth-5.0-91_<ts>.prn`.
+
+- **Pros:** unambiguous slicing. Each `.prn` is internally consistent
+  (no duplicate basenames).
+- **Cons:** parity-diff, journal schema, workflow output collection,
+  and the runbook `gh run download` examples all need updates. New
+  `-GeneratePh5_91URLHealthReport`-style flags? Or detect from SPECS
+  tree automatically?
+
+### C. Column 13 — SubreleasePath
+
+Add a new column to `.prn` carrying the `SpecRelativePath` prefix
+(empty for main, `91` for SPECS/91, `90` for SPECS/90). Filename stays
+single-per-branch.
+
+- **Pros:** unambiguous within a single `.prn`. Disambiguation by a
+  proper data column instead of sentinel-encoding in cols 4 + 11.
+  Tooling diff is smaller than Option B.
+- **Cons:** schema change. Parity-diff awareness of col 13 needed.
+  Journal columns unchanged. Existing `pinned` sentinel can stay or
+  be removed.
+
+## Decision
+
+**Pending user input (TODO §4 checkpoint).** Reviewing the C port's
+current state, Option C (add col 13) is the agent's recommendation:
+smallest tooling delta with cleanest data model. Option A keeps
+working until SPECS/90 makes the duplicate-basename problem painful;
+not actively broken today.
+
+## Consequences
+
+- Whichever option is chosen, the PS L 2155-2200 (or equivalent)
+  pinned-emit short-circuit must continue to recognise the SPECS/<N>/
+  subpath.
+- C port needs symmetric implementation in `parse_directory` →
+  `check_urlhealth` → row assembly.
+- This ADR is gating for Stage 4 of [`TODO.md`](../../../../TODO.md).
+
+## Related
+
+- ADR-0006 (bit-identical `.prn`)
+- ADR-0009 (CI parity gate)
+- FRD-002 (spec parsing)
+- FRD-014 (`.prn` row assembly)
+- [`docs/prn-analysis/photon-5.0-SPECS-90.md`](../../docs/prn-analysis/photon-5.0-SPECS-90.md)
+- [`docs/prn-analysis/photon-5.0-SPECS-91.md`](../../docs/prn-analysis/photon-5.0-SPECS-91.md)

--- a/photonos-package-report/photonos-package-report/specs/adr/0013-source0lookup-per-release.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0013-source0lookup-per-release.md
@@ -1,0 +1,130 @@
+# ADR-0013 — Source0Lookup per-release scoping
+
+**Status**: Draft
+
+**Date**: 2026-05-17
+
+**Deciders**: TBD (user gate per TODO §5 checkpoint)
+
+## Context
+
+`Source0LookupData` is a CSV embedded in
+`photonos-package-report.ps1` between markers `=@'` and `'@`
+(currently L 509-1366, ~855 rows). One row per spec. Shared across
+all branches and subreleases.
+
+The C port reads the same CSV at build time via
+`tools/extract-source0-lookup.sh` → `build/generated/source0_lookup_data.h`
+and parses with `pr_source0_lookup_table_t`.
+
+## Problem
+
+Some specs have **per-release divergent upstream conventions**:
+
+- `dbus.spec` in main 5.0 SPECS/ uses upstream
+  `https://dbus.freedesktop.org/releases/dbus/dbus-<v>.tar.xz`.
+  Same spec in `SPECS/91/dbus/` is vendor-pinned — short-circuits the
+  lookup entirely. Same row applies to both; the SPECS/91/ pipeline
+  is short-circuited externally (in PS substitution logic).
+- `Linux-PAM.spec` exists in SPECS/, SPECS/90/, SPECS/91/. Each
+  branch may want a different version-stream Source0Lookup row.
+- `gstreamer-plugins-base.spec` — overridden `repoName` in PS (see
+  L 2368). Subrelease variants may diverge further.
+
+Today these divergences are handled either by:
+
+1. Hard-coded `if ($currentTask.spec -ilike '...')` exception
+   blocks scattered through the PS script (Phase 3b `extract-spec-hooks.sh`
+   tracks these and the C port mirrors via `src/hooks/*.c`).
+2. The Source0Lookup's `Warning` column to flag manual overrides.
+3. Implicit acceptance that the same lookup row applies to all
+   variants and the result for the "wrong" variant is filtered
+   downstream.
+
+This works for the current ~5-10 divergent specs but doesn't scale
+cleanly if more vendor-pinned subreleases land.
+
+## Options
+
+### A. Status quo
+
+Keep one shared `Source0LookupData` CSV. Per-release / per-subrelease
+exceptions stay as PS hook blocks + C `src/hooks/*.c` mirrors.
+
+- **Pros:** zero schema change. ~855 rows × 1 = 855 rows total. Easy
+  to grep / maintain.
+- **Cons:** doesn't scale. If a new subrelease wants a different
+  upstream URL for spec X, today's only mechanism is a hook block.
+  Hook blocks are imperative code; the CSV is declarative — hooks
+  encode information that "should" be data.
+
+### B. Add `subrelease` column to CSV
+
+CSV schema gains col 10 `subrelease` (after `ArchivationDate`).
+Empty → matches all subreleases. Specific value (`"91"`,
+`"90"`) → matches only that subrelease.
+
+- **Pros:** backward-compat (empty subrelease keeps current
+  behaviour). Targeted divergence — one row per
+  (spec, subrelease) tuple. Replaces several hook blocks with data.
+- **Cons:** lookup is now a two-key match (spec basename +
+  subrelease path). PS + C both need updating. CSV row count grows
+  by the count of (spec, subrelease) tuples actually diverging.
+
+### C. Per-release split files
+
+`Source0Lookup-default.csv`, `Source0Lookup-91.csv`, `-90.csv`. PS
+script reads the appropriate file at runtime based on subrelease.
+
+- **Pros:** maximum separation. Easy to see "what's special for
+  91". Each file ~855 rows or smaller.
+- **Cons:** maintaining N files where most rows are duplicates.
+  Multiple file updates per spec change. PS-extract logic doubles.
+  Easy to drift between files.
+
+### D. Source0LookupData as inheritance chain
+
+Default file is the base. Per-subrelease files contain only the
+differences (overrides). Lookup falls through default → subrelease.
+
+- **Pros:** DRY. Override files are tiny (only the diverging rows).
+- **Cons:** new conceptual layer. Cache invalidation harder. Drift
+  detection more complex.
+
+## Decision
+
+**Pending user input (TODO §5 checkpoint).** Agent recommendation
+on first glance: Option B (add subrelease column). It's the smallest
+backward-compat-preserving schema change and matches how SPECS/<N>/
+is already organised on the filesystem.
+
+But the right answer depends on **how many specs would actually need
+divergent Source0Lookup entries**. If the answer is < 20, Option A
+(status quo + hook blocks) wins. If 20-50, Option B. If > 50,
+consider C or D.
+
+**Pre-decision survey task** (block on this before deciding):
+
+```sh
+# For each spec under SPECS/91/, compare its Source0Lookup row's
+# expected Source0 against the actual Source0 in the .spec. Count
+# divergences.
+```
+
+Output of that survey gates which option is selected.
+
+## Consequences
+
+- Whichever option is chosen, `tools/extract-source0-lookup.sh` and
+  `tools/csv-to-c-string.sh` need updating (and possibly a new
+  `csv-to-c-multitable.sh` for option C/D).
+- `pr_source0_lookup_t` schema may gain a `subrelease` field.
+- Parity gate must handle the choice symmetrically PS↔C.
+- This ADR is gating for Stage 5 of [`TODO.md`](../../../../TODO.md).
+
+## Related
+
+- ADR-0005 (bash+awk source0 embedder)
+- ADR-0006 (bit-identical `.prn`)
+- FRD-003 (Source0Lookup embed)
+- ADR-0012 (subrelease output layout — companion)

--- a/photonos-package-report/photonos-package-report/specs/features/FRD-017-parity-artefact-preservation.md
+++ b/photonos-package-report/photonos-package-report/specs/features/FRD-017-parity-artefact-preservation.md
@@ -1,0 +1,99 @@
+# FRD-017-parity-artefact-preservation: Parity artefact preservation + diff analysis
+
+**Feature ID**: FRD-017-parity-artefact-preservation
+**Related PRD Requirements**: REQ-16 (parity harness)
+**Related ADRs**: ADR-0006, ADR-0009
+**PS source range**: n/a (post-run CI tooling only)
+**Status**: Draft
+**Last updated**: 2026-05-17
+
+---
+
+## 1. Overview
+
+The C-side parity workflow (`package-report-C.yml`) writes `.prn` output to
+`${RUNNER_TEMP}/parity-c-wd/scans/` and the GitHub Actions runner cleans
+that path at job end. When the parity-diff step reports a strict-fail, the
+actual offending `.prn` is no longer available for post-hoc inspection.
+PRs investigating regressions are blocked on either re-running the
+workflow (~1-2h) or trusting the strict-row count without per-spec
+detail.
+
+This FRD specifies:
+
+1. Upload of the C-side `.prn` set as a workflow artifact with a
+   meaningful retention window so post-hoc strict-fail analysis is
+   possible.
+2. A reproducible local diff workflow (`tools/diff_analyzer.py` or
+   equivalent) that takes a PS-snapshot's `prn-snapshot/` and a
+   C-side artefact, and emits per-branch markdown bucketed by which
+   column(s) differ.
+
+## 2. Functional requirements
+
+### 2.1 C-side `.prn` upload (Phase M task M05)
+
+- After the `Run C binary` step in `package-report-C.yml`, before the
+  step that diffs against PS-side and before `_temp/` is cleaned, run:
+
+  ```yaml
+  - name: Upload C-side .prn
+    if: always()
+    uses: actions/upload-artifact@v4
+    with:
+      name: c-side-prn-${{ github.run_id }}
+      path: ${{ steps.c_run.outputs.scans }}/photonos-urlhealth-*.prn
+      if-no-files-found: warn
+      retention-days: 30
+  ```
+
+- 30-day retention matches the journal soft-window per ADR-0009.
+- `if: always()` ensures the artifact is uploaded even when subsequent
+  parity-diff fails — that's exactly when we need the artefact.
+
+### 2.2 Per-branch diff markdown (Phase M task M06)
+
+- `tools/diff_analyzer.py` reads two `.prn` files (PS, C) per branch
+  and emits a markdown report with the following sections:
+  1. **Summary table** — row counts on each side, byte-identical
+     count, divergent count, PS-only specs, C-only specs.
+  2. **Diff-signature table** — for each unique tuple of differing
+     non-volatile columns, list count + sample spec + sample
+     PS/C values.
+  3. **Top buckets — full spec lists** — top 8 diff-signature buckets
+     with their complete affected-spec list (truncated at 30 with
+     remainder count).
+
+- Volatile columns 4 (`UrlHealth`) and 7 (`HealthUpdateURL`) are
+  excluded from the signature per ADR-0006.
+- One markdown per branch: `docs/prn-analysis/diff-c-vs-ps-photon-<branch>.md`.
+
+## 3. Bit-identical assertions
+
+This FRD describes post-run analysis tooling. It does NOT change `.prn`
+output. ADR-0006's bit-identical mandate is unaffected.
+
+## 4. Acceptance tests
+
+- After M05 lands: dispatch a C-side workflow run; verify the artifact
+  appears in `gh run view <id>` with 7 `.prn` files. Re-download via
+  `gh run download <id> -n c-side-prn-<id>` and confirm file contents
+  match what the workflow's `parity-diff` step saw (compare via byte
+  diff against a side-by-side local run).
+- After M06 lands: the 7 markdown files exist in `docs/prn-analysis/`
+  and each opens with a valid summary table. Diff-signature buckets
+  total to the journal's strict_rows count for the corresponding
+  branch.
+
+## 5. Dependencies
+
+- ADR-0006 (bit-identical priority)
+- ADR-0009 (CI parity gate)
+- FRD-016 (parity harness)
+- Workflow `package-report-C.yml` (Phase 8)
+
+## 6. Open questions
+
+- Should the markdown analyses also commit to master, or are they
+  artefact-only / on-demand? Current Draft posits they commit. Open
+  to flipping if the docs churn becomes noisy.

--- a/photonos-package-report/photonos-package-report/specs/tasks/README.md
+++ b/photonos-package-report/photonos-package-report/specs/tasks/README.md
@@ -168,6 +168,9 @@ amendment (or new FRD if scope warrants).
 | M02 | Multi-branch dispatcher in `main.c` so the 7 `-GeneratePh*URLHealthReport` flags actually drive iteration (was silently dropped, causing parity-journal strict-fails) | FRD-015 | 0001 | 5040-5215 | strict |
 | M03 | `generate_urlhealth_main` prefixes `photon-` when constructing the on-disk SPECS path + clone_root (matches PS L 461, L 5304). Without this, M02's bare-tag branches hit `parse_directory: SPECS path not a directory`. | FRD-015 | 0001 | 461, 5304 | strict |
 | M04 | `do_clone` switches to `--no-checkout --filter=blob:none` partial clone (10-100× speedup for big repos: llvm-project, dotnet/runtime, elasticsearch). Mask `github_token` / `gitlab_freedesktop_org_token` in main.c param echo, drop `-github_token` CLI arg in workflow (was leaking to ps(1) on the runner). | FRD-012 | 0001,0006 | n/a | strict |
+| M05 | C-side `.prn` upload as workflow artifact in `package-report-C.yml`. Today the runner cleans `_temp/` at job end and the C-side `.prn` is lost, blocking post-hoc strict-diff investigation. Acceptance: `gh run download <id> -n c-side-prn-<id>` returns 7 files. | FRD-017 | 0006 | n/a | n/a |
+| M06 | Diff-analysis baseline. Run C binary against snapshot SHAs locally, run `diff_analyzer.py` per branch, ship 7 markdown files under `docs/prn-analysis/diff-c-vs-ps-photon-<branch>.md`. Buckets specs by column-set signature with sample values. | FRD-017 | 0006 | n/a | n/a |
+| M07 | Per-bucket convergence loop (parent task; spawns Mxx subtasks). Iterates the priority list in [`TODO.md`](../../../../TODO.md) §3. Each bucket = one PR following the 9-step recipe (read bucket → trace to source → fix direction per CLAUDE.md invariant 2 → spec → implement → smoke test → PR → parity-gate → merge). | FRD-011, FRD-014 | 0006 | varies | strict |
 
 ---
 


### PR DESCRIPTION
Wires the [TODO.md](../blob/master/TODO.md) program of work into the SDD chain.

## What this adds

### Task rows in `specs/tasks/README.md` (Phase M section)

| Task | Subject |
|---|---|
| M05 | C-side `.prn` upload as workflow artifact in `package-report-C.yml` |
| M06 | Diff-analysis baseline — run analyzer, ship 7 per-branch markdowns |
| M07 | Per-bucket convergence loop (parent task; spawns Mxx subtasks per priority bucket) |

### New FRD-017 — Parity artefact preservation

Status: **Draft**. Covers M05+M06: workflow upload-artifact step + the `tools/diff_analyzer.py` markdown contract.

### New ADR-0012 — Subrelease output layout

Status: **Draft**. Three options:
- A: status quo (cols 4+11 sentinel)
- B: per-subrelease filename
- C: col-13 SubreleasePath

Pending user decision per TODO §4 checkpoint.

### New ADR-0013 — Source0Lookup per-release scoping

Status: **Draft**. Four options ranging from status quo + hook blocks to per-release split files with inheritance. Pre-decision survey of divergent-spec count needed.

Pending user decision per TODO §5 checkpoint.

## Verification

- [x] `ctest --test-dir build` → 13/13 PASSED.
- [x] CMake configure clean (no new generators touched).
- [x] No code change — docs/specs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)