### PR TITLE
phase-M M41: all-other-types per-spec download-page overrides

### DIFF
--- a/photonos-package-report/photonos-package-report/include/pr_per_spec.h
+++ b/photonos-package-report/photonos-package-report/include/pr_per_spec.h
@@ -56,4 +56,11 @@ void pr_apply_per_spec_global_replace(const char *spec_name,
  */
 const char *pr_per_spec_source_tag_url(const char *spec_name);
 
+/* M41 / PS L 4294-4305 — "all other types" per-spec SourceTagURL
+ * override (project download page). Returns a static URL when the spec
+ * is in the ported subset (launchpad / standard listings), else NULL.
+ * Caller scrapes <a href> tarball links from the page and path-splits
+ * each to its basename before the version pipeline. */
+const char *pr_all_other_source_tag_url(const char *spec_name);
+
 #endif /* PR_PER_SPEC_H */

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1232,7 +1232,15 @@ char *check_urlhealth(pr_task_t                       *task,
                       && (row == NULL || row->gitSource == NULL
                           || row->gitSource[0] == '\0')
                       && pr_github_is_html_tags_spec(task->Spec);
-    if (allow_network && (health == 200 || sf_eligible || cpan_eligible || gh_eligible)
+    /* M41: "all other types" specs (PS L 4260-4305) with a per-spec
+     * project-download-page override. Admitted regardless of health (PS
+     * lists them explicitly in the gate). Tarball <a href> links are
+     * full URLs → path-split to basename after extraction. */
+    const char *ao_url = pr_all_other_source_tag_url(task->Spec);
+    int ao_eligible = (ao_url != NULL)
+                      && (row == NULL || row->gitSource == NULL
+                          || row->gitSource[0] == '\0');
+    if (allow_network && (health == 200 || sf_eligible || cpan_eligible || gh_eligible || ao_eligible)
         && (state.UpdateAvailable == NULL || state.UpdateAvailable[0] == '\0')
         && (atom_url != NULL
             || row == NULL
@@ -1257,7 +1265,21 @@ char *check_urlhealth(pr_task_t                       *task,
         int used_sf   = 0;
         int used_gh   = 0;
         int scrape_ok = 0;
-        if (gh_eligible) {
+        if (ao_eligible) {
+            /* M41: scrape the project download page; its <a href> tarball
+             * links are full URLs, so reduce each to its basename
+             * (PS L 4400 path-split) before the version pipeline. The
+             * basenamed names then run the standard scraper pipeline
+             * (M23 pre-filter + Name-strip + Clean-VersionNames + …). */
+            scrape_ok = (pr_scrape_listing(ao_url, &names, &n) == 0);
+            if (scrape_ok) {
+                for (size_t i = 0; i < n; i++) {
+                    if (names[i] == NULL) continue;
+                    char *base = pr_basename_from_url(names[i]);
+                    if (base) { free(names[i]); names[i] = base; }
+                }
+            }
+        } else if (gh_eligible) {
             /* M38: github special-case HTML tags page. */
             char *gh_url = pr_github_tags_html_url(state.Source0);
             if (gh_url) {

--- a/photonos-package-report/photonos-package-report/src/per_spec_strip.c
+++ b/photonos-package-report/photonos-package-report/src/per_spec_strip.c
@@ -399,3 +399,35 @@ const char *pr_per_spec_source_tag_url(const char *spec_name)
     }
     return NULL;
 }
+
+/* M41 / PS L 4294-4305: "all other types" per-spec SourceTagURL
+ * overrides. These specs' Source0 dir is not a usable listing, so PS
+ * points at a project download page whose <a href> tarball links are
+ * full URLs (path-split to the basename happens in the caller). Only
+ * the launchpad/standard-listing subset is ported here; the bot-walled
+ * / bespoke-parse ones (json-c S3, js, ipset install.html, chrpath,
+ * docbook two-stage, …) are deferred. */
+static const struct {
+    const char *spec_name;
+    const char *url;
+} g_all_other_url_table[] = {
+    {"apparmor.spec",   "https://launchpad.net/apparmor/+download"},
+    {"bzr.spec",        "https://launchpad.net/bzr/+download"},
+    {"intltool.spec",   "https://launchpad.net/intltool/+download"},
+    {"itstool.spec",    "https://itstool.org/download.html"},
+    {"openvswitch.spec","https://www.openvswitch.org/download/"},
+};
+
+static const size_t g_all_other_url_table_count =
+    sizeof g_all_other_url_table / sizeof g_all_other_url_table[0];
+
+const char *pr_all_other_source_tag_url(const char *spec_name)
+{
+    if (spec_name == NULL) return NULL;
+    for (size_t e = 0; e < g_all_other_url_table_count; e++) {
+        if (strcasecmp(g_all_other_url_table[e].spec_name, spec_name) == 0) {
+            return g_all_other_url_table[e].url;
+        }
+    }
+    return NULL;
+}


### PR DESCRIPTION
## Summary
- Ports the launchpad/standard subset of PS's "all other types" block (L4294-4305): apparmor, bzr, intltool, itstool, openvswitch get a `SourceTagURL` override (project download page); the scraper fetches it, path-splits each `<a href>` tarball link to its basename (PS L4400), then runs the existing pipeline.
- Gated narrowly to the 5 override specs; admitted regardless of Source0 health (PS lists them in its gate). Deferred: bespoke-parse specs (json-c S3-XML, ipset install.html, js, chrpath, docbook two-stage).

## Test plan
- [x] build clean, ctest 13/13
- [x] live listings verified: intltool→0.51.0, itstool→2.0.7, openvswitch→3.7.1
- [ ] fresh PS→C 5.0 cycle — confirm the 4-5 specs fixed, no scraper regressions

FRD: FRD-011/018 · ADR: ADR-0001 · PS-source: L 4260-4400 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)