### PR TITLE
phase-M task M71: cat-6 cluster B — gnome cache.json detection (GConf, gnome-common)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -3475,6 +3475,57 @@ function CheckURLHealth {
         }
     }
 
+    # Check UpdateAvailable via the gnome download-server cache.json (cat-6
+    # cluster B). The classic gnome FTP layout (sources/<module>/<M.N>/
+    # <module>-<ver>) defeats HTML listing scraping -- dirname(Source0) is one
+    # minor dir and the parent index lists bare "M.N/" dirs. The gnome server
+    # publishes a JSON index whose element [2] maps each module to its full
+    # version array. SCOPED to the two cat-6 gnome specs: other gnome
+    # /sources/ specs either carry a gitlab.gnome.org gitSource (git-tag path
+    # above) or already detect via the generic scraper (e.g. libsigc++), so a
+    # host-wide rule would risk changing a working spec. Add specs here if
+    # they later regress to cat 6.
+    elseif (($currentTask.spec -ilike 'GConf.spec') -or ($currentTask.spec -ilike 'gnome-common.spec'))
+    {
+        $gnomeModule = $currentTask.Name
+        $cacheUrl = "https://download.gnome.org/sources/$gnomeModule/cache.json"
+        try {
+            $cache = Invoke-RestMethod -Uri $cacheUrl -TimeoutSec 10 -ErrorAction Stop
+            $Names = @($cache[2].$gnomeModule)
+            if ($Names -and $Names.Count -gt 0) {
+                $Names = Clean-VersionNames $Names
+                $Names = $Names -replace "v",""
+                $Names = @($Names | foreach-object { if ($_ -match '\d') {$_}})
+                $Names = @($Names | foreach-object { if (!(($_ -replace '[pP]\d+', '') -match '[a-zA-Z]')) {$_}})
+                if (!([string]::IsNullOrEmpty($Names -join ''))) {$NameLatest = Get-LatestName -Names $Names}
+            }
+        }
+        catch {
+            $NameLatest = ""
+            Write-Warning "gnome cache.json call failed for $gnomeModule : $_"
+        }
+
+        if ($NameLatest -ne "")
+        {
+            if ($version -is [PSCustomObject]) { [string]$version = [string]$version.version }
+
+            $result = Compare-VersionStrings -Namelatest $NameLatest -Version $version
+
+            if ($null -eq $result) {
+                Write-Host "Comparison for $($currentTask.spec) between $NameLatest and $version failed due to invalid input."
+            }
+            elseif ($result -gt 0) {
+                $UpdateAvailable = $NameLatest
+            }
+            elseif ($result -lt 0) {
+                $UpdateAvailable = "Warning: " + $currentTask.spec + " Source0 version " + $version + " is higher than detected latest version " + $NameLatest + " ."
+            }
+            else {
+                $UpdateAvailable = "(same version)"
+            }
+        }
+    }
+
     # Check UpdateAvailable by sourceforge tags detection
     elseif ($Source0 -ilike '*sourceforge.net*')
     {

--- a/photonos-package-report/photonos-package-report/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/CMakeLists.txt
@@ -118,6 +118,7 @@ add_executable(photonos-package-report
     src/stable_source.c
     src/atom_feed.c
     src/rubygems.c
+    src/gnome_cache.c
     src/sourceforge.c
     src/github_tags.c
     src/heapsort.c

--- a/photonos-package-report/photonos-package-report/include/pr_gnome_cache.h
+++ b/photonos-package-report/photonos-package-report/include/pr_gnome_cache.h
@@ -1,0 +1,19 @@
+/* pr_gnome_cache.h — gnome download-server version enumeration (cat-6 cluster B).
+ *
+ * See src/gnome_cache.c. Fetches https://download.gnome.org/sources/<module>/
+ * cache.json and returns the flat version array gnome publishes for the module
+ * (element [2] of the cache). The caller runs the result through the standard
+ * version-name pipeline (pr_get_latest_name + compare), exactly like the HTTP
+ * listing scraper.
+ */
+#ifndef PR_GNOME_CACHE_H
+#define PR_GNOME_CACHE_H
+
+#include <stddef.h>
+
+/* GET the gnome cache.json for `module` and return its released versions in
+ * *out_names / *out_n (heap-allocated, caller frees with pr_git_tags_free).
+ * Returns 0 on success with at least one version, -1 otherwise. */
+int pr_gnome_cache_versions(const char *module, char ***out_names, size_t *out_n);
+
+#endif /* PR_GNOME_CACHE_H */

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -27,6 +27,7 @@
 #include "pr_state.h"
 #include "pr_sha.h"
 #include "pr_scraper.h"
+#include "pr_gnome_cache.h"
 #include "pr_sourceforge.h"
 #include "pr_spec_warnings.h"
 #include "pr_stable_source.h"
@@ -1502,7 +1503,21 @@ char *check_urlhealth(pr_task_t                       *task,
     int jsonc_eligible = spec_eq(task->Spec, "json-c.spec")
                          && (row == NULL || row->gitSource == NULL
                              || row->gitSource[0] == '\0');
-    if (allow_network && (health == 200 || sf_eligible || cpan_eligible || gh_eligible || ao_eligible || moz_eligible || jsonc_eligible)
+    /* cat-6 cluster B: the classic gnome FTP layout
+     * (gnome.org/.../sources/<module>/<M.N>/<module>-<ver>) defeats the
+     * generic listing scraper — dirname(Source0) is one minor dir and the
+     * version-bearing parent lists bare "M.N/" dirs, so enumeration returns
+     * nothing (empty cols 5/6 = cat 6). Enumerate versions from the gnome
+     * download server's cache.json instead. SCOPED to the two cat-6 gnome
+     * specs (GConf, gnome-common) — other gnome /sources/ specs either carry a
+     * gitlab.gnome.org gitSource (git path) or already detect via the generic
+     * scraper (e.g. libsigc++), so a host-wide rule would risk changing a
+     * working spec. Add specs here if they later regress to cat 6. */
+    int gnome_eligible = (spec_eq(task->Spec, "GConf.spec")
+                          || spec_eq(task->Spec, "gnome-common.spec"))
+                         && (row == NULL || row->gitSource == NULL
+                             || row->gitSource[0] == '\0');
+    if (allow_network && (health == 200 || sf_eligible || cpan_eligible || gh_eligible || ao_eligible || moz_eligible || jsonc_eligible || gnome_eligible)
         && (state.UpdateAvailable == NULL || state.UpdateAvailable[0] == '\0')
         && (atom_url != NULL
             || row == NULL
@@ -1523,11 +1538,12 @@ char *check_urlhealth(pr_task_t                       *task,
          * Otherwise fall through to the HTML listing scraper.
          * The M23 pre-filter is skipped on the atom path — atom titles
          * are tag names, not file basenames. */
-        int used_atom = 0;
-        int used_sf   = 0;
-        int used_gh   = 0;
-        int used_moz  = 0;
-        int scrape_ok = 0;
+        int used_atom  = 0;
+        int used_sf    = 0;
+        int used_gh    = 0;
+        int used_moz   = 0;
+        int used_gnome = 0;
+        int scrape_ok  = 0;
         if (jsonc_eligible) {
             /* M44: S3-bucket XML listing -> <Key> values. Drop the
              * -nodoc variant (PS L 4367) and strip the "releases/json-c-"
@@ -1619,6 +1635,17 @@ char *check_urlhealth(pr_task_t                       *task,
                 used_sf = 1;
                 free(sf_url);
             }
+        } else if (gnome_eligible) {
+            /* cluster B: gnome cache.json. Module name = the gnome module,
+             * i.e. task->Name (Source0 is .../sources/%{name}/...). The
+             * returned strings are bare versions ("3.2.6"), so the standard
+             * pipeline below (no Name-strip needed, but harmless) finds the
+             * latest. Skip the M23 href pre-filter — these aren't basenames. */
+            const char *module = (task->Name && task->Name[0]) ? task->Name : NULL;
+            if (module) {
+                scrape_ok = (pr_gnome_cache_versions(module, &names, &n) == 0);
+                used_gnome = 1;
+            }
         } else if (atom_url != NULL) {
             scrape_ok = (pr_scrape_atom_feed(atom_url, &names, &n) == 0);
             used_atom = 1;
@@ -1630,7 +1657,7 @@ char *check_urlhealth(pr_task_t                       *task,
             if (scrape_ok) apply_href_basename(names, n);
         }
         if (scrape_ok && n > 0) {
-            if (!used_atom && !used_sf && !used_gh && !used_moz) {
+            if (!used_atom && !used_sf && !used_gh && !used_moz && !used_gnome) {
                 /* M23 (PS L 4321-4341) — HTML href path only. */
                 apply_scraper_pre_filters(names, n, task->Spec);
             }

--- a/photonos-package-report/photonos-package-report/src/gnome_cache.c
+++ b/photonos-package-report/photonos-package-report/src/gnome_cache.c
@@ -1,0 +1,154 @@
+/* gnome_cache.c — gnome download-server version enumeration (cat-6 cluster B).
+ *
+ * The classic gnome FTP layout (ftp.gnome.org/.../sources/<module>/<M.N>/
+ * <module>-<ver>.tar.*) defeats the generic listing scraper: dirname(Source0)
+ * points at one minor-version dir (only the current release's files), and the
+ * version-bearing parent index lists bare "M.N/" dirs (no patch level). The
+ * gnome download server instead publishes a machine-readable index:
+ *
+ *   GET https://download.gnome.org/sources/<module>/cache.json
+ *     -> [ 4, {<module>:{<ver>:{...}}}, {<module>:[<ver>,...]}, {...} ]
+ *
+ * Element [2] maps each module to a flat array of every released version. We
+ * GET it and return that array; the standard version pipeline then picks the
+ * latest and compares. Element [1] is "<module>":{...} (object), so matching
+ * `"<module>" : [` selects the element-[2] array unambiguously.
+ *
+ * Parsed with PCRE2 (no json-c dependency), consistent with rubygems.c.
+ */
+#include "pr_gnome_cache.h"
+
+#include <curl/curl.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define BODY_CAP_BYTES (16 * 1024 * 1024)
+
+struct body_buf {
+    char  *data;
+    size_t len;
+    size_t cap;
+    int    overflow;
+};
+
+static size_t body_write_cb(void *ptr, size_t size, size_t nmemb, void *userdata)
+{
+    struct body_buf *b = (struct body_buf *)userdata;
+    size_t n = size * nmemb;
+    if (b->overflow) return n;
+    if (b->len + n > BODY_CAP_BYTES) { b->overflow = 1; return n; }
+    if (b->len + n > b->cap) {
+        size_t newcap = b->cap ? b->cap * 2 : 16384;
+        while (newcap < b->len + n) newcap *= 2;
+        char *p = (char *)realloc(b->data, newcap);
+        if (!p) { b->overflow = 1; return n; }
+        b->data = p;
+        b->cap = newcap;
+    }
+    memcpy(b->data + b->len, ptr, n);
+    b->len += n;
+    return n;
+}
+
+/* Append a heap copy of [s, s+len) to a growable name list. */
+static int push_name(char ***names, size_t *n, size_t *cap,
+                     const char *s, size_t len)
+{
+    if (*n == *cap) {
+        size_t nc = *cap ? *cap * 2 : 32;
+        char **p = (char **)realloc(*names, nc * sizeof *p);
+        if (!p) return -1;
+        *names = p; *cap = nc;
+    }
+    char *v = (char *)malloc(len + 1);
+    if (!v) return -1;
+    memcpy(v, s, len);
+    v[len] = '\0';
+    (*names)[(*n)++] = v;
+    return 0;
+}
+
+int pr_gnome_cache_versions(const char *module, char ***out_names, size_t *out_n)
+{
+    if (out_names) *out_names = NULL;
+    if (out_n)     *out_n     = 0;
+    if (module == NULL || module[0] == '\0' || out_names == NULL || out_n == NULL)
+        return -1;
+
+    char *url = NULL;
+    if (asprintf(&url, "https://download.gnome.org/sources/%s/cache.json", module) < 0)
+        return -1;
+
+    struct body_buf body = {0};
+    CURL *c = curl_easy_init();
+    if (!c) { free(url); return -1; }
+    curl_easy_setopt(c, CURLOPT_URL,            url);
+    curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(c, CURLOPT_TIMEOUT_MS,     20000L);
+    curl_easy_setopt(c, CURLOPT_USERAGENT,      "photonos-package-report/C");
+    curl_easy_setopt(c, CURLOPT_WRITEFUNCTION,  body_write_cb);
+    curl_easy_setopt(c, CURLOPT_WRITEDATA,      &body);
+    curl_easy_setopt(c, CURLOPT_ACCEPT_ENCODING, "");
+    CURLcode rc = curl_easy_perform(c);
+    long status = 0;
+    if (rc == CURLE_OK) curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &status);
+    curl_easy_cleanup(c);
+    free(url);
+
+    if (rc != CURLE_OK || status < 200 || status >= 300
+        || body.overflow || body.len == 0) {
+        free(body.data);
+        return -1;
+    }
+
+    /* Build  "<module>"\s*:\s*\[([^\]]*)\]  with the module name quoted
+     * literally (\Q..\E) so regex metacharacters in it are inert. */
+    char *pat = NULL;
+    if (asprintf(&pat, "\"\\Q%s\\E\"\\s*:\\s*\\[([^\\]]*)\\]", module) < 0) {
+        free(body.data);
+        return -1;
+    }
+    int        err = 0;
+    PCRE2_SIZE off = 0;
+    pcre2_code *re = pcre2_compile((PCRE2_SPTR)pat, PCRE2_ZERO_TERMINATED,
+                                   PCRE2_DOTALL, &err, &off, NULL);
+    free(pat);
+    if (!re) { free(body.data); return -1; }
+
+    char **names = NULL;
+    size_t n = 0, cap = 0;
+    pcre2_match_data *md = pcre2_match_data_create_from_pattern(re, NULL);
+    if (md && pcre2_match(re, (PCRE2_SPTR)body.data, body.len, 0, 0, md, NULL) >= 0) {
+        PCRE2_SIZE *ov = pcre2_get_ovector_pointer(md);
+        PCRE2_SIZE as = ov[2], ae = ov[3];   /* array-body capture */
+        if (as != PCRE2_UNSET && ae != PCRE2_UNSET) {
+            /* Extract each "..." string inside the array slice. */
+            const char *p = body.data + as;
+            const char *end = body.data + ae;
+            while (p < end) {
+                const char *q1 = memchr(p, '"', (size_t)(end - p));
+                if (!q1) break;
+                q1++;
+                const char *q2 = memchr(q1, '"', (size_t)(end - q1));
+                if (!q2) break;
+                if (q2 > q1) {
+                    if (push_name(&names, &n, &cap, q1, (size_t)(q2 - q1)) != 0)
+                        break;
+                }
+                p = q2 + 1;
+            }
+        }
+    }
+    if (md) pcre2_match_data_free(md);
+    pcre2_code_free(re);
+    free(body.data);
+
+    if (n == 0) { free(names); return -1; }
+    *out_names = names;
+    *out_n     = n;
+    return 0;
+}

--- a/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
@@ -107,6 +107,7 @@ add_executable(test_phase6
     ${CMAKE_SOURCE_DIR}/src/stable_source.c
     ${CMAKE_SOURCE_DIR}/src/atom_feed.c
     ${CMAKE_SOURCE_DIR}/src/rubygems.c
+    ${CMAKE_SOURCE_DIR}/src/gnome_cache.c
     ${CMAKE_SOURCE_DIR}/src/sourceforge.c
     ${CMAKE_SOURCE_DIR}/src/github_tags.c
     ${CMAKE_SOURCE_DIR}/src/hook_dispatch.c


### PR DESCRIPTION
## Summary

Second slice of the category-6 investigation.

**Cluster B root cause:** the classic gnome FTP layout (`gnome.org/.../sources/<module>/<M.N>/<module>-<ver>`) defeats the generic listing scraper — `dirname(Source0)` is one minor-version dir and the version-bearing parent index lists bare `M.N/` dirs, so enumeration yields nothing → empty cols 5/6 (cat 6). Git is unusable (these dead modules' gitlab repos are CVS-era tag soup with no clean 3.x release tags). **PS fails identically** → shared quality gap.

**Fix:** enumerate from the gnome download server's machine-readable index `https://download.gnome.org/sources/<module>/cache.json` (element [2] = module→version array). New `src/gnome_cache.c` GETs + PCRE2-extracts it (no json-c dep, same approach as `rubygems.c`), wired into the C scrape dispatch and mirrored in the PS detection chain.

**Scoped to the two cat-6 specs (GConf, gnome-common)** — *not* a host-wide rule. The other 11 gnome `/sources/` specs either carry a `gitlab.gnome.org` gitSource (git path) or already detect via the generic scraper (e.g. `libsigc++`), so a host-wide rule would risk changing a working spec. **Zero blast radius** beyond the two targets.

## Validation (live network)
- GConf `3.2.6` → `(same version)`
- gnome-common `3.18.0` → `(same version)` (comparator correctly ranks 3.18.0 > 3.7.4 despite JSON string order)
- Both leave cat 6; `libsigc++` provably untouched (not in the spec match)
- ctest 13/13; PS parses clean

## Parity
C and PS use the identical cache.json source + selection pipeline → parity-preserving by construction; confirmed on the next side-by-side cycle.

FRD: FRD-018 · ADR: ADR-0001, ADR-0006 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)