### PR TITLE
phase-M task M09: ftp.gnu.org → ftp.funet.fi mirror rewrite

### DIFF
--- a/photonos-package-report/photonos-package-report/specs/tasks/README.md
+++ b/photonos-package-report/photonos-package-report/specs/tasks/README.md
@@ -172,6 +172,7 @@ amendment (or new FRD if scope warrants).
 | M06 | Diff-analysis baseline. Run C binary against snapshot SHAs locally, run `diff_analyzer.py` per branch, ship 7 markdown files under `docs/prn-analysis/diff-c-vs-ps-photon-<branch>.md`. Buckets specs by column-set signature with sample values. | FRD-017 | 0006 | n/a | n/a |
 | M07 | Per-bucket convergence loop (parent task; spawns Mxx subtasks). Iterates the priority list in [`TODO.md`](../../../../TODO.md) §3. Each bucket = one PR following the 9-step recipe (read bucket → trace to source → fix direction per CLAUDE.md invariant 2 → spec → implement → smoke test → PR → parity-gate → merge). | FRD-011, FRD-014 | 0006 | varies | strict |
 | M08 | `%{version}` substitution cut: mirror PS L 2111-2119 to strip the trailing `-release` from `task->Version` before substitution (with dot-suffix preservation for Photon dist tags). Fixes the dominant ~550-spec-per-branch diff signature `Source0_modified,UpdateAvailable,UpdateURL,SHAName,UpdateDownloadName`. Smoke: 946 of 1034 photon-4.0 specs now have matching col-3 vs ~2 before. | FRD-011 | 0006 | 2111-2119 | strict |
+| M09 | ftp.gnu.org → ftp.funet.fi mirror rewrite post-substitution (PS L 2343-2346). Affects ~50 specs/branch using GNU FTP. Confirmed byte-exact match for autoconf-archive. | FRD-011 | 0001,0006 | 2343-2346 | strict |
 
 ---
 

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -21,6 +21,7 @@
 #include "pr_latest.h"
 #include "pr_state.h"
 #include "pr_sha.h"
+#include "pr_strutil.h"
 #include "pr_substitute.h"
 #include "pr_url_util.h"
 #include "pr_urlhealth.h"
@@ -145,6 +146,16 @@ char *check_urlhealth(pr_task_t                       *task,
 
     /* Phase 4 substitution (PS L 2172-2199). */
     pr_source0_substitute(task, &state.Source0, state.version);
+
+    /* PS L 2343-2346: ftp.gnu.org is frequently down. Rewrite to the
+     * FUNET mirror which holds an identical archive layout. Applies
+     * post-substitution, pre-urlhealth. The rewrite is case-insensitive
+     * (`-replace` in PS without `c` flag); `istr_replace_all` matches. */
+    if (state.Source0 && strstr(state.Source0, "ftp.gnu.org") != NULL) {
+        state.Source0 = istr_replace_all(state.Source0,
+                                         "ftp.gnu.org",
+                                         "ftp.funet.fi/pub/gnu/ftp.gnu.org");
+    }
 
     /* Phase 5 urlhealth probe. Skipped offline so ctest stays hermetic. */
     int health = 0;


### PR DESCRIPTION
Next Stage-3 bucket fix per [TODO.md §3](TODO.md). Targets bucket #5 in [diff-c-vs-ps-photon-4.0.md](photonos-package-report/photonos-package-report/docs/prn-analysis/diff-c-vs-ps-photon-4.0.md): `Source0_modified,UpdateAvailable,UpdateURL,SHAName,UpdateDownloadName` (~50 specs/branch using GNU upstreams).

## Root cause

PS L 2343-2346: rewrites any post-substitution Source0 containing `ftp.gnu.org` to the FUNET mirror `ftp.funet.fi/pub/gnu/ftp.gnu.org` because the GNU FTP is frequently down. C port was missing this rewrite.

## Fix

`src/check_urlhealth.c` between Phase 4 substitution and Phase 5 urlhealth probe:

```c
if (state.Source0 && strstr(state.Source0, "ftp.gnu.org") != NULL) {
    state.Source0 = istr_replace_all(state.Source0,
                                     "ftp.gnu.org",
                                     "ftp.funet.fi/pub/gnu/ftp.gnu.org");
}
```

`strstr` gate keeps the realloc path off the hot loop for non-GNU specs.

## Smoke

| | Source0_modified |
|---|---|
| PS expected | `http://ftp.funet.fi/pub/gnu/ftp.gnu.org/gnu/autoconf-archive/autoconf-archive-2019.01.06.tar.xz` |
| C output    | (same) |

Byte-exact match. `ctest` 13/13 PASSED.

## Affected specs (50 in 4.0)

autoconf-archive, autogen, bison, compat-gdbm, ed, emacs, gcc, gcc-12, gcc-aarch64-linux-gnu, guile, libunwind, patch, pth, tar, wget, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)