### PR TITLE
phase-M: col9 tarball-cache mechanism (C side, env-gated)

### DIFF
--- a/photonos-package-report/photonos-package-report/include/pr_sha.h
+++ b/photonos-package-report/photonos-package-report/include/pr_sha.h
@@ -47,4 +47,18 @@ int pr_sha_of_url_multi(const char *url,
                         char **sha256_hex,
                         char **sha512_hex);
 
+/* Tarball-cache variants (ADR-0009 amendment, 2026-05-21). When
+ * `cache_file` is non-NULL, the tarball is read from / written to that
+ * persistent path (the shared SOURCES_NEW the PS run also uses) so PS
+ * and C hash byte-identical bytes: if the file already exists it is
+ * hashed in place; otherwise `url` is downloaded INTO it (creating
+ * parent dirs) and then hashed. When `cache_file` is NULL these behave
+ * exactly like their non-cached counterparts. */
+char *pr_sha_of_url_cached(pr_sha_alg_t alg, const char *url,
+                           const char *cache_file);
+int   pr_sha_of_url_multi_cached(const char *url,
+                                 char **sha256_hex,
+                                 char **sha512_hex,
+                                 const char *cache_file);
+
 #endif /* PR_SHA_H */

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -86,6 +86,28 @@ static int spec_eq(const char *spec, const char *name)
     return spec != NULL && strcasecmp(spec, name) == 0;
 }
 
+/* Tarball-cache path for col9 (ADR-0009 amendment, 2026-05-21). When
+ * PR_SHA_CACHE=1 is set, returns a malloc'd path
+ * <upstreams>/<branch>/SOURCES_NEW/<download_name> — the SAME file the
+ * PS run writes — derived from clone_root (= <upstreams>/<branch>/clones).
+ * So PS and C hash byte-identical tarballs and col9 stops drifting.
+ * Returns NULL (→ legacy /tmp download) when caching is off or inputs
+ * are missing. */
+static char *col9_cache_path(const char *clone_root, const char *download_name)
+{
+    if (getenv("PR_SHA_CACHE") == NULL) return NULL;
+    if (clone_root == NULL || clone_root[0] == '\0') return NULL;
+    if (download_name == NULL || download_name[0] == '\0') return NULL;
+    const char *suffix = "/clones";
+    size_t cl = strlen(clone_root), sl = strlen(suffix);
+    if (cl < sl || strcmp(clone_root + cl - sl, suffix) != 0) return NULL;
+    char *cache = NULL;
+    if (asprintf(&cache, "%.*s/SOURCES_NEW/%s",
+                 (int)(cl - sl), clone_root, download_name) < 0)
+        return NULL;
+    return cache;
+}
+
 /* M35: sourceforge specs whose PS quirks are NOT yet ported — unzip/zip
  * need a $version munge (PS L 3487/3493) and libusb needs a two-stage
  * fetch (PS L 3503-3522). Skip the sourceforge fetch for these so they
@@ -1028,12 +1050,14 @@ char *check_urlhealth(pr_task_t                       *task,
                                     task->Spec, latest, state.UpdateURL);
                                 const char *hash_url = sha_url
                                     ? sha_url : state.UpdateURL;
+                                char *cache_file = col9_cache_path(
+                                    clone_root, state.UpdateDownloadName);
                                 /* ADR-0014 (Option B): single GET, dual-hash
                                  * when PR_EMIT_MULTI_SHA is set. Otherwise
                                  * the single-algorithm pr_sha_of_url. */
                                 if (getenv("PR_EMIT_MULTI_SHA") != NULL) {
                                     char *h256 = NULL, *h512 = NULL;
-                                    if (pr_sha_of_url_multi(hash_url, &h256, &h512) == 0) {
+                                    if (pr_sha_of_url_multi_cached(hash_url, &h256, &h512, cache_file) == 0) {
                                         free(state.SHA256Name); state.SHA256Name = h256;
                                         free(state.SHA512Name); state.SHA512Name = h512;
                                         /* SHAValue (col 9) keeps the spec's
@@ -1047,7 +1071,7 @@ char *check_urlhealth(pr_task_t                       *task,
                                             state.SHAValue = strdup(primary);
                                         } else {
                                             /* SHA1 still needs single hash. */
-                                            char *h1 = pr_sha_of_url(PR_SHA1, hash_url);
+                                            char *h1 = pr_sha_of_url_cached(PR_SHA1, hash_url, cache_file);
                                             if (h1) {
                                                 free(state.SHAValue);
                                                 state.SHAValue = h1;
@@ -1055,12 +1079,13 @@ char *check_urlhealth(pr_task_t                       *task,
                                         }
                                     }
                                 } else {
-                                    char *hex = pr_sha_of_url(alg, hash_url);
+                                    char *hex = pr_sha_of_url_cached(alg, hash_url, cache_file);
                                     if (hex) {
                                         free(state.SHAValue);
                                         state.SHAValue = hex;
                                     }
                                 }
+                                free(cache_file);
                                 free(sha_url);
                             }
                         }
@@ -1133,8 +1158,11 @@ char *check_urlhealth(pr_task_t                       *task,
                             if (strstr(line, "%define sha256") != NULL) { alg = PR_SHA256; break; }
                             if (strstr(line, "%define sha512") != NULL) { alg = PR_SHA512; break; }
                         }
-                        char *hex = pr_sha_of_url(alg, state.UpdateURL);
+                        char *cache_file = col9_cache_path(
+                            clone_root, state.UpdateDownloadName);
+                        char *hex = pr_sha_of_url_cached(alg, state.UpdateURL, cache_file);
                         if (hex) { free(state.SHAValue); state.SHAValue = hex; }
+                        free(cache_file);
                     }
                 }
             } else if (rc == 0) {
@@ -1357,10 +1385,12 @@ char *check_urlhealth(pr_task_t                       *task,
                                 task->Spec, latest, state.UpdateURL);
                             const char *hash_url = sha_url ? sha_url
                                                             : state.UpdateURL;
+                            char *cache_file = col9_cache_path(
+                                clone_root, state.UpdateDownloadName);
                             /* ADR-0014 (Option B): multi-hash when env var set. */
                             if (getenv("PR_EMIT_MULTI_SHA") != NULL) {
                                 char *h256 = NULL, *h512 = NULL;
-                                if (pr_sha_of_url_multi(hash_url, &h256, &h512) == 0) {
+                                if (pr_sha_of_url_multi_cached(hash_url, &h256, &h512, cache_file) == 0) {
                                     free(state.SHA256Name); state.SHA256Name = h256;
                                     free(state.SHA512Name); state.SHA512Name = h512;
                                     const char *primary =
@@ -1370,17 +1400,18 @@ char *check_urlhealth(pr_task_t                       *task,
                                         free(state.SHAValue);
                                         state.SHAValue = strdup(primary);
                                     } else {
-                                        char *h1 = pr_sha_of_url(PR_SHA1, hash_url);
+                                        char *h1 = pr_sha_of_url_cached(PR_SHA1, hash_url, cache_file);
                                         if (h1) { free(state.SHAValue); state.SHAValue = h1; }
                                     }
                                 }
                             } else {
-                                char *hex = pr_sha_of_url(alg, hash_url);
+                                char *hex = pr_sha_of_url_cached(alg, hash_url, cache_file);
                                 if (hex) {
                                     free(state.SHAValue);
                                     state.SHAValue = hex;
                                 }
                             }
+                            free(cache_file);
                             free(sha_url);
                         }
                     }

--- a/photonos-package-report/photonos-package-report/src/sha.c
+++ b/photonos-package-report/photonos-package-report/src/sha.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 static const EVP_MD *md_for(pr_sha_alg_t alg)
@@ -90,6 +91,92 @@ cleanup:
 static size_t write_to_file(char *p, size_t s, size_t n, void *u)
 {
     return fwrite(p, s, n, (FILE *)u);
+}
+
+/* mkdir -p the parent directory of `path` (best-effort). */
+static void mkdir_parents(const char *path)
+{
+    char *dup = strdup(path);
+    if (!dup) return;
+    for (char *p = dup + 1; *p; p++) {
+        if (*p == '/') {
+            *p = '\0';
+            mkdir(dup, 0775);
+            *p = '/';
+        }
+    }
+    free(dup);
+}
+
+/* Download `url` into `dest` (persistent path). Creates parent dirs.
+ * Returns 0 on a 2xx response with the file written, -1 otherwise
+ * (and removes any partial file). */
+static int download_url_to_file(const char *url, const char *dest)
+{
+    mkdir_parents(dest);
+    FILE *f = fopen(dest, "w+b");
+    if (!f) return -1;
+    CURL *c = curl_easy_init();
+    if (!c) { fclose(f); unlink(dest); return -1; }
+    curl_easy_setopt(c, CURLOPT_URL,            url);
+    curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(c, CURLOPT_TIMEOUT_MS,     120000);
+    curl_easy_setopt(c, CURLOPT_WRITEFUNCTION,  write_to_file);
+    curl_easy_setopt(c, CURLOPT_WRITEDATA,      f);
+    curl_easy_setopt(c, CURLOPT_USERAGENT,      "photonos-package-report/C");
+    CURLcode rc = curl_easy_perform(c);
+    long status = 0;
+    curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &status);
+    curl_easy_cleanup(c);
+    fflush(f);
+    fclose(f);
+    if (rc != CURLE_OK || status < 200 || status >= 300) {
+        unlink(dest);
+        return -1;
+    }
+    return 0;
+}
+
+char *pr_sha_of_url_cached(pr_sha_alg_t alg, const char *url,
+                           const char *cache_file)
+{
+    if (cache_file == NULL || cache_file[0] == '\0')
+        return pr_sha_of_url(alg, url);
+    /* Already present (e.g. fetched by the PS run): hash in place so PS
+     * and C produce byte-identical col9. */
+    if (access(cache_file, R_OK) == 0)
+        return pr_sha_file(alg, cache_file);
+    /* Not cached: download into the cache path, persist, hash. */
+    if (download_url_to_file(url, cache_file) != 0)
+        return NULL;
+    return pr_sha_file(alg, cache_file);
+}
+
+int pr_sha_of_url_multi_cached(const char *url,
+                               char **sha256_hex,
+                               char **sha512_hex,
+                               const char *cache_file)
+{
+    if (cache_file == NULL || cache_file[0] == '\0')
+        return pr_sha_of_url_multi(url, sha256_hex, sha512_hex);
+    if (sha256_hex) *sha256_hex = NULL;
+    if (sha512_hex) *sha512_hex = NULL;
+    if (access(cache_file, R_OK) != 0
+        && download_url_to_file(url, cache_file) != 0)
+        return -1;
+    if (sha256_hex) {
+        *sha256_hex = pr_sha_file(PR_SHA256, cache_file);
+        if (!*sha256_hex) goto fail;
+    }
+    if (sha512_hex) {
+        *sha512_hex = pr_sha_file(PR_SHA512, cache_file);
+        if (!*sha512_hex) goto fail;
+    }
+    return 0;
+fail:
+    if (sha256_hex && *sha256_hex) { free(*sha256_hex); *sha256_hex = NULL; }
+    if (sha512_hex && *sha512_hex) { free(*sha512_hex); *sha512_hex = NULL; }
+    return -1;
 }
 
 char *pr_sha_of_url(pr_sha_alg_t alg, const char *url)


### PR DESCRIPTION
## Summary
- The persistent-cache half of the col9 strategy (ADR-0009 amendment). When `PR_SHA_CACHE=1`, col9 SHA is computed against `<upstreams>/<branch>/SOURCES_NEW/<UpdateDownloadName>` — the SAME file the PS run writes — so PS and C hash byte-identical tarballs (kills the 7 byte-drifts) and fill PS's empty-col9 cases once warm (dual-goal-positive).
- `pr_sha_of_url_cached` / `pr_sha_of_url_multi_cached`: cache_file NULL → legacy /tmp download (unchanged); present → hash in place; missing → download into the cache path (mkdir -p), persist, hash.
- `col9_cache_path()` derives the path from the existing `clone_root` param (sibling of `clones/`) — no signature change. Wired at all 3 col9 sites.

## Safety
**Inert by default**: with `PR_SHA_CACHE` unset, `col9_cache_path` returns NULL and behavior is identical to before. The workflow enables it + adds an LRU size-cap prune in a follow-up PR.

## Test plan
- [x] `cmake --build build` clean, `ctest` 13/13
- [x] cache-hit verified: hashes existing file in place without re-downloading
- [ ] parity-gate (expected no-op — env unset)

FRD: FRD-011 · ADR: ADR-0009/0014/0015 · Parity: strict (no-op until PR_SHA_CACHE set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)