### PR TITLE
phase-M task M67b: spec-matrix + issue-category tables for the C implementation too

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -312,6 +312,21 @@ jobs:
           echo "scans=$SCANS" >> "$GITHUB_OUTPUT"
           ls -l "$SCANS"
 
+      # M67: the same cross-branch issue report the PS workflow emits, but
+      # over the C implementation's own .prn output — gives the C run a
+      # spec-matrix (issue category per branch) + an issue-category table
+      # listing affected packages, in its dynamic job summary. Runs before the
+      # upload so the generated issue .md files ship in the artifact too.
+      - name: Generate URL health issue summaries (C-side)
+        if: always() && steps.c_run.outputs.scans != ''
+        run: |
+          SCRIPT="repo/.github/scripts/generate-urlhealth-summary.py"
+          if [ -f "$SCRIPT" ]; then
+            python3 "$SCRIPT" "${{ steps.c_run.outputs.scans }}"
+          else
+            echo "::warning::URL health summary script not found at $SCRIPT"
+          fi
+
       # M05 (FRD-017): preserve C-side .prn for post-hoc strict-diff
       # investigation. The runner cleans _temp/ at job end, so without
       # this upload the .prn that parity-diff judged is lost. `always()`
@@ -327,6 +342,7 @@ jobs:
           # alongside; parity-gate integration pending clean-CI validation).
           path: |
             ${{ steps.c_run.outputs.scans }}/photonos-urlhealth-*.prn
+            ${{ steps.c_run.outputs.scans }}/photonos-urlhealth-issues-*.md
             ${{ steps.c_run.outputs.scans }}/photonos-diff-report-*.prn
             ${{ steps.c_run.outputs.scans }}/photonos-package-report_*.prn
           if-no-files-found: warn


### PR DESCRIPTION
## Summary

M67 added the cross-branch **spec-matrix** and **issue-category → affected-packages** tables to the dynamic report — but only for the **PS** workflow (`package-report.yml`), which invokes `generate-urlhealth-summary.py`. The **C** workflow (`package-report-C.yml`) never called that script; its dynamic report showed only the parity-verdict table. So the new content was PS-only.

This adds a *"Generate URL health issue summaries (C-side)"* step that runs the **same** script over the C implementation's own `.prn` output (`steps.c_run.outputs.scans`). The C run now gets the identical spec-matrix + category tables in its job summary — derived from **C-detected** URL health rather than PS.

## Details

- The script is unchanged and schema-agnostic (12-col urlhealth `.prn`), so PS and C share one `classify_row()` taxonomy — the two views can't drift.
- Step is placed before the C-side upload, and the issue `.md` glob was added to the `c-side-prn` artifact so the generated reports ship there too.
- Runs on the same self-hosted Photon runner the PS workflow already uses `python3` on.

Now both implementations emit the same dynamic content:
- `package-report.yml` (PS) — via the existing "Generate URL health issue summaries" step.
- `package-report-C.yml` (C) — via the new step.

FRD: FRD-017 · ADR: ADR-0009 · Parity: n/a (CI reporting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)