### PR TITLE
phase-M M41b: add ipset to all-other-types overrides

### DIFF
--- a/photonos-package-report/photonos-package-report/src/per_spec_strip.c
+++ b/photonos-package-report/photonos-package-report/src/per_spec_strip.c
@@ -416,6 +416,7 @@ static const struct {
     {"intltool.spec",   "https://launchpad.net/intltool/+download"},
     {"itstool.spec",    "https://itstool.org/download.html"},
     {"openvswitch.spec","https://www.openvswitch.org/download/"},
+    {"ipset.spec",      "https://ipset.netfilter.org/install.html"},
 };
 
 static const size_t g_all_other_url_table_count =


### PR DESCRIPTION
Adds ipset → ipset.netfilter.org/install.html to the M41 override table (PS L4298). Relative tarball hrefs → pipeline yields 7.24, matching PS. build+ctest green; reuses the validated M41 path.

FRD: FRD-011/018 · ADR: ADR-0001 · PS-source: L4298 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)