### PR TITLE
phase-M M39: samba-family gitlab atom-feed detection

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -114,6 +114,24 @@ static void drop_year_names(char **names, size_t n)
     }
 }
 
+/* M39 / PS L 3691-3695: the samba-family atom feeds return tags named
+ * "<lib>-<ver>" (ldb-2.9.2, talloc-2.4.2, ...); strip the per-spec
+ * prefix token so the version pipeline isolates the number. */
+static void apply_samba_tokens(const char *spec, char **names, size_t n)
+{
+    const char *tok = NULL;
+    if      (spec_eq(spec, "libldb.spec"))       tok = "ldb-";
+    else if (spec_eq(spec, "libtalloc.spec"))    tok = "talloc-";
+    else if (spec_eq(spec, "libtdb.spec"))       tok = "tdb-";
+    else if (spec_eq(spec, "libtevent.spec"))    tok = "tevent-";
+    else if (spec_eq(spec, "samba-client.spec")) tok = "samba-";
+    if (tok == NULL) return;
+    for (size_t i = 0; i < n; i++) {
+        if (names[i] == NULL) continue;
+        names[i] = istr_replace_all(names[i], tok, "");
+    }
+}
+
 /* M37: a spec's Source0 points at a CPAN author directory. PS L 3933
  * gates the CPAN branch on the host alone, independent of Source0
  * health. The three forms PS recognises (L 3933). */
@@ -1242,6 +1260,10 @@ char *check_urlhealth(pr_task_t                       *task,
                     names[i] = istr_replace_all(names[i], "python-networkx-", "");
                     names[i] = istr_replace_all(names[i], "networkx-", "");
                 }
+            }
+            /* M39 / PS L 3691-3695: samba-family per-library prefix token. */
+            if (used_atom) {
+                apply_samba_tokens(task->Spec, names, n);
             }
             apply_replace_strings(names, n, row ? row->replaceStrings : NULL);
             /* M26 (PS L 2152 + L 4376): drop candidates matching

--- a/photonos-package-report/photonos-package-report/src/per_spec_strip.c
+++ b/photonos-package-report/photonos-package-report/src/per_spec_strip.c
@@ -376,6 +376,14 @@ static const struct per_spec_url g_per_spec_url_table[] = {
     {"shared-mime-info.spec",     "https://gitlab.freedesktop.org/xdg/shared-mime-info/-/tags?format=atom"},
     {"wayland.spec",              "https://gitlab.freedesktop.org/wayland/wayland/-/tags?format=atom"},
     {"wayland-protocols.spec",    "https://gitlab.freedesktop.org/wayland/wayland-protocols/-/tags?format=atom"},
+    /* M39 / PS L 3691-3695: samba family — single repo, filtered by a
+     * per-library `search=` query. Each also strips its own prefix token
+     * (see apply_samba_tokens in check_urlhealth.c). */
+    {"libldb.spec",               "https://gitlab.com/samba-team/devel/samba/-/tags?sort=updated_desc&search=ldb*&format=atom"},
+    {"libtalloc.spec",            "https://gitlab.com/samba-team/devel/samba/-/tags?sort=updated_desc&search=talloc*&format=atom"},
+    {"libtdb.spec",               "https://gitlab.com/samba-team/devel/samba/-/tags?sort=updated_desc&search=tdb*&format=atom"},
+    {"libtevent.spec",            "https://gitlab.com/samba-team/devel/samba/-/tags?sort=updated_desc&search=tevent*&format=atom"},
+    {"samba-client.spec",         "https://gitlab.com/samba-team/devel/samba/-/tags?sort=updated_desc&search=samba*&format=atom"},
 };
 
 static const size_t g_per_spec_url_table_count =


### PR DESCRIPTION
## Summary
- The samba libraries (libldb, libtalloc, libtdb, libtevent, samba-client) are tags in the single `gitlab.com/samba-team/devel/samba` repo, filtered by a per-library `search=<lib>*` atom query (PS L3691-3695).
- Added the 5 atom-feed URL overrides to the M33 per-spec atom table + a per-spec prefix-token strip (`ldb-`, `talloc-`, `tdb-`, `tevent-`, `samba-`) on the atom path.
- Reuses the existing M32 atom parser / M33 dispatcher — no new fetch code.

## Test plan
- [x] `cmake --build build` clean, `ctest` 13/13
- [x] Live: libldb atom feed → ldb-2.9.2 (newest), strips to 2.9.2
- [ ] Single-branch 5.0 validation

FRD: FRD-011, FRD-019 · ADR: ADR-0001 · PS-source: L 3691-3695 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)