### PR TITLE
phase-M: fix M43 mozilla transform to basename full-path hrefs

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -195,8 +195,13 @@ static void apply_mozilla_transform(const char *spec, char **names, size_t n)
     int is_nss = spec_eq(spec, "nss.spec");
     for (size_t i = 0; i < n; i++) {
         if (names[i] == NULL) continue;
+        /* pr_scrape_listing returns full-path hrefs like
+         * "/pub/nspr/releases/v4.39/" — strip trailing slash(es) then
+         * reduce to the last path segment so the pipeline sees "v4.39". */
         size_t l = strlen(names[i]);
-        if (l > 0 && names[i][l - 1] == '/') names[i][l - 1] = '\0';
+        while (l > 0 && names[i][l - 1] == '/') names[i][--l] = '\0';
+        char *slash = strrchr(names[i], '/');
+        if (slash) memmove(names[i], slash + 1, strlen(slash + 1) + 1);
         if (is_nss) {
             names[i] = istr_replace_all(names[i], "NSS_", "");
             names[i] = istr_replace_all(names[i], "_RTM", "");


### PR DESCRIPTION
M43 was a no-op: pr_scrape_listing returns full-path hrefs (/pub/nspr/releases/v4.39/), but apply_mozilla_transform only stripped the trailing slash → /pub/.../ prefix alphas → no-alpha filter dropped all → nspr empty. Now basenames to the last segment → pipeline sees v4.39 → 4.39 (= PS). Simulated against live index. build+ctest green.

FRD: FRD-011 · ADR: ADR-0001 · PS-source: L3252-3272 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)