### PR TITLE
phase-M M45: drop lsscsi's bogus dot-less 030 entry

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -178,6 +178,11 @@ static void apply_generic_scrape_tokens(const char *spec, char **names, size_t n
     else if (spec_eq(spec, "proto.spec"))             tok = "xproto-";
     else if (spec_eq(spec, "xorg-applications.spec")) tok = "bdftopcf-";
     else if (spec_eq(spec, "xorg-fonts.spec"))        tok = "encodings-";
+    /* M45 / PS L 4404: lsscsi's listing has a bogus dot-less "lsscsi-030"
+     * entry that parses as 30 (> the real 0.32) and wins the sort. PS
+     * strips it; here (post Name-strip) the entry is "030", so stripping
+     * "030" drops it and leaves the real 0.3x versions. */
+    else if (spec_eq(spec, "lsscsi.spec"))            tok = "030";
     if (tok == NULL) return;
     for (size_t i = 0; i < n; i++) {
         if (names[i] == NULL) continue;


### PR DESCRIPTION
PS L4404: lsscsi's listing has a legacy 'lsscsi-030.tgz' that becomes '030' (parses as 30 > real 0.32) and wins the sort → C wrongly emitted 030. Added '030' to lsscsi's strip tokens; real latest 0.32 == spec → '(same version)' = PS (verified locally). Safe (no real version contains 030). build+ctest green.

FRD: FRD-011 · ADR: ADR-0001 · PS-source: L4404 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)