### PR TITLE
phase-M task M10: UpdateAvailable comparison branches

### DIFF
--- a/photonos-package-report/photonos-package-report/specs/tasks/README.md
+++ b/photonos-package-report/photonos-package-report/specs/tasks/README.md
@@ -173,6 +173,7 @@ amendment (or new FRD if scope warrants).
 | M07 | Per-bucket convergence loop (parent task; spawns Mxx subtasks). Iterates the priority list in [`TODO.md`](../../../../TODO.md) §3. Each bucket = one PR following the 9-step recipe (read bucket → trace to source → fix direction per CLAUDE.md invariant 2 → spec → implement → smoke test → PR → parity-gate → merge). | FRD-011, FRD-014 | 0006 | varies | strict |
 | M08 | `%{version}` substitution cut: mirror PS L 2111-2119 to strip the trailing `-release` from `task->Version` before substitution (with dot-suffix preservation for Photon dist tags). Fixes the dominant ~550-spec-per-branch diff signature `Source0_modified,UpdateAvailable,UpdateURL,SHAName,UpdateDownloadName`. Smoke: 946 of 1034 photon-4.0 specs now have matching col-3 vs ~2 before. | FRD-011 | 0006 | 2111-2119 | strict |
 | M09 | ftp.gnu.org → ftp.funet.fi mirror rewrite post-substitution (PS L 2343-2346). Affects ~50 specs/branch using GNU FTP. Confirmed byte-exact match for autoconf-archive. | FRD-011 | 0001,0006 | 2343-2346 | strict |
+| M10 | UpdateAvailable comparison branches: emit `(same version)` when latest==spec, emit warning when latest<spec (PS L 2538-2553). Also fix the compare to use `state.version` (cut form) instead of `task->Version` (X-Y form) — otherwise tomcat9-style packages with Release suffix never match "same". Buckets affected: `UpdateAvailable` (62 specs/4.0) and `UpdateAvailable,warning` (25 specs/4.0). | FRD-011 | 0001,0006 | 2538-2553 | strict |
 
 ---
 

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -239,13 +239,42 @@ char *check_urlhealth(pr_task_t                       *task,
                                 state.UpdateDownloadName = dup_or_empty(latest);
                             }
 
-                            /* UpdateAvailable (col 5): set to NameLatest iff
-                             * pr_version_compare(NameLatest, task.version) == 1. */
+                            /* UpdateAvailable (col 5) per PS L 2538-2553:
+                             *
+                             *   $result = Compare-VersionStrings $Namelatest $version
+                             *   if ($result -gt 0) $UpdateAvailable = $NameLatest
+                             *   elseif ($result -lt 0) $UpdateAvailable = "Warning: ..."
+                             *   else                   $UpdateAvailable = "(same version)"
+                             *
+                             * The compare in PS uses `$version` (the cut form from
+                             * L 2114), NOT $currentTask.version (the uncut "X-Y"
+                             * form). Mirror that here — pass state.version, not
+                             * task->Version, otherwise tomcat9-style packages
+                             * with Release suffix never match "same". */
                             int rc = pr_version_compare(latest,
-                                                        task->Version ? task->Version : "");
+                                                        state.version ? state.version : "");
+                            free(state.UpdateAvailable);
                             if (rc == 1) {
-                                free(state.UpdateAvailable);
                                 state.UpdateAvailable = dup_or_empty(latest);
+                            } else if (rc == 0) {
+                                state.UpdateAvailable = dup_or_empty("(same version)");
+                            } else if (rc == -1) {
+                                /* PS warning text — note the lone-space before
+                                 * the trailing period; must match byte-for-byte. */
+                                char *warn = NULL;
+                                if (asprintf(&warn,
+                                             "Warning: %s Source0 version %s is higher than detected latest version %s .",
+                                             task->Spec ? task->Spec : "",
+                                             state.version ? state.version : "",
+                                             latest) < 0) {
+                                    warn = NULL;
+                                }
+                                state.UpdateAvailable = warn ? warn : dup_or_empty("");
+                            } else {
+                                /* rc == -2 (parse error): PS Write-Host the
+                                 * "comparison failed" diagnostic and leaves
+                                 * $UpdateAvailable as its prior empty default. */
+                                state.UpdateAvailable = dup_or_empty("");
                             }
 
                             /* Phase 6f col 9 SHAValue (PS L 4912-4921):


### PR DESCRIPTION
Fixes the bucket `UpdateAvailable` (62 specs/4.0, sample apache-tomcat9) and contributes to `UpdateAvailable,warning` (25 specs/4.0).

## Root cause

`check_urlhealth.c` only handled `pr_version_compare() == 1`. Missing:
- `== 0` → `UpdateAvailable = "(same version)"`
- `== -1` → warning string

Plus the compare used `task->Version` (uncut `3.2.5-2`) where PS L 2538 uses `$version` (cut form). For Release-suffixed specs the compare never returned 0 even when versions did match.

## Fix

`src/check_urlhealth.c:242` — all four PS branches wired in, compare uses `state.version` (cut form from M08).

PS warning string mirrored byte-for-byte including the lone space before the trailing period.

`ctest` 13/13 PASSED. Smoke verification deferred to CI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)