### PR TITLE
docs: promote ADR-0014 + ADR-0015 to Accepted; document Stage 6 (WireGuard)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -298,9 +298,11 @@ Updated 2026-05-18 with status:
 1. ~~End of Stage 2 — diff-signature taxonomy~~ ✅ approved; M08-M21 followed.
 2. ~~ADR-0012 — single-file vs. split-`.prn`~~ ✅ Option A.
 3. ~~ADR-0013 — Source0Lookup CSV restructure~~ ✅ Option A.
-4. **ADR-0014** — multi-SHA emission strategy. Draft pending user decision.
-5. **Stage 6** — VPN/proxy provisioning decision (operator-only).
-6. **Per-PS-edit guards** — any PS edit touching >3 lookup rows
+4. ~~**ADR-0014** — multi-SHA emission strategy~~ ✅ Option B (new cols 13/14).
+5. ~~**ADR-0015** — stable-source SHA for github auto-archives~~ ✅ Option A (col-9 override).
+6. ~~**Stage 6** — VPN/proxy provisioning direction~~ ✅ WireGuard with policy routing (operator implementation; runbook §10).
+7. **Per-upstream-family scrapers** ✅ atom-feed parser is next implementation focus (FRD-019 to be drafted).
+8. **Per-PS-edit guards** — any PS edit touching >3 lookup rows
    or the L 2161-2199 substitution sequence (CLAUDE.md invariant 3)
    still pauses for confirmation.
 

--- a/photonos-package-report/photonos-package-report/docs/maintainer-runbook.md
+++ b/photonos-package-report/photonos-package-report/docs/maintainer-runbook.md
@@ -534,3 +534,70 @@ only when:
 
 In both cases open a separate PR that resets the journal explicitly
 with a justification linked to the ADR or PRD change.
+
+---
+
+## 10. On-demand VPN for blocked upstream hosts (Stage 6)
+
+Some upstream hosts (`netfilter.org`, geo-restricted release mirrors)
+return 5xx, redirect loops, or 403 when probed from the runner's
+egress IP. C reports those as `no_update_available` / `url_unhealthy`,
+which dilutes the parity-gate signal — the data is present upstream
+but the runner can't see it.
+
+**Decision (2026-05-18): WireGuard with policy routing.**
+
+A WireGuard interface activates when an in-flight clone or probe
+targets a known-blocked CIDR. Implementation owned by the operator
+(needs host root + ISP egress allocation); the agent does not have
+sufficient privilege.
+
+### Design contract for the operator
+
+1. Maintain a small allowlist of blocked-host CIDRs (initially the
+   netfilter.org public IPs; expand as new hosts surface in the
+   `cols[3 4]` / `cols[5]` residual buckets).
+2. `wg-quick up <iface>` activates a tunnel keyed on dest CIDR via
+   `ip rule add to <CIDR> table <N>` + `ip route add default via
+   <wg-peer> table <N>`.
+3. Per-spec or per-host overrides MAY be added to
+   `tools/clone-config.sh` (a new file) that maps spec names to
+   require-VPN flags. Current C code already honours the runner's
+   default routing table; no in-binary changes are needed.
+
+### Affected specs (post-M21-wired residual sample)
+
+The `netfilter.org` family — at minimum:
+
+- `libnetfilter_conntrack.spec`
+- `libnetfilter_cthelper.spec`
+- `libnetfilter_cttimeout.spec`
+- `libnetfilter_queue.spec`
+- `libnfnetlink.spec`
+- `libnftnl.spec`
+- `libmnl.spec`
+- `nftables.spec`
+- `conntrack-tools.spec`
+- `iptables.spec`
+- `ebtables.spec`
+- `ipset.spec`
+
+PS handles these with a custom Referer in `urlhealth()` (L 1486-1495);
+when the WireGuard tunnel is up, the C `urlhealth()` libcurl probe
+follows the same routing and observes the same upstream contents.
+
+### Alternatives considered
+
+- HTTP/SOCKS5 proxy with `git config http.<base>.proxy` — cheaper but
+  doesn't help git clones for these repos.
+- `gh api`-cached fetcher (offline manifest) — doesn't help
+  per-probe network operations.
+- Accepting the blocked-host residual as "parity-gate known
+  limitations" — weakens the strict-diff signal as more hosts go
+  geo-restricted over time. Rejected.
+
+### Status
+
+- Decided 2026-05-18.
+- Operator implementation TBD; agent will track residual specs in
+  the journal as the VPN comes online.

--- a/photonos-package-report/photonos-package-report/specs/adr/0014-multi-sha-emission.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0014-multi-sha-emission.md
@@ -1,10 +1,10 @@
 # ADR-0014 — Multi-SHA emission strategy
 
-**Status**: Draft
+**Status**: Accepted (Option B)
 
 **Date**: 2026-05-18
 
-**Deciders**: TBD (user gate)
+**Deciders**: dcasota (2026-05-18 evening)
 
 ## Context
 
@@ -65,9 +65,8 @@ row" assumptions.
 
 ## Decision
 
-**Pending user input.** Agent recommendation: **Option B (additional
-columns)**, gated by a clean coordinated PS + C + tooling rollout.
-Reasons:
+**Accepted: Option B (additional columns 13/14)** on 2026-05-18.
+Coordinated PS + C + tooling rollout in one PR. Reasons:
 
 - Cleanest data model. Consumers that don't care about the new
   columns ignore them.

--- a/photonos-package-report/photonos-package-report/specs/adr/0015-stable-source-sha.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0015-stable-source-sha.md
@@ -1,10 +1,10 @@
 # ADR-0015 — Stable-source SHA for github auto-archives
 
-**Status**: Draft
+**Status**: Accepted (Option A)
 
 **Date**: 2026-05-18
 
-**Deciders**: TBD (user gate)
+**Deciders**: dcasota (2026-05-18 evening)
 
 ## Context
 
@@ -106,9 +106,10 @@ real bugs where the SHA computation logic itself drifts.
 
 ## Decision
 
-**Pending user input.** Agent recommendation: **Option A (col-9
-override with auto-archive fallback)**, gated by a per-host
-allowlist (initially `github.com` only).
+**Accepted: Option A (col-9 override with auto-archive fallback)** on
+2026-05-18. Initial per-host allowlist: `github.com` only. Composes
+with ADR-0014 (Accepted same day) — col 9's stable URL is also the
+source for the new cols 13/14 SHA-256/SHA-512 hashes.
 
 Reasons:
 


### PR DESCRIPTION
Documents user decisions on 2026-05-18:

- **ADR-0014** → Accepted Option B (cols 13/14 schema)
- **ADR-0015** → Accepted Option A (col-9 stable URL override)
- **Stage 6** → WireGuard with policy routing (runbook §10)
- **Per-upstream-family** → atom-feed parser is next focus

No code change. Implementation PRs follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)