### PR TITLE
phase-M M38: github HTML tags-page detection (special-case specs)

### DIFF
--- a/photonos-package-report/photonos-package-report/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/CMakeLists.txt
@@ -112,6 +112,7 @@ add_executable(photonos-package-report
     src/atom_feed.c
     src/rubygems.c
     src/sourceforge.c
+    src/github_tags.c
     src/heapsort.c
     src/jdk.c
     src/url_util.c

--- a/photonos-package-report/photonos-package-report/include/pr_github_tags.h
+++ b/photonos-package-report/photonos-package-report/include/pr_github_tags.h
@@ -1,0 +1,37 @@
+/* pr_github_tags.h — github.com tags-page release detection (M38).
+ *
+ * Ports the HTML "special-case" half of PS's github branch
+ * (photonos-package-report.ps1 L 2766-2872). For a fixed list of specs
+ * whose Source0 points at github.com but which have NO gitSource row,
+ * PS scrapes the HTML tags page
+ *   https://github.com/<owner>/<repo>/tags
+ * and harvests the tag names from the embedded
+ *   /archive/refs/tags/<tag>.tar.gz
+ * download links (PS L 2869-2871). The names then run through
+ * check_urlhealth.c's existing version pipeline.
+ *
+ * The api.github.com path (PS L 2784-2788, used for non-special-case
+ * github specs) is NOT ported here — it needs an auth token and is out
+ * of scope for the special-case list.
+ */
+#ifndef PR_GITHUB_TAGS_H
+#define PR_GITHUB_TAGS_H
+
+#include <stddef.h>
+
+/* True when `spec` is in PS's github special-case list (L 2791-2816),
+ * i.e. the specs that scrape the HTML tags page rather than the API. */
+int pr_github_is_html_tags_spec(const char *spec);
+
+/* Derive the HTML tags URL "https://github.com/<owner>/<repo>/tags"
+ * from a github Source0 (PS L 2774-2784). Returns malloc'd string
+ * (caller frees) or NULL when owner/repo can't be extracted. */
+char *pr_github_tags_html_url(const char *source0);
+
+/* GET `url` (the HTML tags page) and harvest tag names from the
+ * /archive/refs/tags/<tag> download links, dropping .whl/.asc/.dmg/
+ * .zip/.exe entries and stripping archive extensions (PS L 2878-2885).
+ * On success returns 0 and sets *names_out / *n_out. */
+int pr_github_scrape_tags_html(const char *url, char ***names_out, size_t *n_out);
+
+#endif /* PR_GITHUB_TAGS_H */

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -18,6 +18,7 @@
 #include "pr_atom_feed.h"
 #include "pr_clone.h"
 #include "pr_git_tags.h"
+#include "pr_github_tags.h"
 #include "pr_hook.h"
 #include "pr_latest.h"
 #include "pr_per_spec.h"
@@ -1167,7 +1168,16 @@ char *check_urlhealth(pr_task_t                       *task,
      * Source0 health (PS L 3933). The fetch is the normal listing scrape
      * of dirname(Source0) — only the perl-* strip tokens differ. */
     int cpan_eligible = cpan_eligible_source0(state.Source0);
-    if (allow_network && (health == 200 || sf_eligible || cpan_eligible)
+    /* M38: github special-case specs with NO gitSource scrape the HTML
+     * tags page (PS L 2766/2817-2818), independent of Source0 health.
+     * Specs WITH a gitSource are handled by the Phase-6d git path above
+     * and must not be disturbed, so require gitSource to be absent. */
+    int gh_eligible = state.Source0
+                      && strstr(state.Source0, "github.com") != NULL
+                      && (row == NULL || row->gitSource == NULL
+                          || row->gitSource[0] == '\0')
+                      && pr_github_is_html_tags_spec(task->Spec);
+    if (allow_network && (health == 200 || sf_eligible || cpan_eligible || gh_eligible)
         && (state.UpdateAvailable == NULL || state.UpdateAvailable[0] == '\0')
         && (atom_url != NULL
             || row == NULL
@@ -1190,8 +1200,17 @@ char *check_urlhealth(pr_task_t                       *task,
          * are tag names, not file basenames. */
         int used_atom = 0;
         int used_sf   = 0;
+        int used_gh   = 0;
         int scrape_ok = 0;
-        if (sf_eligible) {
+        if (gh_eligible) {
+            /* M38: github special-case HTML tags page. */
+            char *gh_url = pr_github_tags_html_url(state.Source0);
+            if (gh_url) {
+                scrape_ok = (pr_github_scrape_tags_html(gh_url, &names, &n) == 0);
+                used_gh = 1;
+                free(gh_url);
+            }
+        } else if (sf_eligible) {
             /* M35: SourceForge — derive the project files URL and parse
              * the embedded net.sf.files JSON instead of HTML hrefs. */
             char *sf_url = pr_sourceforge_tag_url(task->Spec, state.Source0);
@@ -1207,13 +1226,22 @@ char *check_urlhealth(pr_task_t                       *task,
             scrape_ok = (pr_scrape_listing(parent, &names, &n) == 0);
         }
         if (scrape_ok && n > 0) {
-            if (!used_atom && !used_sf) {
+            if (!used_atom && !used_sf && !used_gh) {
                 /* M23 (PS L 4321-4341) — HTML href path only. */
                 apply_scraper_pre_filters(names, n);
             }
             /* M35 / PS L 3525-3529: tboot year-stamped dir drops. */
             if (used_sf && spec_eq(task->Spec, "tboot.spec")) {
                 drop_year_names(names, n);
+            }
+            /* M38 / PS L 2888 switch "python-networkx.spec": extra strip
+             * tokens so "networkx-X" / "python-networkx-X" reduce to X. */
+            if (used_gh && spec_eq(task->Spec, "python-networkx.spec")) {
+                for (size_t i = 0; i < n; i++) {
+                    if (names[i] == NULL) continue;
+                    names[i] = istr_replace_all(names[i], "python-networkx-", "");
+                    names[i] = istr_replace_all(names[i], "networkx-", "");
+                }
             }
             apply_replace_strings(names, n, row ? row->replaceStrings : NULL);
             /* M26 (PS L 2152 + L 4376): drop candidates matching

--- a/photonos-package-report/photonos-package-report/src/github_tags.c
+++ b/photonos-package-report/photonos-package-report/src/github_tags.c
@@ -1,0 +1,221 @@
+/* github_tags.c — github.com tags-page release detection (M38).
+ *
+ * Ports the HTML special-case half of PS's github branch
+ * (photonos-package-report.ps1 L 2766-2872 + L 2878-2885). See
+ * pr_github_tags.h for the overview.
+ */
+#include "pr_github_tags.h"
+
+#include <curl/curl.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#define BODY_CAP_BYTES (32 * 1024 * 1024)   /* tags pages are ~250 KB+ */
+
+int pr_github_is_html_tags_spec(const char *spec)
+{
+    if (spec == NULL) return 0;
+    /* PS L 2791-2816 verbatim. */
+    static const char *const list[] = {
+        "apr-util.spec", "go.spec", "httpd.spec", "hwloc.spec",
+        "jna.spec", "libmodulemd.spec", "libnsl.spec", "libxkbcommon.spec",
+        "lmdb.spec", "logrotate.spec", "mariadb.spec", "mkinitcpio.spec",
+        "npth.spec", "openjdk11.spec", "openjdk17.spec", "openjdk21.spec",
+        "paho-c.spec", "python-coverage.spec", "python-decorator.spec",
+        "python-hypothesis.spec", "python-networkx.spec", "python-rsa.spec",
+        "python-wheel.spec", "selinux-policy.spec", NULL,
+    };
+    for (int i = 0; list[i]; i++)
+        if (strcasecmp(spec, list[i]) == 0) return 1;
+    return 0;
+}
+
+char *pr_github_tags_html_url(const char *source0)
+{
+    if (source0 == NULL || source0[0] == '\0') return NULL;
+
+    /* PS L 2774-2780: strip scheme/host + /archive[/refs/tags], then the
+     * first two path segments are <owner>/<repo>. */
+    const char *p = source0;
+    static const char *const hosts[] = {
+        "https://github.com", "https://www.github.com",
+        "http://github.com",  "http://www.github.com", NULL,
+    };
+    for (int i = 0; hosts[i]; i++) {
+        size_t hl = strlen(hosts[i]);
+        if (strncasecmp(p, hosts[i], hl) == 0) { p += hl; break; }
+    }
+    /* p now begins with "/<owner>/<repo>/...". Split segments. */
+    while (*p == '/') p++;
+    const char *owner_s = p;
+    const char *owner_e = strchr(owner_s, '/');
+    if (owner_e == NULL) return NULL;
+    const char *repo_s = owner_e + 1;
+    const char *repo_e = strchr(repo_s, '/');
+    if (repo_e == NULL) repo_e = repo_s + strlen(repo_s);
+    if (repo_e == repo_s) return NULL;
+
+    char *url = NULL;
+    if (asprintf(&url, "https://github.com/%.*s/%.*s/tags",
+                 (int)(owner_e - owner_s), owner_s,
+                 (int)(repo_e - repo_s), repo_s) < 0)
+        url = NULL;
+    return url;
+}
+
+struct body_buf {
+    char  *data;
+    size_t len;
+    size_t cap;
+    int    overflow;
+};
+
+static size_t body_write_cb(void *ptr, size_t size, size_t nmemb, void *userdata)
+{
+    struct body_buf *b = (struct body_buf *)userdata;
+    size_t n = size * nmemb;
+    if (b->overflow) return n;
+    if (b->len + n > BODY_CAP_BYTES) { b->overflow = 1; return n; }
+    if (b->len + n > b->cap) {
+        size_t newcap = b->cap ? b->cap * 2 : 262144;
+        while (newcap < b->len + n) newcap *= 2;
+        char *q = (char *)realloc(b->data, newcap);
+        if (!q) { b->overflow = 1; return n; }
+        b->data = q;
+        b->cap = newcap;
+    }
+    memcpy(b->data + b->len, ptr, n);
+    b->len += n;
+    return n;
+}
+
+static pcre2_code     *RE_TAG;
+static pthread_once_t  g_tag_once = PTHREAD_ONCE_INIT;
+
+static void init_re_tag(void)
+{
+    int        err = 0;
+    PCRE2_SIZE off = 0;
+    /* Capture the leaf of an /archive/refs/tags/<leaf> href (PS L 2870). */
+    RE_TAG = pcre2_compile((PCRE2_SPTR)"/archive/refs/tags/([^\"]+)",
+                           PCRE2_ZERO_TERMINATED, 0, &err, &off, NULL);
+    if (!RE_TAG) {
+        PCRE2_UCHAR ebuf[256];
+        pcre2_get_error_message(err, ebuf, sizeof ebuf);
+        fprintf(stderr, "github_tags.c: re_compile failed: %s\n", (char *)ebuf);
+        abort();
+    }
+}
+
+/* PS L 2878-2882: drop assets whose name contains these markers. */
+static int is_dropped_asset(const char *s)
+{
+    static const char *const drops[] = {
+        ".whl", ".asc", ".dmg", ".zip", ".exe", NULL,
+    };
+    for (int i = 0; drops[i]; i++)
+        if (strstr(s, drops[i]) != NULL) return 1;
+    return 0;
+}
+
+static void strip_archive_ext(char *s)
+{
+    static const char *const exts[] = {
+        ".tar.gz", ".tar.bz2", ".tar.xz", NULL,
+    };
+    for (int e = 0; exts[e]; e++) {
+        size_t el = strlen(exts[e]);
+        char *hit;
+        while ((hit = strstr(s, exts[e])) != NULL)
+            memmove(hit, hit + el, strlen(hit + el) + 1);
+    }
+}
+
+int pr_github_scrape_tags_html(const char *url, char ***names_out, size_t *n_out)
+{
+    if (url == NULL || names_out == NULL || n_out == NULL) return -1;
+    *names_out = NULL;
+    *n_out = 0;
+
+    struct body_buf body = {0};
+    CURL *c = curl_easy_init();
+    if (!c) return -1;
+    curl_easy_setopt(c, CURLOPT_URL,             url);
+    curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION,  1L);
+    curl_easy_setopt(c, CURLOPT_TIMEOUT_MS,      20000L);
+    curl_easy_setopt(c, CURLOPT_USERAGENT,       "PowerShell");
+    curl_easy_setopt(c, CURLOPT_WRITEFUNCTION,   body_write_cb);
+    curl_easy_setopt(c, CURLOPT_WRITEDATA,       &body);
+    curl_easy_setopt(c, CURLOPT_ACCEPT_ENCODING, "");
+    CURLcode rc = curl_easy_perform(c);
+    long status = 0;
+    if (rc == CURLE_OK) curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &status);
+    curl_easy_cleanup(c);
+
+    if (rc != CURLE_OK || status < 200 || status >= 300 || body.overflow || body.len == 0) {
+        free(body.data);
+        return -1;
+    }
+
+    pthread_once(&g_tag_once, init_re_tag);
+    pcre2_match_data *md = pcre2_match_data_create_from_pattern(RE_TAG, NULL);
+    if (!md) { free(body.data); return -1; }
+
+    size_t cap = 64, n = 0;
+    char **names = (char **)malloc(cap * sizeof *names);
+    if (!names) { pcre2_match_data_free(md); free(body.data); return -1; }
+
+    PCRE2_SIZE offset = 0;
+    while (offset < body.len) {
+        int hits = pcre2_match(RE_TAG, (PCRE2_SPTR)body.data, body.len,
+                                offset, 0, md, NULL);
+        if (hits < 0) break;
+        PCRE2_SIZE *ov = pcre2_get_ovector_pointer(md);
+        PCRE2_SIZE vs = ov[2], ve = ov[3];
+        if (vs != PCRE2_UNSET && ve > vs) {
+            size_t vlen = (size_t)(ve - vs);
+            char *val = (char *)malloc(vlen + 1);
+            if (val) {
+                memcpy(val, body.data + vs, vlen);
+                val[vlen] = '\0';
+                if (is_dropped_asset(val)) {
+                    free(val);
+                } else {
+                    strip_archive_ext(val);
+                    /* Dedup: the page lists each tag's .tar.gz and .zip;
+                     * the .zip is dropped above, but guard anyway. */
+                    int dup = 0;
+                    for (size_t k = 0; k < n; k++)
+                        if (names[k] && strcmp(names[k], val) == 0) { dup = 1; break; }
+                    if (dup) {
+                        free(val);
+                    } else {
+                        if (n == cap) {
+                            cap *= 2;
+                            char **q = (char **)realloc(names, cap * sizeof *names);
+                            if (!q) { free(val); break; }
+                            names = q;
+                        }
+                        names[n++] = val;
+                    }
+                }
+            }
+        }
+        offset = ov[1];
+        if (offset <= ov[0]) offset++;
+    }
+
+    pcre2_match_data_free(md);
+    free(body.data);
+
+    if (n == 0) { free(names); return -1; }
+    *names_out = names;
+    *n_out = n;
+    return 0;
+}

--- a/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
@@ -107,6 +107,7 @@ add_executable(test_phase6
     ${CMAKE_SOURCE_DIR}/src/atom_feed.c
     ${CMAKE_SOURCE_DIR}/src/rubygems.c
     ${CMAKE_SOURCE_DIR}/src/sourceforge.c
+    ${CMAKE_SOURCE_DIR}/src/github_tags.c
     ${CMAKE_SOURCE_DIR}/src/hook_dispatch.c
     ${CMAKE_SOURCE_DIR}/src/task.c
     ${CMAKE_SOURCE_DIR}/src/clone.c


### PR DESCRIPTION
## Summary
- New `src/github_tags.c` + `include/pr_github_tags.h`: ports PS's github special-case HTML path (L2766-2872). For specs with a github Source0 but NO gitSource row, scrape `github.com/<owner>/<repo>/tags` and harvest tag names from `/archive/refs/tags/<tag>` links.
- Wired as a branch gated on **github Source0 + no gitSource + special-case-list membership**, admitted regardless of Source0 health (PS gates on host). The Phase-6d gitSource github path is untouched, so working github specs can't regress.
- python-networkx gets its switch-case strip tokens (PS L2888).

## Why
The 9 empty-emitting github specs (hwloc, jna, libmodulemd, libnsl, lmdb, npth, paho-c, python-networkx, python-wheel) are all in PS's HTML special-case list and had no C detection path.

## Test plan
- [x] `cmake --build build` clean, `ctest` 13/13
- [x] Live smoke: hwloc→2.13.0, jna→5.18.1 (match PS)
- [ ] Single-branch 5.0 validation — watch for regressions (esp. no disturbance to gitSource github specs)

FRD: FRD-011 · ADR: ADR-0001, ADR-0006 · PS-source: L 2766-2885 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)