### PR TITLE
phase-M M47b: strip linux- for separate-dir kernel specs

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -234,6 +234,14 @@ static void apply_generic_scrape_tokens(const char *spec, char **names, size_t n
      * strips it; here (post Name-strip) the entry is "030", so stripping
      * "030" drops it and leaves the real 0.3x versions. */
     else if (spec_eq(spec, "lsscsi.spec"))            tok = "030";
+    /* M47b / PS L 4031 ($replace += "linux-"): kernel-family specs in
+     * their OWN dir (Name != "linux") don't get "linux-" stripped by the
+     * Name-token step, so "linux-6.1.173" keeps the prefix and the
+     * no-alpha filter drops it. (linux/linux-esx/linux-rt share
+     * SPECS/linux/ -> Name="linux" -> already stripped.) */
+    else if (spec_eq(spec, "linux-api-headers.spec")) tok = "linux-";
+    else if (spec_eq(spec, "linux-secure.spec"))      tok = "linux-";
+    else if (spec_eq(spec, "linux-aws.spec"))         tok = "linux-";
     if (tok == NULL) return;
     for (size_t i = 0; i < n; i++) {
         if (names[i] == NULL) continue;


### PR DESCRIPTION
M47 fixed linux-esx/rt (Name='linux' via SPECS/linux/ → linux- already stripped). linux-api-headers (own dir) has Name='linux-api-headers', so 'linux-6.1.173' kept its prefix → no-alpha filter dropped it → empty. PS adds 'linux-' to $replace for the family (L4031). Added explicit 'linux-' strip for the separate-dir kernel specs. Verified locally: linux-api-headers → 6.1.173 + col6 = PS. build+ctest green.

FRD: FRD-011 · ADR: ADR-0001 · PS-source: L4031,L4210-4219 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)