### PR TITLE
phase-M M51: apply generic-scrape tokens before Name tokens

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1503,11 +1503,16 @@ char *check_urlhealth(pr_task_t                       *task,
             if (cpan_eligible) {
                 apply_cpan_perl_tokens(names, n, task->Name ? task->Name : "");
             }
+            /* M42 / PS L 3335-3350: per-spec generic-scrape prefix tokens
+             * (freetype-, grub-, xproto-, ...). No-op for other specs.
+             * M51: applied BEFORE the Name tokens (matching PS $replace
+             * array order, where these are added earlier) — critical for
+             * proto, where Name="proto" would otherwise strip the "proto"
+             * inside "xproto-7.0.31" → "x-7.0.31" (dropped on the "x")
+             * before the "xproto-" token could fire. */
+            apply_generic_scrape_tokens(task->Spec, names, n);
             apply_name_replace_augmentations(names, n,
                                              task->Name ? task->Name : "");
-            /* M42 / PS L 3335-3350: per-spec generic-scrape prefix tokens
-             * (freetype-, grub-, xproto-, ...). No-op for other specs. */
-            apply_generic_scrape_tokens(task->Spec, names, n);
             /* M22 (PS L 441-451 Clean-VersionNames): leading rel//v/r
              * strips, _→. replace, drop pre-release candidates. */
             apply_clean_version_names(names, n);


### PR DESCRIPTION
proto candidate 'xproto-7.0.31' + Name='proto' → Name-token strips the 'proto' in 'xproto-' → 'x-7.0.31' → dropped on 'x'. PS strips 'xproto-' first ( order). Reordered apply_generic_scrape_tokens before apply_name_replace_augmentations. Verified locally: proto = PS warning (7.7>7.0.31); grub2/freetype2/xorg-fonts unaffected. build+ctest green.

FRD: FRD-011 · ADR: ADR-0001 · PS-source: L3346 vs L4193 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)