### PR TITLE
phase-M task M08: %{version} substitution cuts trailing -release

### DIFF
--- a/photonos-package-report/photonos-package-report/specs/tasks/README.md
+++ b/photonos-package-report/photonos-package-report/specs/tasks/README.md
@@ -171,6 +171,7 @@ amendment (or new FRD if scope warrants).
 | M05 | C-side `.prn` upload as workflow artifact in `package-report-C.yml`. Today the runner cleans `_temp/` at job end and the C-side `.prn` is lost, blocking post-hoc strict-diff investigation. Acceptance: `gh run download <id> -n c-side-prn-<id>` returns 7 files. **Implemented** in workflow YAML; smoke-test pending next workflow_dispatch. | FRD-017 | 0006 | n/a | n/a |
 | M06 | Diff-analysis baseline. Run C binary against snapshot SHAs locally, run `diff_analyzer.py` per branch, ship 7 markdown files under `docs/prn-analysis/diff-c-vs-ps-photon-<branch>.md`. Buckets specs by column-set signature with sample values. | FRD-017 | 0006 | n/a | n/a |
 | M07 | Per-bucket convergence loop (parent task; spawns Mxx subtasks). Iterates the priority list in [`TODO.md`](../../../../TODO.md) §3. Each bucket = one PR following the 9-step recipe (read bucket → trace to source → fix direction per CLAUDE.md invariant 2 → spec → implement → smoke test → PR → parity-gate → merge). | FRD-011, FRD-014 | 0006 | varies | strict |
+| M08 | `%{version}` substitution cut: mirror PS L 2111-2119 to strip the trailing `-release` from `task->Version` before substitution (with dot-suffix preservation for Photon dist tags). Fixes the dominant ~550-spec-per-branch diff signature `Source0_modified,UpdateAvailable,UpdateURL,SHAName,UpdateDownloadName`. Smoke: 946 of 1034 photon-4.0 specs now have matching col-3 vs ~2 before. | FRD-011 | 0006 | 2111-2119 | strict |
 
 ---
 

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -54,6 +54,58 @@ static char *dup_or_empty(const char *s)
     return p;
 }
 
+/* PS L 2111-2119: "cut last index in $currentTask.version and save value
+ * in $version". Mirror byte-for-byte.
+ *
+ *   $versionArray = ($currentTask.version).split("-")
+ *   if ($versionArray.length -gt 0) {
+ *       $version = $versionArray[0]
+ *       for ($i=1; $i -lt ($versionArray.length-1); $i++) {
+ *           $version = concat($version, "-", $versionArray[$i])
+ *       }
+ *       if ($versionArray[length-1] -ilike '*.*') {
+ *           if (last("." split of last element) -ne "") {
+ *               $version = concat($version, "-", that-last-dot-split-element)
+ *           }
+ *       }
+ *   }
+ *
+ * Equivalent in C: take task_version[0..last_dash) as the prefix; if the
+ * last "-"-separated element contains a '.', append "-" + the part after
+ * its last '.'. The "loop concat" is implicit because strrchr finds the
+ * LAST dash, so the prefix already includes intermediate dashes. */
+static char *version_cut(const char *task_version)
+{
+    if (task_version == NULL || *task_version == '\0') return dup_or_empty("");
+
+    const char *last_dash = strrchr(task_version, '-');
+    size_t prefix_len = last_dash ? (size_t)(last_dash - task_version)
+                                  : strlen(task_version);
+
+    /* "Last element" is everything after the last '-', or the whole
+     * string if there is none (mirroring PS when versionArray.length=1). */
+    const char *last_part = last_dash ? last_dash + 1 : task_version;
+    const char *last_dot_in_part = strrchr(last_part, '.');
+
+    if (last_dot_in_part && *(last_dot_in_part + 1)) {
+        const char *suffix = last_dot_in_part + 1;
+        size_t suffix_len = strlen(suffix);
+        char *out = (char *)malloc(prefix_len + 1 + suffix_len + 1);
+        if (!out) return dup_or_empty("");
+        memcpy(out, task_version, prefix_len);
+        out[prefix_len] = '-';
+        memcpy(out + prefix_len + 1, suffix, suffix_len);
+        out[prefix_len + 1 + suffix_len] = '\0';
+        return out;
+    }
+
+    char *out = (char *)malloc(prefix_len + 1);
+    if (!out) return dup_or_empty("");
+    memcpy(out, task_version, prefix_len);
+    out[prefix_len] = '\0';
+    return out;
+}
+
 char *check_urlhealth(pr_task_t                       *task,
                       const pr_source0_lookup_table_t *lookup_table,
                       const char                      *clone_root,
@@ -82,10 +134,11 @@ char *check_urlhealth(pr_task_t                       *task,
         state.ArchivationDate = dup_or_empty(row->ArchivationDate);
     }
 
-    /* PS L 2108: $version cut. Phase 6b refines this; for 6a we use
-     * task->Version verbatim. */
+    /* PS L 2111-2119: cut the trailing "-release" off task->Version
+     * (with dot-suffix preservation for Photon-style dist tags like
+     * "ph5"). See version_cut() above. */
     free(state.version);
-    state.version = dup_or_empty(task->Version);
+    state.version = version_cut(task->Version);
 
     /* Phase 3b per-spec exception hook. */
     pr_hooks_run(task, &state);


### PR DESCRIPTION
First Stage-3 bucket fix per [TODO.md §3](TODO.md). Targets the dominant diff signature surfaced by [M06's analyzer](photonos-package-report/photonos-package-report/docs/prn-analysis/diff-c-vs-ps-photon-4.0.md):

`Source0_modified, UpdateAvailable, UpdateURL, SHAName, UpdateDownloadName` — ~550 specs per branch, ~2700 across 4.0/5.0/6.0/dev/master.

## Root cause

PS at L 2111-2119 (inside CheckURLHealth) cuts the trailing `-release` off `task.Version` before substitution. C port skipped this — see the comment `Phase 6b refines this; for 6a we use task->Version verbatim` at `src/check_urlhealth.c:86`. So `%{version}` got substituted with `3.2.5-2` instead of `3.2.5`, the rewritten URL 404'd, and downstream cols cascade-empty.

## Fix

Static `version_cut()` helper in `src/check_urlhealth.c`. Mirrors PS byte-for-byte:

| Input | Output |
|---|---|
| `3.2.5-2` | `3.2.5` |
| `3.2.5-3.ph5` | `3.2.5-ph5` (dot-suffix preserved for Photon dist tags like `ph5` / `kat`) |
| `a-b-c-d` | `a-b-c` (only the LAST `-` segment dropped) |
| `""` | `""` |

The dot-suffix branch mirrors PS's L 2119 behaviour of preserving distributors like `ph5` where the Release field looks like `3.ph5`.

## Smoke verification

Offline binary against photon-4.0 SPECS tree (1034 specs):

| | matching col-3 (Source0_modified) |
|---|---|
| Before | **2** / 1034 |
| After  | **946** / 1034 |

Sample (GConf, Version 3.2.5 Release 2):
- Before: `...GConf/3.2/GConf-3.2.5-2.tar.xz` (broken — 404 on probe)
- After:  `...GConf/3.2/GConf-3.2.5.tar.xz` (matches PS)

`ctest --test-dir build` 13/13 PASSED.

## Test plan

- [x] Build clean.
- [x] Unit tests 13/13 PASSED.
- [x] Offline smoke: GConf, atftp, apr Source0_modified all match PS exactly.
- [x] Whole-branch 4.0 smoke: 946/1034 col-3 match.
- [ ] After merge: dispatch C-side workflow, verify M06's `%{version}` diff signature collapses across all 7 branches in the next diff_analyzer rebaseline.

## Expected post-merge effect

The dominant 550-spec bucket should disappear from `diff-c-vs-ps-photon-<branch>.md` for 4.0/5.0/6.0/dev/master. Other related buckets that cascade from this same bug (e.g. `Source0_modified,UpdateAvailable`) will also shrink. The remaining ~88 col-3 mismatches on 4.0 are different bugs — M09+ candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)