### PR TITLE
phase-M task M68: GitPhoton tree refresh + fill all subrelease matrix columns

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -489,9 +489,15 @@ function GitPhoton {
     {
         Set-Location $photonPath
         try {
-            Invoke-GitWithTimeout "fetch --prune --prune-tags --tags" -WorkingDirectory $photonPath
-            # unnecessary to reset hard to origin since we only read spec files and don't care about local changes, and it can cause issues if the repo is in a bad state (e.g. due to interrupted fetch/clone)
-            # Invoke-GitWithTimeout "reset --hard origin/$release" -WorkingDirectory $photonPath
+            Invoke-GitWithTimeout "fetch --prune --prune-tags --tags origin $release" -WorkingDirectory $photonPath
+            # Update the working tree to the fetched branch tip. `fetch` only
+            # moves the remote-tracking ref; without this reset the checkout
+            # stays frozen at the first-clone commit, so specs and subrelease
+            # dirs added upstream after that commit (e.g. SPECS/90) never
+            # appear in ParseDirectory. The catch below deletes + re-clones if
+            # the reset fails (corrupt/interrupted repo), so a bad local state
+            # still self-heals.
+            Invoke-GitWithTimeout "reset --hard origin/$release" -WorkingDirectory $photonPath
         }
         catch {
             # If fetch/reset fails, delete and re-clone
@@ -5590,10 +5596,10 @@ if ($GeneratePhPackageReport)
             'photon-4.0' = if($srPkg.Spec -in $Packages4.Spec -and ($Packages4 | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease })) {($Packages4 | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease } | Select-Object -First 1).Version} else {""}
             'photon-5.0' = if($srPkg.Spec -in $Packages5.Spec -and ($Packages5 | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease })) {($Packages5 | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease } | Select-Object -First 1).Version} else {""}
             'photon-6.0' = if($srPkg.Spec -in $Packages6.Spec -and ($Packages6 | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease })) {($Packages6 | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease } | Select-Object -First 1).Version} else {""}
-            'photon-common' = ""
-            'photon-dev' = ""
-            'photon-master' = ""
-            'photon-main' = ""
+            'photon-common' = if($srPkg.Spec -in $PackagesCommon.Spec -and ($PackagesCommon | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease })) {($PackagesCommon | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease } | Select-Object -First 1).Version} else {""}
+            'photon-dev' = if($srPkg.Spec -in $PackagesDev.Spec -and ($PackagesDev | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease })) {($PackagesDev | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease } | Select-Object -First 1).Version} else {""}
+            'photon-master' = if($srPkg.Spec -in $PackagesMaster.Spec -and ($PackagesMaster | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease })) {($PackagesMaster | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease } | Select-Object -First 1).Version} else {""}
+            'photon-main' = if($srPkg.Spec -in $PackagesMain.Spec -and ($PackagesMain | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease })) {($PackagesMain | Where-Object { $_.Spec -eq $srPkg.Spec -and $_.SubRelease -eq $srPkg.SubRelease } | Select-Object -First 1).Version} else {""}
         }
         $result += $srRow
     }

--- a/photonos-package-report/photonos-package-report/src/package_report.c
+++ b/photonos-package-report/photonos-package-report/src/package_report.c
@@ -109,21 +109,27 @@ int pr_write_package_report(const pr_task_list_t *const lists[8],
     }
 
     /* Subrelease rows: one per distinct (Spec, SubRelease). Version columns
-     * only for the numeric branches 3.0/4.0/5.0/6.0 (lists[0..3]);
-     * common/dev/master/main are always empty (PS hardcodes them ""). Generated
-     * per subrelease task occurrence; duplicates collapse in the sort. */
+     * for every branch via the (Spec, SubRelease) lookup — symmetric with the
+     * main rows. Branches with no matching subrelease occurrence resolve to ""
+     * (so 3.0/4.0/6.0/common/dev/master stay empty for a 5.0-only pin, and
+     * photon-main carries main/SPECS/NN versions). Generated per subrelease
+     * task occurrence; duplicates collapse in the sort. */
     for (int k = 0; k < 8; k++) {
         for (size_t i = 0; i < lists[k]->count; i++) {
             const pr_task_t *t = &lists[k]->items[i];
             if (!(t->SubRelease && t->SubRelease[0] != '\0')) continue;
             if (t->Spec == NULL) continue;
             char *row = NULL;
-            if (asprintf(&row, "%s,%s,%s,%s,%s,%s,,,,",
+            if (asprintf(&row, "%s,%s,%s,%s,%s,%s,%s,%s,%s,%s",
                          t->Spec, t->SubRelease,
                          sr_version(lists[0], t->Spec, t->SubRelease),
                          sr_version(lists[1], t->Spec, t->SubRelease),
                          sr_version(lists[2], t->Spec, t->SubRelease),
-                         sr_version(lists[3], t->Spec, t->SubRelease)) >= 0 && row) {
+                         sr_version(lists[3], t->Spec, t->SubRelease),
+                         sr_version(lists[4], t->Spec, t->SubRelease),
+                         sr_version(lists[5], t->Spec, t->SubRelease),
+                         sr_version(lists[6], t->Spec, t->SubRelease),
+                         sr_version(lists[7], t->Spec, t->SubRelease)) >= 0 && row) {
                 rows[n++] = row;
             }
         }


### PR DESCRIPTION
## Summary

Two coupled fixes uncovered while verifying the M66 `main` branch — together they fix the missing `5.0/SPECS/90` column and make `main`'s subrelease versions non-empty.

### 1. GitPhoton stale working tree — *root cause of the missing `5.0/SPECS/90`*
On a cache hit, `GitPhoton` ran `git fetch` but `reset --hard origin/$release` was **commented out**. With the persistent `$HOME` workingDir, every branch checkout was frozen at its first-clone commit. `photon-5.0` was cloned before `SPECS/90` existed upstream, so the subrelease (and anything added since) never reached `ParseDirectory` — only `main` (first-cloned this run) reflected the current tree. Re-enabling the reset refreshes every branch to current upstream; the existing `catch → delete + re-clone` fallback still self-heals a corrupt repo.

### 2. Package-matrix subrelease rows left non-numeric columns empty
The subrelease block computed only `photon-3.0/4.0/5.0/6.0` and hardcoded `common/dev/master/main = ""`, so `main/SPECS/90|91` rows came out fully blank. Now all 8 columns use the `(Spec, SubRelease)` lookup (symmetric with the main rows). Existing 5.0-only pins are byte-unchanged; `main` subreleases now carry their `photon-main` version. C `package_report.c` mirrors the change (row format 6→10 fields).

## Validation
- `ctest` 13/13; PS `[Parser]::ParseFile` clean.
- Smoke test: a main-only `SPECS/90` pin lands its version in `photon-main`, other branches empty.
- The M67 issues-matrix is already dynamic, so `5.0/SPECS/90` will appear automatically once a run executes against the refreshed tree.

FRD: FRD-015 · ADR: ADR-0001, ADR-0006, ADR-0015 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)