### PR TITLE
phase-M M36: propagate ftp.gnu.org→FUNET mirror to the UpdateURL

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -199,16 +199,42 @@ update-detection adapter (vs the HTML scraper). Queries
 URL + SHA. Closes the dominant rubygem-* slice (~64 specs/branch) of
 the cols[5 6 7 9 10] bucket. Validation: run 26185297395 (5.0).
 
-**Trustworthy baseline (run 26160062078, journal == local-diff verified):**
+**Trustworthy baseline (journal == local-diff verified):**
 
-| Branch | Initial | Now | % closed |
-|--------|--------:|----:|---------:|
-| 3.0    |  919 | 551 | 40% |
-| 4.0    | 1034 | 484 | 53% |
-| 5.0    | 1113 | 392 | 65% |
-| 6.0    | 1093 | 373 | 66% |
-| dev    | 1090 | 386 | 65% |
-| master | 1090 | 381 | 65% |
+| Branch | Initial | Now | % closed | as-of run |
+|--------|--------:|----:|---------:|-----------|
+| 3.0    |  919 | 551 | 40% | 26160062078 |
+| 4.0    | 1034 | 484 | 53% | 26160062078 |
+| 5.0    | 1113 | **266** | **76%** | 26201671031 (post-M34) |
+| 6.0    | 1093 | 373 | 66% | 26160062078 |
+| dev    | 1090 | 386 | 65% | 26160062078 |
+| master | 1090 | 381 | 65% | 26160062078 |
+
+**M34 validated (5.0, run 26201671031):** 392→266 strict (−126).
+117 rubygem specs in 5.0, only 11 still mismatched → M34 closed ~106.
+Journal == local parity-diff (266/60) confirmed. No regressions: the
+improvement is concentrated in rubygem-* rows. Other branches not yet
+re-run post-M34 (single-branch validation per memory guidance).
+
+**M36 (in flight): ftp.gnu.org → FUNET mirror on the UpdateURL.** The
+funet rewrite (PS L2395) was applied to the probe Source0 (col 3) but
+NOT to the constructed UpdateURL — so col 6 kept the canonical
+`ftp.gnu.org` (health 0 from the runner) and col 9 SHA stayed empty for
+~40 GNU specs (`cols[6 7 9]`: bash, coreutils, grep, gawk, glibc, …).
+Extracted a `funet_mirror()` helper and applied it at both UpdateURL
+build sites. Validate via single-branch 5.0.
+
+**NEW FINDING — sort-collation divergence (CHECKPOINT, touches the
+"do-not-break" sort invariant):** 12 rows in 5.0 are misaligned (col[1]
+Spec mismatch cascades) because C sorts with `strcasecmp` (ordinal:
+`-`<`.`<`_`) while PS's .NET `Sort-Object` is culture word-sort
+(`_`<`-`<`.`, hyphen treated as ignorable). Affected: python-backports_abc,
+python-backports.ssl_match_hostname, python-setuptools_scm,
+python-setuptools-rust, rubygem-http_parser.rb + http-* cluster,
+rubygem-unf_ext/unf. Fixing requires emulating .NET word-sort
+(ignorable-char rules) or linking ICU — both carry global-realignment
+regression risk. **Decision needed before touching `prn_writer.c`
+cmp_str_asc.** Est. ~12 rows/branch (~70 total).
 
 NOTE: journal rows before run 26160062078 were measured against a
 **frozen May 17 PS baseline** (snapshot-selection bug, fixed in PRs

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -67,6 +67,18 @@ static char *dup_or_empty(const char *s)
     return p;
 }
 
+/* PS L 2395-2397: ftp.gnu.org is frequently down; rewrite to the FUNET
+ * mirror (identical archive layout, very stable). PS applies this once
+ * to $Source0 before update detection, so every URL later derived from
+ * it (the probe Source0 AND the constructed UpdateURL) inherits the
+ * mirror. istr_replace_all is a no-op when the needle is absent and
+ * frees its input on rewrite, so reassignment is always safe. */
+static char *funet_mirror(char *url)
+{
+    return istr_replace_all(url, "ftp.gnu.org",
+                            "ftp.funet.fi/pub/gnu/ftp.gnu.org");
+}
+
 /* PS L 2520-2525: post-strip name filter pipeline for non-amdvlk.
  *
  *   $Names = $Names -replace "v",""                       # all 'v' → ''
@@ -729,15 +741,9 @@ char *check_urlhealth(pr_task_t                       *task,
     /* Phase 4 substitution (PS L 2172-2199). */
     pr_source0_substitute(task, &state.Source0, state.version);
 
-    /* PS L 2343-2346: ftp.gnu.org is frequently down. Rewrite to the
-     * FUNET mirror which holds an identical archive layout. Applies
-     * post-substitution, pre-urlhealth. The rewrite is case-insensitive
-     * (`-replace` in PS without `c` flag); `istr_replace_all` matches. */
-    if (state.Source0 && strstr(state.Source0, "ftp.gnu.org") != NULL) {
-        state.Source0 = istr_replace_all(state.Source0,
-                                         "ftp.gnu.org",
-                                         "ftp.funet.fi/pub/gnu/ftp.gnu.org");
-    }
+    /* PS L 2395-2397: rewrite ftp.gnu.org → FUNET mirror, post-
+     * substitution / pre-urlhealth. See funet_mirror(). */
+    state.Source0 = funet_mirror(state.Source0);
 
     /* Phase 5 urlhealth probe. Skipped offline so ctest stays hermetic. */
     int health = 0;
@@ -839,6 +845,7 @@ char *check_urlhealth(pr_task_t                       *task,
                                 char *update_url = dup_or_empty(template);
                                 if (update_url) {
                                     pr_source0_substitute(task, &update_url, latest);
+                                    update_url = funet_mirror(update_url);
                                     free(state.UpdateURL);
                                     state.UpdateURL = update_url;
                                 }
@@ -1158,6 +1165,9 @@ char *check_urlhealth(pr_task_t                       *task,
                     char *update_url = dup_or_empty(template);
                     if (update_url) {
                         pr_source0_substitute(task, &update_url, latest);
+                        /* PS rewrites $Source0 (L2395) before deriving the
+                         * UpdateURL, so the mirror propagates here too. */
+                        update_url = funet_mirror(update_url);
                         free(state.UpdateURL);
                         state.UpdateURL = update_url;
                     }


### PR DESCRIPTION
## Summary
- The funet mirror rewrite (PS L2395) was applied only to the probe `Source0` (col 3), not to the constructed `UpdateURL`. So for ~40 GNU specs (`cols[6 7 9]`: bash, coreutils, grep, gawk, glibc, …) col 6 kept canonical `ftp.gnu.org` (health 0 from the runner) and col 9 SHA stayed empty — even though UpdateAvailable (col 5) already matched PS.
- Extracted a `funet_mirror()` helper and applied it at both UpdateURL build sites (scraper path + gitSource path) plus the probe Source0. PS rewrites `$Source0` once before update detection, so every derived URL inherits the mirror; this mirrors that.

## Why
Closes the dominant cause of the 40-row `cols[6 7 9]` bucket on 5.0. High info value: C currently emits an unreachable URL + empty SHA; the fix yields a reachable mirror URL + real SHA512.

## Validation context
M34 (rubygems) validated cleanly first: 5.0 392→266 strict, journal == local diff. This bucket analysis is off that trustworthy post-M34 baseline.

## Test plan
- [x] `cmake --build build` clean
- [x] `ctest --test-dir build` — 13/13 pass
- [ ] Parity-gate workflow (single-branch 5.0 validation)

FRD: FRD-011 · ADR: ADR-0001 · PS-source: L 2395-2397 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)