### PR TITLE
phase-M M34: rubygems.org JSON-API update detection adapter

### DIFF
--- a/photonos-package-report/photonos-package-report/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/CMakeLists.txt
@@ -110,6 +110,7 @@ add_executable(photonos-package-report
     src/per_spec_strip.c
     src/stable_source.c
     src/atom_feed.c
+    src/rubygems.c
     src/heapsort.c
     src/jdk.c
     src/url_util.c

--- a/photonos-package-report/photonos-package-report/include/pr_rubygems.h
+++ b/photonos-package-report/photonos-package-report/include/pr_rubygems.h
@@ -1,0 +1,24 @@
+/* pr_rubygems.h — rubygems.org latest-version detection (M34).
+ *
+ * Mirrors photonos-package-report.ps1 L 3402-3456: when a spec's
+ * Source0 points at rubygems.org, PS queries the RubyGems JSON API
+ *   https://rubygems.org/api/v1/versions/<gem_name>.json
+ * which returns an array of version objects sorted newest-first.
+ * It filters out `"prerelease":true` entries and takes the first
+ * remaining `"number"`.
+ *
+ * The C port parses the JSON with PCRE2 (no json-c link dependency,
+ * matching the manual-parse precedent in koji.c). The RubyGems schema
+ * places `"number":"X"` before `"prerelease":(true|false)` within each
+ * version object with no nested object between them, so a non-greedy
+ * `"number":"([^"]+)".*?"prerelease":(true|false)` pairs them safely.
+ */
+#ifndef PR_RUBYGEMS_H
+#define PR_RUBYGEMS_H
+
+/* GET the RubyGems versions API for `gem_name` and return the newest
+ * NON-prerelease version string (malloc'd, caller frees), or NULL on
+ * transport/parse failure or when no stable version exists. */
+char *pr_rubygems_latest_version(const char *gem_name);
+
+#endif /* PR_RUBYGEMS_H */

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -21,6 +21,7 @@
 #include "pr_hook.h"
 #include "pr_latest.h"
 #include "pr_per_spec.h"
+#include "pr_rubygems.h"
 #include "pr_state.h"
 #include "pr_sha.h"
 #include "pr_scraper.h"
@@ -977,6 +978,86 @@ char *check_urlhealth(pr_task_t                       *task,
             }
             free(repo_name);
         }
+    }
+
+    /* M34 / FRD-020: rubygems.org JSON-API update detection.
+     *
+     * PS L 3402-3456: when Source0 points at rubygems.org, PS queries
+     * the RubyGems versions API instead of HTML-scraping (which is
+     * useless for rubygems.org/downloads/). The C scraper had no
+     * rubygems handling, leaving ~64 rubygem-* specs per branch in the
+     * cols[5 6 7 9 10] residual bucket. Mirror PS exactly: gem_name
+     * from task (fallback: spec minus `rubygem-` prefix / `.spec`
+     * suffix), GET the API, take the newest non-prerelease version,
+     * build the .gem download URL, compare, emit. */
+    if (allow_network
+        && (state.UpdateAvailable == NULL || state.UpdateAvailable[0] == '\0')
+        && state.Source0 && strstr(state.Source0, "rubygems.org") != NULL) {
+        const char *gem = (task->gem_name && task->gem_name[0])
+                          ? task->gem_name : NULL;
+        char *gem_fallback = NULL;
+        if (gem == NULL && task->Spec) {
+            /* spec minus leading "rubygem-" and trailing ".spec". */
+            const char *s = task->Spec;
+            if (strncmp(s, "rubygem-", 8) == 0) s += 8;
+            size_t sl = strlen(s);
+            if (sl > 5 && strcmp(s + sl - 5, ".spec") == 0) sl -= 5;
+            gem_fallback = (char *)malloc(sl + 1);
+            if (gem_fallback) { memcpy(gem_fallback, s, sl); gem_fallback[sl] = '\0'; gem = gem_fallback; }
+        }
+        char *latest = gem ? pr_rubygems_latest_version(gem) : NULL;
+        if (latest && latest[0]) {
+            int rc = pr_version_compare(latest, state.version ? state.version : "");
+            free(state.UpdateAvailable);
+            if (rc == 1) {
+                state.UpdateAvailable = dup_or_empty(latest);
+                char *update_url = NULL;
+                if (asprintf(&update_url,
+                             "https://rubygems.org/downloads/%s-%s.gem",
+                             gem, latest) >= 0) {
+                    free(state.UpdateURL);
+                    state.UpdateURL = update_url;
+                    int h = urlhealth(state.UpdateURL);
+                    char buf[16]; snprintf(buf, sizeof buf, "%d", h);
+                    free(state.HealthUpdateURL); state.HealthUpdateURL = strdup(buf);
+                    /* UpdateDownloadName = <gem>-<latest>.gem basename. */
+                    char *dl = pr_basename_from_url(state.UpdateURL);
+                    if (dl) {
+                        dl = download_name_post(dl, task->Name ? task->Name : "",
+                                                task->Spec ? task->Spec : "");
+                        free(state.UpdateDownloadName); state.UpdateDownloadName = dl;
+                    }
+                    /* SHA (col 9): rubygems .gem files are immutable
+                     * stored blobs — no auto-archive drift — so hash
+                     * the download URL directly. */
+                    if (state.UpdateURL[0]) {
+                        pr_sha_alg_t alg = PR_SHA512;
+                        for (size_t li = 0; li < task->content_lines; li++) {
+                            const char *line = task->content[li];
+                            if (line == NULL) continue;
+                            if (strstr(line, "%define sha1")   != NULL) { alg = PR_SHA1;   break; }
+                            if (strstr(line, "%define sha256") != NULL) { alg = PR_SHA256; break; }
+                            if (strstr(line, "%define sha512") != NULL) { alg = PR_SHA512; break; }
+                        }
+                        char *hex = pr_sha_of_url(alg, state.UpdateURL);
+                        if (hex) { free(state.SHAValue); state.SHAValue = hex; }
+                    }
+                }
+            } else if (rc == 0) {
+                state.UpdateAvailable = dup_or_empty("(same version)");
+            } else if (rc == -1) {
+                char *warn = NULL;
+                if (asprintf(&warn,
+                             "Warning: %s Source0 version %s is higher than detected latest version %s .",
+                             task->Spec ? task->Spec : "",
+                             state.version ? state.version : "", latest) < 0) warn = NULL;
+                state.UpdateAvailable = warn ? warn : dup_or_empty("");
+            } else {
+                state.UpdateAvailable = dup_or_empty("");
+            }
+        }
+        free(latest);
+        free(gem_fallback);
     }
 
     /* M20 / FRD-018: non-git update detection via HTTP listing scrape.

--- a/photonos-package-report/photonos-package-report/src/rubygems.c
+++ b/photonos-package-report/photonos-package-report/src/rubygems.c
@@ -1,0 +1,140 @@
+/* rubygems.c — rubygems.org latest-version detection (M34).
+ *
+ * Ports photonos-package-report.ps1 L 3402-3456. RubyGems exposes a
+ * JSON API that is far more reliable than HTML scraping:
+ *   GET https://rubygems.org/api/v1/versions/<gem_name>.json
+ *     -> [ {"number":"X.Y.Z", ... ,"prerelease":false, ...}, ... ]
+ * sorted newest-first by created_at. PS takes the first object whose
+ * "prerelease" is false.
+ *
+ * JSON is parsed with PCRE2 (consistent with koji.c's manual-parse
+ * approach; avoids a json-c link dependency). The RubyGems schema
+ * emits "number" before "prerelease" within each version object with
+ * no nested object between them, so a non-greedy match pairs them
+ * within the same object.
+ */
+#include "pr_rubygems.h"
+
+#include <curl/curl.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define BODY_CAP_BYTES (8 * 1024 * 1024)   /* gems with many versions */
+
+struct body_buf {
+    char  *data;
+    size_t len;
+    size_t cap;
+    int    overflow;
+};
+
+static size_t body_write_cb(void *ptr, size_t size, size_t nmemb, void *userdata)
+{
+    struct body_buf *b = (struct body_buf *)userdata;
+    size_t n = size * nmemb;
+    if (b->overflow) return n;
+    if (b->len + n > BODY_CAP_BYTES) { b->overflow = 1; return n; }
+    if (b->len + n > b->cap) {
+        size_t newcap = b->cap ? b->cap * 2 : 16384;
+        while (newcap < b->len + n) newcap *= 2;
+        char *p = (char *)realloc(b->data, newcap);
+        if (!p) { b->overflow = 1; return n; }
+        b->data = p;
+        b->cap = newcap;
+    }
+    memcpy(b->data + b->len, ptr, n);
+    b->len += n;
+    return n;
+}
+
+/* Compile once: capture group 1 = version number, group 2 = prerelease
+ * boolean. PCRE2_DOTALL so `.` spans the inter-field whitespace/newlines. */
+static pcre2_code     *RE_VER;
+static pthread_once_t  g_ver_once = PTHREAD_ONCE_INIT;
+
+static void init_re_ver(void)
+{
+    int        err = 0;
+    PCRE2_SIZE off = 0;
+    RE_VER = pcre2_compile(
+        (PCRE2_SPTR)"\"number\"\\s*:\\s*\"([^\"]+)\".*?\"prerelease\"\\s*:\\s*(true|false)",
+        PCRE2_ZERO_TERMINATED, PCRE2_DOTALL, &err, &off, NULL);
+    if (!RE_VER) {
+        PCRE2_UCHAR ebuf[256];
+        pcre2_get_error_message(err, ebuf, sizeof ebuf);
+        fprintf(stderr, "rubygems.c: re_compile failed: %s\n", (char *)ebuf);
+        abort();
+    }
+}
+
+char *pr_rubygems_latest_version(const char *gem_name)
+{
+    if (gem_name == NULL || gem_name[0] == '\0') return NULL;
+
+    char *url = NULL;
+    if (asprintf(&url, "https://rubygems.org/api/v1/versions/%s.json", gem_name) < 0)
+        return NULL;
+
+    struct body_buf body = {0};
+    CURL *c = curl_easy_init();
+    if (!c) { free(url); return NULL; }
+    curl_easy_setopt(c, CURLOPT_URL,            url);
+    curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(c, CURLOPT_TIMEOUT_MS,     20000L);
+    curl_easy_setopt(c, CURLOPT_USERAGENT,      "photonos-package-report/C");
+    curl_easy_setopt(c, CURLOPT_WRITEFUNCTION,  body_write_cb);
+    curl_easy_setopt(c, CURLOPT_WRITEDATA,      &body);
+    curl_easy_setopt(c, CURLOPT_ACCEPT_ENCODING, "");
+    CURLcode rc = curl_easy_perform(c);
+    long status = 0;
+    if (rc == CURLE_OK) curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &status);
+    curl_easy_cleanup(c);
+    free(url);
+
+    if (rc != CURLE_OK || status < 200 || status >= 300 || body.overflow || body.len == 0) {
+        free(body.data);
+        return NULL;
+    }
+
+    pthread_once(&g_ver_once, init_re_ver);
+    pcre2_match_data *md = pcre2_match_data_create_from_pattern(RE_VER, NULL);
+    if (!md) { free(body.data); return NULL; }
+
+    char *result = NULL;
+    PCRE2_SIZE offset = 0;
+    while (offset < body.len) {
+        int hits = pcre2_match(RE_VER, (PCRE2_SPTR)body.data, body.len,
+                                offset, 0, md, NULL);
+        if (hits < 0) break;
+        PCRE2_SIZE *ov = pcre2_get_ovector_pointer(md);
+        /* group 1 = number, group 2 = prerelease */
+        PCRE2_SIZE num_s = ov[2], num_e = ov[3];
+        PCRE2_SIZE pre_s = ov[4], pre_e = ov[5];
+        if (num_s != PCRE2_UNSET && pre_s != PCRE2_UNSET) {
+            size_t pre_len = (size_t)(pre_e - pre_s);
+            int is_prerelease = (pre_len == 4
+                && strncmp(body.data + pre_s, "true", 4) == 0);
+            if (!is_prerelease) {
+                /* First stable version in newest-first order — take it. */
+                size_t vlen = (size_t)(num_e - num_s);
+                result = (char *)malloc(vlen + 1);
+                if (result) {
+                    memcpy(result, body.data + num_s, vlen);
+                    result[vlen] = '\0';
+                }
+                break;
+            }
+        }
+        offset = ov[1];
+        if (offset <= ov[0]) offset++;
+    }
+
+    pcre2_match_data_free(md);
+    free(body.data);
+    return result;
+}

--- a/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
@@ -105,6 +105,7 @@ add_executable(test_phase6
     ${CMAKE_SOURCE_DIR}/src/per_spec_strip.c
     ${CMAKE_SOURCE_DIR}/src/stable_source.c
     ${CMAKE_SOURCE_DIR}/src/atom_feed.c
+    ${CMAKE_SOURCE_DIR}/src/rubygems.c
     ${CMAKE_SOURCE_DIR}/src/hook_dispatch.c
     ${CMAKE_SOURCE_DIR}/src/task.c
     ${CMAKE_SOURCE_DIR}/src/clone.c


### PR DESCRIPTION
## Summary
- Adds a RubyGems versions-API branch to the CheckURLHealth orchestrator (`src/check_urlhealth.c`). When a spec's `Source0` points at `rubygems.org`, the C port now queries `https://rubygems.org/api/v1/versions/<gem>.json`, takes the newest non-prerelease version, builds the `.gem` download URL, compares against the cut version, and emits `UpdateAvailable` / `UpdateURL` / `HealthUpdateURL` / `UpdateDownloadName` / `SHAValue`.
- New `src/rubygems.c` + `include/pr_rubygems.h`: libcurl GET + PCRE2 parse of `"number":"X" ... "prerelease":(true|false)` (no json-c link, per the `koji.c` manual-parse precedent).
- Mirrors `photonos-package-report.ps1` L 3402-3456 exactly. `gem_name` from `task->gem_name`, fallback = spec minus `rubygem-` prefix / `.spec` suffix.

## Why
The dominant rubygem-* slice (~64 specs/branch) of the cols[5 6 7 9 10] residual bucket previously fell through to the useless HTML scraper (rubygems.org/downloads/ has no listing). This is the highest-leverage next-unit in the Phase-M convergence backlog.

## Test plan
- [x] `cmake --build build` clean
- [x] `ctest --test-dir build` — 13/13 pass
- [x] Live API smoke test: rake→13.4.2, nokogiri→1.19.3 (both newest stable)
- [ ] Parity-gate workflow (single-branch 5.0 validation)

FRD: FRD-011 · ADR: ADR-0001, ADR-0006 · PS-source: L 3402-3456 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)