### PR TITLE
phase-M workflow fix: dedup by filename-timestamp + clean PS staging dir

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -126,25 +126,33 @@ jobs:
           fi
           # Even within a freshly-extracted tarball, the PS workflow may
           # have included multiple `.prn` files per branch when its own
-          # scans/ dir accumulated files across runs (until that workflow
-          # is also patched). Keep only the NEWEST per branch so the
-          # parity-diff for-loop doesn't double-count.
-          for branch_glob in prn-snapshot/photonos-urlhealth-*.prn; do
-            [ -f "$branch_glob" ] || continue
-            base=$(basename "$branch_glob")
-            branch=$(echo "$base" | sed -E 's|photonos-urlhealth-(.+)_[0-9]+\.prn|\1|')
-            # First time we see this branch — keep newest, drop the rest.
-            if [ -z "${SEEN:+x}" ] || ! echo " $SEEN " | grep -q " $branch "; then
-              keep=$(ls -t prn-snapshot/photonos-urlhealth-"$branch"_*.prn 2>/dev/null | head -1)
-              for stale in $(ls prn-snapshot/photonos-urlhealth-"$branch"_*.prn 2>/dev/null); do
-                if [ "$stale" != "$keep" ]; then
-                  echo "  dropping stale: $stale (keeping $keep)"
-                  rm -f "$stale"
-                fi
-              done
-              SEEN="${SEEN:-} $branch"
-            fi
+          # STAGING dir accumulated files across runs. Keep only the
+          # NEWEST per branch so the parity-diff for-loop doesn't
+          # double-count.
+          #
+          # CRITICAL: dedup by the FILENAME-embedded timestamp
+          # (photonos-urlhealth-<branch>_<YYYYMMDDHHMM>.prn), NOT by
+          # file mtime. `tar -xzf` gives every extracted file the same
+          # mtime, so `ls -t` ties arbitrarily — in practice it kept the
+          # OLDEST filename, making the journal record the wrong (stale)
+          # PS file's diff (see the 2026-05-20 dedup-by-mtime incident,
+          # run 26140575536: journal recorded 425 = the 09:20 file while
+          # the true 05:54 file gave 366). Lexical sort of the
+          # zero-padded YYYYMMDDHHMM suffix is correct chronological order.
+          for branch in $(ls prn-snapshot/photonos-urlhealth-*.prn 2>/dev/null \
+                          | sed -E 's|.*photonos-urlhealth-(.+)_[0-9]+\.prn|\1|' \
+                          | sort -u); do
+            keep=$(ls -1 prn-snapshot/photonos-urlhealth-"$branch"_*.prn 2>/dev/null \
+                   | sort | tail -1)
+            for f in $(ls -1 prn-snapshot/photonos-urlhealth-"$branch"_*.prn 2>/dev/null); do
+              if [ "$f" != "$keep" ]; then
+                echo "  dropping stale: $f (keeping $keep)"
+                rm -f "$f"
+              fi
+            done
           done
+          echo "Files after filename-timestamp dedup:"
+          ls prn-snapshot/photonos-urlhealth-*.prn
           echo "Files after dedup:"; ls prn-snapshot/photonos-urlhealth-*.prn
           echo "dir=$(pwd)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/package-report.yml
+++ b/.github/workflows/package-report.yml
@@ -312,6 +312,15 @@ jobs:
           SCANS="${{ steps.snapshot.outputs.scans_dir }}"
           MANIFEST="${{ steps.snapshot.outputs.manifest }}"
           STAGING="/tmp/new-reports"
+          # Clean STAGING first. On the self-hosted runner /tmp/new-reports
+          # persists across runs; without this the staging dir accumulates
+          # every PS run's .prn files, and the parity-snapshot tarball then
+          # bundles all of them (e.g. four 5.0 files from four runs). The
+          # downstream C workflow has to dedup, and a single bug there
+          # (mtime ties) silently selects the wrong PS file. Cleaning here
+          # makes the snapshot contain exactly this run's outputs. See the
+          # 2026-05-20 staging-accumulation incident.
+          rm -rf "$STAGING"
           mkdir -p "$STAGING"
 
           NEW_COUNT=0


### PR DESCRIPTION
Two remaining staleness bugs from the single-branch 5.0 validation (run 26140575536):

1. **C dedup used `ls -t` (mtime).** tar extraction gives all files the same mtime → tie broke to the OLDEST filename. Journal recorded 425 (the 09:20 file) while the true newest (05:54) gives **366**. Fix: dedup by filename-embedded `_YYYYMMDDHHMM` via `sort | tail -1`.

2. **PS `/tmp/new-reports` STAGING accumulates across runs** → snapshot tarball bundled FOUR 5.0 files. Fix: `rm -rf` it before populating.

The validated real 5.0 number (366 strict vs the fresh 05:54 PS file) is the best yet — ADR-0015 + M30 runspace fix + #139 exact-tarball are all confirmed working. Post-this-PR cycle will record 366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)