### PR TITLE
phase-M M48: keep amdvlk quarterly versions (skip no-alpha filter)

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1043,8 +1043,14 @@ char *check_urlhealth(pr_task_t                       *task,
                          * candidates (alpha/beta/rc/preview/dev/pre). */
                         apply_clean_version_names(names, n);
                         /* M21 (PS L 2522-2524): post-strip filters —
-                         * v-strip + has-digit + no-alpha-after-pN-strip. */
-                        apply_name_post_filters(names, n);
+                         * v-strip + has-digit + no-alpha-after-pN-strip.
+                         * M48 / PS L 2569: SKIP for amdvlk — its tags are
+                         * quarterly "YYYY.Q#.#" (the comparator handles
+                         * them, Case 2b), but the no-alpha filter would
+                         * drop them on the "Q", leaving older non-Q tags
+                         * as the wrong latest. */
+                        if (!spec_eq(task->Spec, "amdvlk.spec"))
+                            apply_name_post_filters(names, n);
                         char *latest = pr_get_latest_name(names, n);
                         if (latest && latest[0]) {
                             /* PS L 2538-2553: compare first; only the


### PR DESCRIPTION
amdvlk tags are quarterly YYYY.Q#.# (2025.Q2.1). The comparator already orders them (version.c Case 2b), but the no-alpha post-filter dropped them on the 'Q' → C picked an older non-Q tag (2018.4.2). PS skips that filter for amdvlk (L2569). Gated apply_name_post_filters on !amdvlk. Verified locally ROW-IDENTICAL to PS incl col9 SHA. Low blast radius (gated; shared comparator unchanged). build+ctest green.

FRD: FRD-011 · ADR: ADR-0001 · PS-source: L2569-2574 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)