### PR TITLE
phase-M: treat col9 (SHA) as soft during tarball-cache warm-up

### DIFF
--- a/photonos-package-report/photonos-package-report/specs/adr/0009-side-by-side-ci-parity.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0009-side-by-side-ci-parity.md
@@ -40,3 +40,26 @@ The retirement PR (Phase 9 task 090) is opened automatically once a workflow run
 
 - **Direct cutover after Phase 7**: rejected, see Context.
 - **Side-by-side forever**: pays double compute cost forever; rejected once parity is proven.
+
+## Amendment 2026-05-21 — col9 (SHA) interim-soft during tarball-cache warm-up
+
+Measured on branch 5.0 (run 26233502563): of ~35 strict rows differing
+in col9 (SHAValue), **27 are PS-empty / C-has-a-real-SHA** — i.e. PS's
+`Get-FileHashWithRetry` left col9 empty because its tarball fetch into
+`SOURCES_NEW` failed, while C's live download succeeded. Only ~7 are
+genuine byte-drift (github/gitlab auto-archive tarballs regenerated
+between the PS-snapshot and C-run), and ~1 is a C-side transient. So the
+col9 gap is dominated by **PS deficiency, not C error** — C is the more
+correct implementation on those cells.
+
+Decision (operator, 2026-05-21): treat **col9 as SOFT** in
+`parity-diff.sh` (joining cols 4/7) so the per-run SHA jitter stops
+masking real convergence and the journal can reach green. In parallel,
+build a **persistent shared `SOURCES_NEW` cache** on the self-hosted
+runner so PS and C hash byte-identical tarballs (fills PS's empties AND
+kills the byte-drift — dual-goal-positive). Once the cache is warm and
+col9 parity holds, re-enable strict col9 via `PR_STRICT_COL9=1` and
+resume the 90-day strict-green clock for col9.
+
+The 90-day-green timeline above applies to the strict columns; col9 runs
+its own clock starting when `PR_STRICT_COL9=1` is set.

--- a/photonos-package-report/photonos-package-report/tools/parity-diff.sh
+++ b/photonos-package-report/photonos-package-report/tools/parity-diff.sh
@@ -22,8 +22,14 @@
 #   col 13  SHA256Name                — ADR-0014 (optional, gated by env)
 #   col 14  SHA512Name                — ADR-0014 (optional, gated by env)
 #
-# Volatile columns (4 and 7) are soft-diffed; all other columns are
-# strict — one byte ≠ → strict-diff verdict. The col-13/14 additions
+# Volatile columns (4 and 7) are soft-diffed. Column 9 (SHA) is ALSO
+# soft-diffed during the tarball-cache warm-up (ADR-0009 interim,
+# 2026-05-21): measured on 5.0, ~27/35 col9 diffs are PS-empty / C-has-
+# real-SHA (C is more correct than PS, whose tarball fetch is flakier);
+# only ~7 are genuine byte-drift. Re-enable strict col9 with
+# PR_STRICT_COL9=1 once the persistent shared SOURCES_NEW cache is warm
+# and col9 parity holds. All other columns are strict — one byte ≠ →
+# strict-diff verdict. The col-13/14 additions
 # are strict (no volatility — they're SHA digests of the stable source
 # URL per ADR-0015). The verdict feeds into the 30/60/90-day ladder
 # in tools/parity-gate.sh (task 083).
@@ -79,7 +85,8 @@ if cmp -s "$PS_PRN" "$C_PRN"; then
     exit 0
 fi
 
-awk -F',' -v PS="$PS_PRN" -v C="$C_PRN" -v QUIET="$quiet" '
+awk -F',' -v PS="$PS_PRN" -v C="$C_PRN" -v QUIET="$quiet" \
+    -v STRICT_COL9="${PR_STRICT_COL9:-0}" '
 BEGIN {
     ln_ps = 0
     while ((getline line < PS) > 0) ps[++ln_ps] = line
@@ -123,7 +130,15 @@ BEGIN {
             pv = (k <= npf) ? pf[k] : ""
             cv = (k <= ncf) ? cf[k] : ""
             if (pv != cv) {
-                if (k != 4 && k != 7) only_volatile = 0
+                # cols 4,7 always soft (HTTP-status volatility).
+                # col 9 (SHA) soft during the tarball-cache warm-up
+                # (ADR-0009 interim, 2026-05-21): C is currently MORE
+                # correct than PS on most col9 cells (PS leaves col9
+                # empty when its tarball fetch fails). Set
+                # PR_STRICT_COL9=1 to restore strict once the persistent
+                # SOURCES_NEW cache is warm and col9 parity holds.
+                col9_soft = (k == 9 && STRICT_COL9 != "1")
+                if (k != 4 && k != 7 && !col9_soft) only_volatile = 0
                 diff_cols = diff_cols " " k
             }
         }


### PR DESCRIPTION
## Summary
- Make col9 (SHAValue) soft-diffed in `parity-diff.sh` (joining the volatile cols 4/7), reversible via `PR_STRICT_COL9=1`.
- Amends ADR-0009 to document the interim decision + the warm-cache exit criterion.

## Why
Measured on 5.0 (run 26233502563): of ~35 strict rows differing in col9, **27 are PS-empty / C-has-a-real-SHA** (PS's `Get-FileHashWithRetry` leaves col9 empty when its tarball fetch fails; C's live download succeeds) — C is the *more correct* implementation. Only ~7 are genuine byte-drift, ~1 C-transient. The per-run col9 jitter was exceeding per-PR signal and masking real convergence.

This is the "soft now" half of the operator-chosen **both** path: soft col9 so the journal can go green, while a persistent shared `SOURCES_NEW` cache is built in parallel; flip back to strict (`PR_STRICT_COL9=1`) once warm.

## Effect
5.0 strict 198 → 163 (35 rows move to soft). `PR_STRICT_COL9=1` cleanly restores 198/61.

FRD: FRD-016 · ADR: ADR-0009 · Parity: n/a (validation tooling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)