### PR TITLE
phase-M M50: strip .orig for ltrace

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -242,6 +242,10 @@ static void apply_generic_scrape_tokens(const char *spec, char **names, size_t n
     else if (spec_eq(spec, "linux-api-headers.spec")) tok = "linux-";
     else if (spec_eq(spec, "linux-secure.spec"))      tok = "linux-";
     else if (spec_eq(spec, "linux-aws.spec"))         tok = "linux-";
+    /* M50 / PS L 4405: ltrace tarball is "ltrace_<ver>.orig.tar.bz2";
+     * after the Name-strip the candidate is "<ver>.orig" and the no-alpha
+     * filter would drop it on "orig". Strip ".orig". */
+    else if (spec_eq(spec, "ltrace.spec"))            tok = ".orig";
     if (tok == NULL) return;
     for (size_t i = 0; i < n; i++) {
         if (names[i] == NULL) continue;


### PR DESCRIPTION
ltrace tarball is ltrace_<ver>.orig.tar.bz2 → candidate '<ver>.orig' dropped by no-alpha filter → C empty. PS strips '.orig' (L4405). Added the token. Verified locally: ltrace → '(same version)' = PS. build+ctest green.

FRD: FRD-011 · ADR: ADR-0001 · PS-source: L4405 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)