### PR TITLE
phase-M task M73: cat-6 long-tail — apache-maven, fakeroot, gptfdisk detection fixes

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -529,7 +529,7 @@ ansible.spec,https://github.com/ansible/ansible/archive/refs/tags/v%{version}.ta
 ansible-community-general.spec,https://github.com/ansible-collections/community.general/archive/refs/tags/%{version}.tar.gz,https://github.com/ansible-collections/community.general.git
 ansible-posix.spec,https://github.com/ansible-collections/ansible.posix/archive/refs/tags/%{version}.tar.gz,https://github.com/ansible-collections/ansible.posix.git
 apache-ant.spec,https://github.com/apache/ant/archive/refs/tags/rel/%{version}.tar.gz,https://github.com/apache/ant.git,,,"rel/"
-apache-maven.spec,https://github.com/apache/maven/archive/refs/tags/maven-%{version}.tar.gz,https://github.com/apache/maven.git,,apache-maven,"workspace-v0,maven-"
+apache-maven.spec,https://github.com/apache/maven/archive/refs/tags/maven-%{version}.tar.gz,https://github.com/apache/maven.git,,maven-[0-9],"workspace-v0,maven-"
 apache-tomcat.spec,https://github.com/apache/tomcat/archive/refs/tags/%{version}.tar.gz,https://github.com/apache/tomcat.git
 apache-tomcat-native.spec,https://github.com/apache/tomcat-native/archive/refs/tags/%{version}.tar.gz,https://github.com/apache/tomcat-native.git
 apparmor.spec,https://launchpad.net/apparmor/3.1/%{version}/+download/apparmor-%{version}.tar.gz
@@ -663,7 +663,7 @@ etcd.spec,https://github.com/etcd-io/etcd/archive/refs/tags/v%{version}.tar.gz,h
 ethtool.spec,https://git.kernel.org/pub/scm/network/ethtool/ethtool.git/snapshot/ethtool-%{version}.tar.gz,https://git.kernel.org/pub/scm/network/ethtool/ethtool.git
 expat.spec,https://github.com/libexpat/libexpat/releases/download/R_%{version}/expat-%{version}.tar.xz,https://github.com/libexpat/libexpat.git
 fail2ban.spec,https://github.com/fail2ban/fail2ban/archive/refs/tags/%{version}.tar.gz,https://github.com/fail2ban/fail2ban.git
-fakeroot.spec,https://salsa.debian.org/clint/fakeroot/-/archive/debian/%{version}/fakeroot-debian-%{version}.tar.gz,https://salsa.debian.org/clint/fakeroot.git
+fakeroot.spec,https://salsa.debian.org/clint/fakeroot/-/archive/debian/%{version}/fakeroot-debian-%{version}.tar.gz,https://salsa.debian.org/clint/fakeroot.git,,upstream/,"upstream/"
 fakeroot-ng.spec,https://master.dl.sourceforge.net/project/fakerootng/fakeroot-ng/fakeroot-ng-%{version}.tar.gz,https://git.code.sf.net/p/fakerootng/source.git
 falco.spec,https://github.com/falcosecurity/falco/archive/refs/tags/%{version}.tar.gz,https://github.com/falcosecurity/falco.git
 fatrace.spec,https://github.com/martinpitt/fatrace/archive/refs/tags/%{version}.tar.gz,https://github.com/martinpitt/fatrace.git
@@ -711,7 +711,7 @@ google-guest-configs.spec,https://github.com/GoogleCloudPlatform/guest-configs/a
 google-guest-oslogin.spec,https://github.com/GoogleCloudPlatform/guest-oslogin/archive/refs/tags/%{version}.tar.gz,https://github.com/GoogleCloudPlatform/guest-oslogin.git
 govmomi.spec,https://github.com/vmware/govmomi/archive/refs/tags/v%{version}.0.tar.gz,https://github.com/vmware/govmomi.git
 gperftools.spec,https://github.com/gperftools/gperftools/releases/download/gperftools-%{version}/gperftools-%{version}.tar.gz,https://github.com/gperftools/gperftools.git
-gptfdisk.spec,https://netix.dl.sourceforge.net/project/gptfdisk/gptfdisk/%{version}/gptfdisk-%{version}.tar.gz,https://git.code.sf.net/p/gptfdisk/code.git
+gptfdisk.spec,https://downloads.sourceforge.net/project/gptfdisk/gptfdisk/%{version}/gptfdisk-%{version}.tar.gz
 graphene.spec,https://github.com/ebassi/graphene/archive/refs/tags/%{version}.tar.gz,https://github.com/ebassi/graphene.git
 grpc.spec,https://github.com/grpc/grpc/archive/refs/tags/v%{version}.tar.gz,https://github.com/grpc/grpc.git
 gssntlmssp.spec,https://github.com/gssapi/gss-ntlmssp/releases/download/v%{version}/gssntlmssp-%{version}.tar.gz,https://github.com/gssapi/gss-ntlmssp.git

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase3.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase3.c
@@ -126,8 +126,8 @@ static void run_assertions(void)
     int rc = source0_lookup(&t);
     EXPECT_INT_EQ(rc, 0);
 
-    /* The PS embed currently has 855 data rows + 1 header. */
-    EXPECT_INT_EQ((long)t.count, 855);
+    /* The PS embed currently has 856 data rows + 1 header (M72 added dwarves). */
+    EXPECT_INT_EQ((long)t.count, 856);
 
     /* First row */
     if (t.count > 0) {
@@ -163,11 +163,12 @@ static void run_assertions(void)
     }
 
     /* apache-maven row: 6 cells, with embedded comma inside a quoted
-     * field landing in replaceStrings. */
+     * field landing in replaceStrings. customRegex was "apache-maven" but the
+     * repo's tags are "maven-X" (M73 fix), so it now filters on "maven-[0-9]". */
     pr_source0_lookup_t *maven = find_row(&t, "apache-maven.spec");
     if (maven) {
         EXPECT_STREQ(maven->gitBranch,       "");
-        EXPECT_STREQ(maven->customRegex,     "apache-maven");
+        EXPECT_STREQ(maven->customRegex,     "maven-[0-9]");
         EXPECT_STREQ(maven->replaceStrings,  "workspace-v0,maven-");
         EXPECT_STREQ(maven->ignoreStrings,   "");
     } else {


### PR DESCRIPTION
## Summary

Continuing the cat-6 sweep beyond clusters A–D. Reproduced the remaining cat-6 specs locally to split transient from deterministic:
- **Transient (no fix, now detect):** lasso, libbsd, libevent → `(same version)`
- **Deterministic (broken Source0Lookup config), fixed:**

| spec | root cause | fix | result |
|---|---|---|---|
| apache-maven | customRegex `apache-maven` filters out every tag (tags are `maven-X`, no `apache-` prefix) | customRegex → `maven-[0-9]` | 3.9.0 → 3.9.16 |
| fakeroot | salsa tags `upstream/1.38.1` — prefix survives strips, no-alpha drops all | add customRegex/replaceStrings `upstream/` | 1.37.1.1 → 1.38.1 |
| gptfdisk | tagless gitSource + `netix.dl` mirror host defeats sf project-URL derivation | drop gitSource, use canonical `downloads.sourceforge.net` host | 1.0.9 → 1.0.10 |

All three fail identically in PS → shared quality gaps, not parity gaps. Source0Lookup CSV edits in the PS source-of-truth (C regenerates its embedded copy) → parity-preserving. Live-tested each.

## Also: test fixture fix
`test_phase3` tracked stale expectations — row count `855→856` (M72's dwarves row; **ctest isn't run in the PR gate workflow**, so M72 slipped it through) and the maven customRegex. Now ctest 13/13. *(Worth considering adding ctest to the PR gate.)*

## Deferred (documented follow-ups)
log4cpp (date-stamped `REL_<ver>_<date>` tags + nested sf layout), big-repo specs whose batch empties may be clone timeouts (erlang, libclc, gstreamer-plugins-base, nmap), and the no-git scrapers (cscope, eventlog, iotop[403], xorg-applications).

FRD: FRD-006 · ADR: ADR-0001, ADR-0002, ADR-0005 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)