### PR TITLE
docs: session-context refresh for fresh-session continuity

### DIFF
--- a/ITERATIONS-LOG.md
+++ b/ITERATIONS-LOG.md
@@ -1,0 +1,97 @@
+# Iterations log — Phase M convergence loop
+
+Append-only record of the autonomous-loop iterations. Each entry lists
+the PR(s) shipped, the C run that validated them, and the journal-row
+delta. For methodology and current backlog, see `TODO.md`. For
+decision history, see `specs/adr/*.md`. For per-task spec rows, see
+`photonos-package-report/photonos-package-report/specs/tasks/README.md`.
+
+---
+
+## Session 1: 2026-05-17 evening → 2026-05-18 morning
+
+Started with parity gate freshly online (Phase 8 done). Goal initially
+framed as parity-only; reframed mid-session (per user) as dual goal —
+parity AND vendor-info quality.
+
+### Iteration shape
+
+```
+M08 → M09 → M10 → M11 → M12 → M13 → M14 → M15 → M16
+                                      │
+                                      └─ keystone fix (case-insensitive sort)
+                                         unmasked M08-M13 in the journal
+```
+
+Plus M17 (ADR-0012/0013 decisions + pinned sentinel), M18/M19 (HEAD-fail
+warning + name-replace augmentations), M20 (HTTP listing scraper /
+FRD-018), M21 (post-strip filters), ADR-0014 (multi-SHA Draft).
+
+### Per-iteration log
+
+| PR | Task | Key insight |
+|---|---|---|
+| #100 | **M08** — `%{version}` cut (PS L 2111-2119) | C was using the uncut `Version-Release` form for substitution. |
+| #102 | **M09** — `ftp.gnu.org` → `ftp.funet.fi` mirror | PS L 2343-2346. ~50 GNU specs affected. |
+| #103 | **M10** — UpdateAvailable compare branches | Emit `(same version)` / warning text; compare against cut form. |
+| #104 | **M11** — UpdateDownloadName post-process | v-strip + name-prefix-for-numeric (PS L 4770/4782-4783). |
+| #105 | **M12** — Gate URL/SHA/DownloadName on rc==1 only | PS leaves cols empty when "(same version)"; C was filling them. |
+| #106 | **M13** — Per-spec warning table (~70 entries) | PS L 4442-4519. New `src/spec_warnings.c`. |
+| #107 | **M14** — `.prn` sort case-insensitive (KEYSTONE) | `parity-diff.sh` compares by line index. PS uses case-insensitive sort; C used `strcmp`. After fix, M08-M13's column-level work became visible in the journal. **−191 strict on 4.0 in one PR.** |
+| #108 | **M15** — Clear Source0 when no update + bad urlhealth | PS L 4527 mirror. |
+| #109 | **M16** — Apply Source0Lookup.replaceStrings to tags | PS L 2151. C parsed but never applied. |
+| #110 | **M17** — Pinned-subrelease short-circuit | ADR-0012 Option A implementation. PS L 2104-2106. |
+| #112 | **M18+M19** — HEAD-fail warning + name strips | PS L 4727-4733 + 2507-2516. |
+| #113 | ADR-0014 multi-SHA Draft | User direction; pending decision. |
+| #114 | **M20** — HTTP listing scraper (FRD-018) | New `src/scraper.c`. Targets the dominant non-git update detection gap. **−47 strict / +17 soft on 4.0.** |
+| #115 | **M21** — Post-strip filters | PS L 2522-2524. Drops scraper-noise hrefs (`?C=S;O=A`, `LATEST-IS-X`, `..`). |
+
+### Journal trajectory (strict_rows per branch)
+
+```
+Run / Branch        3.0  4.0   5.0   6.0  common  dev   master
+Initial             919  1034  1113  1093    6   1090   1090
+After M14 unmask    795   841   849   832    6    833    834
+After M16           774   822   835   817    6    818    816
+After M20           748   774   766   766    6    767    769
+After M21          (pending validation — run 26035713128)
+
+Δ from initial    -171  -260  -347  -327    --   -323   -321
+% reduction        19%   25%   31%   30%    --    30%    29%
+```
+
+### Critical findings (preserved as memory entries)
+
+- **`feedback_source0lookup_case_sensitivity`**: PS `.IndexOf` is
+  case-sensitive (Source0Lookup); PS `-ilike` is case-insensitive
+  (warnings/hooks). Don't collapse case-variant Source0Lookup rows.
+- **`feedback_per_package_depth_investigation`**: Remaining gap is
+  per-package adapter work, not bulk-port. Decompose by upstream
+  family.
+- **`feedback_dual_goal`**: Pure-parity fixes that mirror PS's stale
+  data are low value; score on parity-impact + info-impact.
+
+### Architectural decisions made
+
+- ADR-0012 — Subrelease output layout → Option A (status quo, pinned-sentinel).
+- ADR-0013 — Source0Lookup per-release scoping → Option A (status quo, case-variant rows).
+- ADR-0014 — Multi-SHA emission strategy → **Draft**, pending user decision.
+
+### Open infrastructure issues
+
+- WSL2 host occasionally loses TLS connectivity to
+  `*.actions.githubusercontent.com` while `api.github.com` stays
+  healthy. Symptom: runner offline, jobs queued. Recovery: VPN
+  cycle + `systemctl restart actions.runner.*.service`. Seen
+  2026-05-17 and 2026-05-18.
+- On-demand C clones can fill disk if pointed at `/tmp`. Use a path
+  with quota awareness for local non-CI runs.
+
+### Files / artefacts of interest
+
+- `docs/prn-analysis/diff-c-vs-ps-photon-<branch>.md` — auto-generated
+  bucket breakdown per branch. Regenerate via `tools/diff_analyzer.py
+  <PS-snapshot-dir> <C-artifact-dir> docs/prn-analysis`.
+- `tools/parity-journal.tsv` — append-only verdict log; clock for ADR-0009.
+- `c-side-prn-<run_id>` workflow artifact — 30-day retained C-side .prn
+  output, downloadable via `gh run download <id> -n c-side-prn-<id>`.

--- a/TODO.md
+++ b/TODO.md
@@ -180,84 +180,69 @@ For each diff-signature bucket, in descending order of affected-count:
 9. **Update spec status** (`Implemented` if final task, else leave
    `Accepted`). Already part of the merged PR.
 
-### Initial priority bucket list
+### Status — shared-infrastructure phase complete (M01-M21)
 
-(To be filled in from Stage 2 outputs. Skeleton based on prior
-4.0/5.0 PS-side analysis that already exists in
-`docs/prn-analysis/photon-4.0.md` and `photon-5.0-normal.md`. The
-C-side diff buckets may differ — Stage 2 will show.)
+M01-M21 covered shared infrastructure: pinned-sentinel emission,
+case-insensitive sort, version-cut, substitution rewrites, warning
+table, replaceStrings application, post-strip filters, HTTP listing
+scraper. Cumulative parity gap closed by ~30% (varies per branch).
 
-- [ ] **Bucket 1 — SHAName (col 9) always empty in C.**
-      C port doesn't compute SHA-512 of UpdateURL body.
-      Affects: every spec with a populated UpdateURL on the PS side
-      (~80% of "complete" PS rows). Highest leverage.
-      Touches: new `src/sha512_download.c`, `pr_clone_ensure` companion.
-      FRD: extend FRD-014 (.prn row assembly).
-- [ ] **Bucket 2 — warning (col 11) always empty in C.**
-      C port doesn't emit the warning strings ("Manufacturer may
-      changed version packaging format", "Info: VMware internal URL",
-      etc.). Affects: ~100 specs per branch.
-      Touches: `src/check_urlhealth.c` per-warning emission logic.
-      FRD: extend FRD-011 (CheckURLHealth orchestrator).
-- [ ] **Bucket 3 — ArchivationDate (col 12) always empty in C.**
-      C port reads it from lookup row but may not propagate. Affects:
-      every archived spec (~5 per branch). FRD-014.
-- [ ] **Bucket 4 — `pinned` short-circuit (SPECS/91, SPECS/90).**
-      C port doesn't recognise the subrelease path → walks full
-      pipeline → diverges. Affects: 16 specs (91) + ~53 specs (90)
-      once snapshot refreshes. New FRD or extension of FRD-002
-      (parse_directory).
-- [ ] **Bucket 5 — Source0 substitution edge cases.**
-      Specific cols 2/3 mismatches indicating substitution gaps
-      (GitHub archive-URL, RubyGems, CPAN, X.Org). Each
-      sub-bucket = one PR. PS-side already has the logic; gap is in
-      C. FRD-004 (substitution core).
-- [ ] *(remainder filled by Stage 2 data)*
+See `specs/tasks/README.md` for the full M01-M21 task table.
 
----
+### Residual buckets after M21 (the per-package depth territory)
 
-## Stage 4 — Per-release × subrelease coverage
+Per `feedback_per_package_depth_investigation.md` memory entry: the
+remaining gap is **per-package investigation** — each spec in these
+buckets has its own upstream naming scheme / download convention /
+update-detection mechanism.
 
-The PS workflow currently outputs **one `.prn` per branch**. SPECS/90
-and SPECS/91 rows are folded into the parent branch's `.prn` and
-identified via the `vendor-pinned (subrelease N)` warning + `pinned`
-sentinel in col 4.
+Categories (approximate counts per 4.0 after M21 era):
 
-- [ ] **Decision A:** Keep the single-file-per-branch layout, with
-      pinned-emit logic recognising SPECS/<N>/. Lowest impact on tooling.
-- [ ] **Decision B:** Split `.prn` per subrelease
-      (`photonos-urlhealth-5.0-90.prn`, `-91.prn`, default).
-      Requires per-subrelease GeneratePhXURLHealthReport flag,
-      `.prn` filename change, parity-diff awareness, journal schema
-      update. Higher impact.
-- [ ] **Required ADR.** Whichever decision is made, capture it in
-      `specs/adr/0012-subrelease-output-layout.md`. Reviewed +
-      Accepted before any task in this stage starts.
+- ~280 `UpdateAvailable,UpdateURL,SHAName,UpdateDownloadName,warning`
+  GConf-style: scraper returns candidate name(s) but PS's downstream
+  filtering / regex differs per upstream family.
+- ~190 `UpdateAvailable,UpdateURL,SHAName,UpdateDownloadName`
+  ImageMagick-style: C scraper picks a wrong "latest" because the
+  per-family filter (release vs RC vs nightly) isn't implemented.
+- ~75 `SHAName` only — github auto-archive instability. Defer or
+  resolve via ADR-0014 (multi-SHA / stable-source SHA).
+- ~70 `UpdateAvailable` only — non-git "(same version)" path not
+  emitting when scraper finds the current version.
+- ~65 `UpdateAvailable,warning` — autogen-style: PS detected
+  "(same version)", C scraper picks up a sort-query-string href.
+  Some covered by M21; remainder is per-spec edge cases.
+- ~18 `Source0_modified` only — per-spec URL rewrite differences
+  (ModemManager directory vs file URLs etc.).
+
+### Next-units priority (dual-axis: parity + vendor-info)
+
+| Unit | Parity Δ | Info Δ | Effort | Notes |
+|---|---|---|---|---|
+| **Per-upstream-family FRDs** | high | very-high | per-family weeks | gnome.org filter, sourceforge filter, launchpad filter — each refines what the scraper does for a specific listing layout |
+| **ADR-0014 multi-SHA** Accepted + impl | medium | high | 1-2 PRs | drafted; awaiting decision |
+| **M22+ Source0Lookup row repairs** | low | high | 1 PR per spec | one PR per dead-URL spec (bluez-tools→github, etc.) |
+| **`(same version)` for non-git path** | medium | low | 1 PR | when scraper finds latest == current spec version |
+| **`Clean-VersionNames` port** | medium | medium | 1 PR | additional post-filter from PS that's not yet ported |
+| **ADR-0015 stable-source SHA** for github auto-archives | medium | high | needs ADR | switch col-9 source from auto-archive to release-asset where available |
 
 ---
 
-## Stage 5 — Source0Lookup split decision
+## Stage 4 — Per-release × subrelease coverage   ✅ DECIDED
 
-Today: one embedded CSV at PS L 509-1366 (~855 rows) shared across all
-branches and subreleases.
+ADR-0012 → **Accepted Option A (status quo, pinned-sentinel)** on
+2026-05-18. PS L 2104-2106 already emits the sentinel row. M17
+implements the matching C-side short-circuit. No schema change.
 
-Risk: ambiguity when a spec has different upstream conventions per
-release. E.g. `dbus` SPECS/91 → pinned, SPECS/main → upstream; same
-`Source0Lookup` row applied to both yields a wrong result in one case.
+---
 
-- [ ] **Survey** how many specs would actually need per-release
-      divergent Source0Lookup entries. Likely small set — mostly
-      vendor-pinned subrelease entries.
-- [ ] **Option A:** Add a `subrelease` column to the CSV; PS picks
-      the row matching the current SPECS subpath. Backwards-compatible.
-- [ ] **Option B:** Split CSV into per-release files at PS-source
-      level (`Source0Lookup-3.0`, etc.). Larger churn; needs each
-      .ps1 maintainer touching the right file.
-- [ ] **Option C:** Status quo. Document the limitation in
-      `docs/maintainer-runbook.md` §1. Lowest cost; accepts the few
-      cases where per-release differs.
-- [ ] **ADR:** `specs/adr/0013-source0lookup-per-release.md`. Reviewed
-      + Accepted gates this work.
+## Stage 5 — Source0Lookup split decision   ✅ DECIDED
+
+ADR-0013 → **Accepted Option A (status quo, case-variant rows)** on
+2026-05-18. The same conceptual package is listed twice in
+Source0LookupData with different filename casings (PS L 2147
+`.IndexOf` is case-sensitive). Documented in maintainer-runbook §1.
+No schema change. See `feedback_source0lookup_case_sensitivity.md`
+memory entry.
 
 ---
 
@@ -300,17 +285,16 @@ producer.
 
 ## Checkpoints (where the AI pauses for your input)
 
-These are non-trivial / non-reversible decisions where the agent
-should stop and confirm rather than guess:
+Updated 2026-05-18 with status:
 
-1. **End of Stage 2** — diff-signature taxonomy. Confirm the buckets
-   before mass-generating fix PRs.
-2. **Before Stage 4** — single-file vs. split-`.prn` (ADR-0012).
-3. **Before Stage 5** — Source0Lookup CSV restructure (ADR-0013).
-4. **Stage 6** — VPN/proxy provisioning decision.
-5. **Before any PS-side edit that touches more than 3 lookup rows**,
-   or any change to the substitution sequence at PS L 2161-2199
-   (CLAUDE.md invariant 3).
+1. ~~End of Stage 2 — diff-signature taxonomy~~ ✅ approved; M08-M21 followed.
+2. ~~ADR-0012 — single-file vs. split-`.prn`~~ ✅ Option A.
+3. ~~ADR-0013 — Source0Lookup CSV restructure~~ ✅ Option A.
+4. **ADR-0014** — multi-SHA emission strategy. Draft pending user decision.
+5. **Stage 6** — VPN/proxy provisioning decision (operator-only).
+6. **Per-PS-edit guards** — any PS edit touching >3 lookup rows
+   or the L 2161-2199 substitution sequence (CLAUDE.md invariant 3)
+   still pauses for confirmation.
 
 For everything else: proceed.
 

--- a/photonos-package-report/photonos-package-report/CLAUDE.md
+++ b/photonos-package-report/photonos-package-report/CLAUDE.md
@@ -66,7 +66,7 @@ while the tool is live.
 | 8  | CI side-by-side parity gate                           | done (#67)  |
 | 8.5 | Parity convergence loop — per-bucket PS↔C diff fixes (see [TODO.md](../../TODO.md) §3) | in progress |
 | 9  | Retirement (PS → staging/legacy/, C-only)             | pending (gated on 90d green journal) |
-| M  | Maintainer ops & debug tooling — `docs/maintainer-runbook.md`, `.vscode/`; M01 PR #84 mirror (`-UpstreamsExclusionList` clone-skip); M02 multi-branch dispatcher; M03 `photon-` prefix on SPECS path; M04 partial-clone speedup + token-leak hardening | ongoing |
+| M  | Maintainer ops + Phase 8.5 convergence backlog — see `specs/tasks/README.md` for M01-M21 task table and `TODO.md` for the dual-goal program (parity gap + vendor-info quality) | ongoing |
 
 When you land a feature in a numeric phase that changes a workflow the
 maintainer cares about (new flag, new override mechanism, new generator),
@@ -77,5 +77,70 @@ PR. The runbook is the operability source-of-truth.
 
 [`TODO.md`](../../TODO.md) at the repo root tracks the in-flight
 program of work — Phase-M backlog, Stage-3 per-bucket convergence
-priorities, and the user-checkpoint list (ADR-0012, ADR-0013, VPN
-provisioning). Update TODO.md whenever a PR lands.
+priorities, and the user-checkpoint list (now: ADR-0014 multi-SHA
+Draft, on-demand VPN). Update TODO.md whenever a PR lands.
+
+## Goal (dual, user-direction 2026-05-18)
+
+The convergence loop targets TWO goals in parallel:
+
+1. **Shrink the C↔PS `.prn` parity gap** — ADR-0009 90-day-green
+   journal verdict is the floor.
+2. **Maximize accessible vendor package information** — the cells
+   `UpdateAvailable`, `UpdateURL`, `SHAName`, `UpdateDownloadName`
+   should reflect upstream truth, not just C-matches-PS.
+
+When goals conflict (PS has a stale URL and C mirrors it), prefer
+fixing the Source0Lookup row / Phase-3b hook so BOTH sides improve.
+
+## Session-context cheat-sheet (key findings preserved)
+
+For a fresh session: the convergence loop has shipped M01-M21 in
+Phase M, mostly bug-fixes / mirror ports of PS features the C port
+lacked. The remaining gap is dominated by **per-package depth
+investigation** (per-upstream-family scrapers, per-spec adapter
+exceptions). See `feedback_per_package_depth_investigation.md`
+memory entry.
+
+**Architectural decisions made:** ADR-0012 (subrelease layout) and
+ADR-0013 (Source0Lookup split) both Accepted as Option A (status
+quo). ADR-0014 (multi-SHA) Draft, pending user decision.
+
+**Critical mechanics**:
+
+- `parity-diff.sh` compares `.prn` files **line-by-line at the same
+  row index** — not joining on Spec. C's `.prn` row sort MUST match
+  PS's `Sort-Object Spec, SubRelease` (case-INsensitive). Fixed in
+  M14; before that, almost every row mismatched purely from sort
+  order. If you ever change the row-output ordering, this is the
+  one thing not to break.
+- Source0Lookup matching is **case-SENSITIVE** (PS `.IndexOf`).
+  Warnings/hooks are **case-INsensitive** (PS `-ilike`). Preserve
+  this asymmetry — see `feedback_source0lookup_case_sensitivity.md`.
+- `task.Version` is `"Version-Release"` form (PS L 281). `version_cut()`
+  in `src/check_urlhealth.c` strips the trailing `-release` (with
+  Photon dist-tag preservation) before substitution. This is M08.
+- SPECS/91/ + SPECS/90/ subreleases short-circuit via M17's
+  `pinned`-sentinel emission. parse_directory already captures
+  task.SubRelease.
+- HTTP listing scraping for non-git specs lives in `src/scraper.c`
+  (M20, FRD-018). Filtered via M21 to drop sort-query hrefs and
+  symlink-style names.
+
+**Validation cadence:** every PR followed by a
+`gh workflow run "Photon OS Package Report (C-side parity)"
+-f snapshot_run_id=25991871716 -f throttle_limit=8` and a 1-2h
+wait. Journal lands automatically. Diff baseline refresh via
+`tools/diff_analyzer.py <PS-snapshot-dir> <C-artifact-dir>
+docs/prn-analysis`.
+
+**Known transient infra issues:**
+
+- WSL2 host occasionally loses TLS connectivity to
+  `*.actions.githubusercontent.com` (broker / pipelinesghubeus3)
+  while `api.github.com` stays healthy. Symptom: runner offline +
+  jobs stuck queued. Recovery: `systemctl restart
+  actions.runner.dcasota-photonos-scripts.photon5-local.service`
+  after connectivity returns. Seen 2026-05-17 and 2026-05-18.
+- Disk-fill from on-demand clones on a non-`/tmp` non-cleaning path.
+  Recovery: kill in-flight C binary, `rm -rf <upstreams-dir>`.


### PR DESCRIPTION
Updates the auto-loading docs so a new session starts with rich context.

- `CLAUDE.md` — collapsed Phase M enumeration; added dual-goal section and session-context cheat-sheet
- `TODO.md` — ADR-0012/0013 marked DECIDED; bucket list refreshed with M21-era state; checkpoints status updated
- `ITERATIONS-LOG.md` — new append-only iterations record (M08-M21)
- Removed stale `MORNING-SUMMARY.md` (local-only, superseded by ITERATIONS-LOG)

Memory entries (auto-load) already preserve:
- Source0Lookup case-sensitivity asymmetry
- Per-package depth investigation reality
- Dual goal (parity + vendor info)

🤖 Generated with [Claude Code](https://claude.com/claude-code)