### PR TITLE
phase-M task M72: cat-6 cluster C — dwarves git-tag detection (renamed to pahole); cluster D = transient (no fix)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -638,6 +638,7 @@ dool.spec,https://github.com/scottchiefbaker/dool/archive/refs/tags/v%{version}.
 dos2unix.spec,https://waterlan.home.xs4all.nl/dos2unix/dos2unix-%{version}.tar.gz,https://git.code.sf.net/p/dos2unix/dos2unix.git
 dosfstools.spec,https://github.com/dosfstools/dosfstools/releases/download/v%{version}/dosfstools-%{version}.tar.gz,https://github.com/dosfstools/dosfstools.git
 dotnet-runtime.spec,https://github.com/dotnet/runtime/archive/refs/tags/v%{version}.tar.gz,https://github.com/dotnet/runtime.git
+dwarves.spec,http://fedorapeople.org/~acme/dwarves/dwarves-%{version}.tar.xz,https://git.kernel.org/pub/scm/devel/pahole/pahole.git
 dotnet-sdk.spec,https://github.com/dotnet/sdk/archive/refs/tags/v%{version}.tar.gz,https://github.com/dotnet/sdk.git
 double-conversion.spec,https://github.com/google/double-conversion/archive/refs/tags/v%{version}.tar.gz,https://github.com/google/double-conversion.git
 doxygen.spec,https://github.com/doxygen/doxygen/archive/refs/tags/Release_%{version}.tar.gz,https://github.com/doxygen/doxygen.git


### PR DESCRIPTION
## Summary

Final slice of the category-6 investigation — clusters C and D.

### Cluster C — dwarves
**Root cause:** Source0 points at `fedorapeople.org/~acme/dwarves/`, whose listing no longer carries release tarballs (project renamed/relocated to **pahole** on git.kernel.org). The current tarball still HEADs 200 (cat 6, not cat 3), but enumeration finds nothing. dwarves had **no Source0Lookup row**, so it fell to the generic scraper.

**Fix** (same methodology as cluster A): add a Source0Lookup row with `gitSource = https://git.kernel.org/pub/scm/devel/pahole/pahole.git`. Tags are clean `v1.x` (generic v-strip); col2 keeps the fedorapeople Source0 so col4 health is unchanged (1.24 tarball still served).

**Validation (live):** dwarves `1.24 → 1.31` update detected — leaves cat 6.

### Cluster D — libdaemon, lzo (no fix)
Both **reproduce `(same version)` locally** (libdaemon 0.14, lzo 2.10 are final releases). Their cat-6 in run 26366948103 was a **transient** listing-fetch flap (0pointer.de / oberhumer.com), not a defect. Per the "reproduce before concluding / don't fix non-bugs" rule, **no code change** — correctly covered by the soft-column policy + auto-trigger.

## Parity
Source0Lookup CSV change in the PS source-of-truth; C regenerates its embedded copy → parity-preserving. ctest 13/13; PS parses clean.

FRD: FRD-006 · ADR: ADR-0001, ADR-0002, ADR-0005 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)