### PR TITLE
phase-M M44: json-c S3-bucket XML release detection

### DIFF
--- a/photonos-package-report/photonos-package-report/include/pr_scraper.h
+++ b/photonos-package-report/photonos-package-report/include/pr_scraper.h
@@ -33,4 +33,9 @@
  */
 int pr_scrape_listing(const char *url, char ***out_names, size_t *out_n);
 
+/* M44: extract <Key>...</Key> values from an S3-bucket XML listing
+ * (e.g. json-c on s3.amazonaws.com). On success returns 0 and sets
+ * *out_names / *out_n (caller frees); -1 on transport/alloc failure. */
+int pr_scrape_keys(const char *url, char ***out_names, size_t *out_n);
+
 #endif /* PR_SCRAPER_H */

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1292,7 +1292,12 @@ char *check_urlhealth(pr_task_t                       *task,
     int moz_eligible = (moz_url != NULL)
                        && (row == NULL || row->gitSource == NULL
                            || row->gitSource[0] == '\0');
-    if (allow_network && (health == 200 || sf_eligible || cpan_eligible || gh_eligible || ao_eligible || moz_eligible)
+    /* M44 / PS L 4300-4367: json-c is hosted on an S3 bucket whose XML
+     * listing exposes versions as <Key> elements (not <a href>). */
+    int jsonc_eligible = spec_eq(task->Spec, "json-c.spec")
+                         && (row == NULL || row->gitSource == NULL
+                             || row->gitSource[0] == '\0');
+    if (allow_network && (health == 200 || sf_eligible || cpan_eligible || gh_eligible || ao_eligible || moz_eligible || jsonc_eligible)
         && (state.UpdateAvailable == NULL || state.UpdateAvailable[0] == '\0')
         && (atom_url != NULL
             || row == NULL
@@ -1318,7 +1323,25 @@ char *check_urlhealth(pr_task_t                       *task,
         int used_gh   = 0;
         int used_moz  = 0;
         int scrape_ok = 0;
-        if (moz_eligible) {
+        if (jsonc_eligible) {
+            /* M44: S3-bucket XML listing -> <Key> values. Drop the
+             * -nodoc variant (PS L 4367) and strip the "releases/json-c-"
+             * prefix (PS L 4366); the pipeline ext-strip then yields the
+             * version. */
+            scrape_ok = (pr_scrape_keys("https://s3.amazonaws.com/json-c_releases/", &names, &n) == 0);
+            if (scrape_ok) {
+                for (size_t i = 0; i < n; i++) {
+                    if (names[i] == NULL) continue;
+                    if (strstr(names[i], "-nodoc") != NULL) {
+                        free(names[i]); names[i] = NULL; continue;
+                    }
+                    names[i] = istr_replace_all(names[i], "releases/json-c-", "");
+                }
+            }
+            /* Do NOT skip M23 here: the names are "<ver>.tar.gz" — M23
+             * keeps .tar. entries and strips the extension early, before
+             * the no-alpha post-filter would otherwise drop them. */
+        } else if (moz_eligible) {
             /* M43: scrape the mozilla releases index for dir-name
              * versions; transform (basename, strip trailing /, nss
              * NSS_/_RTM) then the standard pipeline finds the latest. */

--- a/photonos-package-report/photonos-package-report/src/scraper.c
+++ b/photonos-package-report/photonos-package-report/src/scraper.c
@@ -180,3 +180,77 @@ int pr_scrape_listing(const char *url, char ***out_names, size_t *out_n)
     *out_n = n;
     return 0;
 }
+
+/* M44 / PS L 4363-4367: extract <Key>...</Key> values from an S3-bucket
+ * XML listing (json-c is hosted on s3.amazonaws.com). The caller filters
+ * by prefix and drops the unwanted variants. Mirrors pr_scrape_listing's
+ * fetch but matches the XML <Key> element instead of <a href>. */
+int pr_scrape_keys(const char *url, char ***out_names, size_t *out_n)
+{
+    if (out_names == NULL || out_n == NULL) return -1;
+    *out_names = NULL;
+    *out_n = 0;
+    if (url == NULL || *url == '\0') return -1;
+
+    struct body_buf body = {0};
+    CURL *c = curl_easy_init();
+    if (!c) return -1;
+    curl_easy_setopt(c, CURLOPT_URL,             url);
+    curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION,  1L);
+    curl_easy_setopt(c, CURLOPT_TIMEOUT_MS,      20000L);
+    curl_easy_setopt(c, CURLOPT_USERAGENT,       "PowerShell");
+    curl_easy_setopt(c, CURLOPT_WRITEFUNCTION,   body_write_cb);
+    curl_easy_setopt(c, CURLOPT_WRITEDATA,       &body);
+    curl_easy_setopt(c, CURLOPT_ACCEPT_ENCODING, "");
+    CURLcode rc = curl_easy_perform(c);
+    long http_status = 0;
+    if (rc == CURLE_OK) curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &http_status);
+    curl_easy_cleanup(c);
+
+    if (rc != CURLE_OK || http_status < 200 || http_status >= 400
+        || body.overflow || body.len == 0) {
+        free(body.data);
+        return (rc == CURLE_OK && body.len == 0) ? 0 : -1;
+    }
+
+    int err = 0; PCRE2_SIZE eoff = 0;
+    pcre2_code *re = pcre2_compile((PCRE2_SPTR)"<Key>([^<]*)</Key>",
+                                   PCRE2_ZERO_TERMINATED, 0, &err, &eoff, NULL);
+    if (!re) { free(body.data); return -1; }
+    pcre2_match_data *md = pcre2_match_data_create_from_pattern(re, NULL);
+    if (!md) { pcre2_code_free(re); free(body.data); return -1; }
+
+    size_t cap = 32, n = 0;
+    char **names = (char **)malloc(cap * sizeof *names);
+    if (!names) { pcre2_match_data_free(md); pcre2_code_free(re); free(body.data); return -1; }
+
+    PCRE2_SIZE offset = 0;
+    while (offset < body.len) {
+        int hits = pcre2_match(re, (PCRE2_SPTR)body.data, body.len, offset, 0, md, NULL);
+        if (hits < 0) break;
+        PCRE2_SIZE *ov = pcre2_get_ovector_pointer(md);
+        PCRE2_SIZE s = ov[2], e = ov[3];
+        if (s != PCRE2_UNSET && e > s) {
+            size_t vlen = (size_t)(e - s);
+            char *v = (char *)malloc(vlen + 1);
+            if (v) {
+                memcpy(v, body.data + s, vlen); v[vlen] = '\0';
+                if (n == cap) {
+                    char **p = (char **)realloc(names, cap * 2 * sizeof *names);
+                    if (!p) { free(v); break; }
+                    names = p; cap *= 2;
+                }
+                names[n++] = v;
+            }
+        }
+        offset = ov[1];
+        if (offset <= ov[0]) offset++;
+    }
+
+    pcre2_match_data_free(md);
+    pcre2_code_free(re);
+    free(body.data);
+    *out_names = names;
+    *out_n = n;
+    return 0;
+}


### PR DESCRIPTION
json-c is on s3.amazonaws.com; its bucket XML exposes versions as <Key>releases/json-c-X.tar.gz</Key> (not <a href>), so the generic scraper found nothing. Added pr_scrape_keys() + a json-c branch (drop -nodoc, strip releases/json-c- prefix, standard pipeline; col6 via S3 re-substitution). Verified locally ROW-IDENTICAL to PS incl. col9 SHA (S3 tarballs byte-stable). build+ctest green.

FRD: FRD-011/018 · ADR: ADR-0001 · PS-source: L4300-4367 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)