### PR TITLE
phase-M M30 fix: propagate Resolve-StableSourceURL into parallel runspaces

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -5153,6 +5153,12 @@ function GenerateUrlHealthReports {
                 'Invoke-GitWithTimeout' = (Get-Command 'Invoke-GitWithTimeout' -ErrorAction SilentlyContinue).Definition
                 'Clean-VersionNames' = (Get-Command 'Clean-VersionNames' -ErrorAction SilentlyContinue).Definition
                 'Test-DiskSpace' = (Get-Command 'Test-DiskSpace' -ErrorAction SilentlyContinue).Definition
+                # ADR-0015 (Accepted Option A): Resolve-StableSourceURL needs
+                # to be visible inside ForEach-Object -Parallel runspaces.
+                # Without this propagation each runspace fails with "term
+                # not recognized" and the SHA computation falls back to
+                # the auto-archive — defeating the ADR.
+                'Resolve-StableSourceURL' = (Get-Command 'Resolve-StableSourceURL' -ErrorAction SilentlyContinue).Definition
                 HeapSortClass = $HeapSortClassDef
             }
             $initParts = @()


### PR DESCRIPTION
Critical M30 (ADR-0015) bug: my PS-side patch added Resolve-StableSourceURL but didn't propagate it into the ForEach-Object -Parallel runspaces, so every worker hit "function not recognized" and silently fell back to the auto-archive — making ADR-0015 inert on the PS side.

Symptom: run 26085247541 (cutover validation against the fresh PS snapshot) showed col[9]-only bucket unchanged at ~48 specs. capstone.spec sample: PS=auto-archive SHA, C=release-asset SHA.

Fix: add Resolve-StableSourceURL to the existing FunctionDefinitions hashtable at L 5147 (alongside CheckURLHealth, urlhealth, Clean-VersionNames, etc.). One line. No semantic change.

pwsh parse-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)