### PR TITLE
ci: retry C-side journal push with rebase

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -350,5 +350,15 @@ jobs:
             echo "No journal changes to commit"
           else
             git commit -m "parity: PS=${{ steps.ps_run.outputs.id }} C=${{ github.run_id }} overall=${{ steps.diff.outputs.overall }}"
-            git push
+            # Retry push with rebase: concurrent master pushes (doc commits,
+            # PS scans-commit) can advance the branch between fetch and push.
+            for attempt in 1 2 3 4 5; do
+              if git push; then
+                echo "journal push ok (attempt $attempt)"
+                break
+              fi
+              echo "journal push rejected, rebasing (attempt $attempt)"
+              git pull --rebase --autostash origin "$(git rev-parse --abbrev-ref HEAD)" || true
+              sleep $(( attempt * 3 ))
+            done
           fi


### PR DESCRIPTION
The C-side Commit-journal step pushed without pulling → concurrent master pushes rejected it and failed the run after the diff computed (losing the journal row). Mirrors the PS workflow's 5-attempt rebase-retry loop. The repeated 'failed to push some refs' C-side failures were this race.

Parity: n/a (CI tooling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)