### PR TITLE
phase-M task M77: PyPI JSON-API second-path detection (github-tagless python packages)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -4557,6 +4557,45 @@ function CheckURLHealth {
     }
     }
     # -------------------------------------------------------------------------------------------------------------------
+    # Second-path detection: PyPI JSON API for python packages whose github
+    # source has no tags/releases and is not declared deprecated. The PyPI JSON
+    # API is the metadata backing pypi.org/project/<pkg>/#files: info.version +
+    # the latest sdist file. Runs BEFORE the "Cannot detect correlating tags"
+    # warning below, so a successful lookup suppresses that warning (it is gated
+    # on $UpdateAvailable -eq ""). Mirrors the C-side pr_pypi fallback.
+    # -------------------------------------------------------------------------------------------------------------------
+    if (($UpdateAvailable -eq "") -and ($GitSource -ilike "*github.com*") -and ([string]::IsNullOrEmpty($ArchivationDate)) -and ($currentTask.Spec -ilike "python-*")) {
+        if ($GitSource -match "/([^/]+)\.git$") {
+            $pypiName = $matches[1]
+            try {
+                $pypi = Invoke-RestMethod -Uri "https://pypi.org/pypi/$pypiName/json" -TimeoutSec 10 -ErrorAction Stop
+                $NameLatest = $pypi.info.version
+                if (-not [string]::IsNullOrEmpty($NameLatest)) {
+                    if ($version -is [PSCustomObject]) { [string]$version = [string]$version.version }
+                    $result = Compare-VersionStrings -Namelatest $NameLatest -Version $version
+                    if ($result -gt 0) {
+                        $UpdateAvailable = $NameLatest
+                        $sdist = $pypi.urls | Where-Object { $_.packagetype -eq 'sdist' } | Select-Object -First 1
+                        if ($sdist) {
+                            $UpdateURL = $sdist.url
+                            $HealthUpdateURL = urlhealth($UpdateURL)
+                            $UpdateDownloadName = $sdist.filename
+                        }
+                    }
+                    elseif ($result -lt 0) {
+                        $UpdateAvailable = "Warning: " + $currentTask.spec + " Source0 version " + $version + " is higher than detected latest version " + $NameLatest + " ."
+                    }
+                    else {
+                        $UpdateAvailable = "(same version)"
+                    }
+                }
+            }
+            catch {
+                # PyPI lookup failed (name not on PyPI -> 404, network, etc.); leave empty.
+            }
+        }
+    }
+    # -------------------------------------------------------------------------------------------------------------------
     # Signalization of not accessible or archived repositories
     # -------------------------------------------------------------------------------------------------------------------
     $warningText="Warning: repo isn't maintained anymore."

--- a/photonos-package-report/photonos-package-report/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/CMakeLists.txt
@@ -119,6 +119,7 @@ add_executable(photonos-package-report
     src/atom_feed.c
     src/rubygems.c
     src/gnome_cache.c
+    src/pypi.c
     src/sourceforge.c
     src/github_tags.c
     src/heapsort.c

--- a/photonos-package-report/photonos-package-report/include/pr_pypi.h
+++ b/photonos-package-report/photonos-package-report/include/pr_pypi.h
@@ -1,0 +1,21 @@
+/* pr_pypi.h — PyPI JSON-API latest-version detection (python family).
+ *
+ * See src/pypi.c. For specs whose upstream is PyPI (Source0 on
+ * files.pythonhosted.org / pypi.python.org), the authoritative version +
+ * download is the JSON API the /project/<pkg>/#files page is rendered from:
+ *   GET https://pypi.org/pypi/<pkg>/json
+ *     -> {"info":{"version":"X"...}, "urls":[{"packagetype":"sdist",
+ *         "filename":"<pkg>-X.tar.gz","url":"https://files.pythonhosted.org/.."}]}
+ */
+#ifndef PR_PYPI_H
+#define PR_PYPI_H
+
+/* GET the PyPI metadata for `package` and return its latest version (heap,
+ * caller frees), or NULL on error. When `out_sdist_url`/`out_sdist_name` are
+ * non-NULL they receive the latest sdist's download URL and filename (heap,
+ * caller frees; set to NULL if no sdist is listed). */
+char *pr_pypi_latest_version(const char *package,
+                             char **out_sdist_url,
+                             char **out_sdist_name);
+
+#endif /* PR_PYPI_H */

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -28,6 +28,7 @@
 #include "pr_sha.h"
 #include "pr_scraper.h"
 #include "pr_gnome_cache.h"
+#include "pr_pypi.h"
 #include "pr_sourceforge.h"
 #include "pr_spec_warnings.h"
 #include "pr_stable_source.h"
@@ -1357,6 +1358,61 @@ char *check_urlhealth(pr_task_t                       *task,
                 }
             }
             free(repo_name);
+        }
+    }
+
+    /* M77: PyPI JSON-API fallback — the "second path" for python packages.
+     * Workflow: a spec whose gitSource is a github repo that is NOT declared
+     * deprecated (no ArchivationDate) yet exposes no tags/releases leaves the
+     * git path above with UpdateAvailable empty. For a python-* spec, fall
+     * through to the authoritative PyPI metadata (the JSON API backing
+     * pypi.org/project/<pkg>/#files): info.version + the latest sdist file.
+     * The PyPI package name is the github repo leaf (== PyPI name for these);
+     * a non-PyPI name simply 404s -> no-op. Mirrors PS L4602: the pyjsparser-
+     * class "Cannot detect correlating tags" warning is gated on
+     * UpdateAvailable being empty, so populating it here suppresses that
+     * warning at the downstream pr_spec_warning() step. */
+    if (allow_network
+        && (state.UpdateAvailable == NULL || state.UpdateAvailable[0] == '\0')
+        && row && row->gitSource && strstr(row->gitSource, "github.com") != NULL
+        && (row->ArchivationDate == NULL || row->ArchivationDate[0] == '\0')
+        && task->Spec && strncmp(task->Spec, "python-", 7) == 0) {
+
+        char *pkg = pr_extract_repo_name(row->gitSource);
+        if (pkg) {
+            char *surl = NULL, *sname = NULL;
+            char *latest = pr_pypi_latest_version(pkg, &surl, &sname);
+            if (latest && latest[0]) {
+                int rc = pr_version_compare(latest, state.version ? state.version : "");
+                free(state.UpdateAvailable);
+                if (rc == 1) {
+                    state.UpdateAvailable = dup_or_empty(latest);
+                    if (surl && surl[0]) {
+                        free(state.UpdateURL);
+                        state.UpdateURL = surl; surl = NULL;
+                        int h = urlhealth(state.UpdateURL);
+                        char b[16]; snprintf(b, sizeof b, "%d", h);
+                        free(state.HealthUpdateURL); state.HealthUpdateURL = strdup(b);
+                    }
+                    if (sname && sname[0]) {
+                        /* Raw PyPI sdist filename (e.g. "pyjsparser-2.7.1.tar.gz");
+                         * the PS mirror uses $sdist.filename verbatim too, so
+                         * col 10 stays byte-identical. */
+                        free(state.UpdateDownloadName);
+                        state.UpdateDownloadName = sname; sname = NULL;
+                    }
+                } else if (rc == -1) {
+                    char *warn = NULL;
+                    if (asprintf(&warn,
+                            "Warning: %s Source0 version %s is higher than detected latest version %s .",
+                            task->Spec, state.version ? state.version : "", latest) < 0) warn = NULL;
+                    state.UpdateAvailable = warn ? warn : dup_or_empty("");
+                } else {
+                    state.UpdateAvailable = dup_or_empty("(same version)");
+                }
+            }
+            free(latest); free(surl); free(sname);
+            free(pkg);
         }
     }
 

--- a/photonos-package-report/photonos-package-report/src/pypi.c
+++ b/photonos-package-report/photonos-package-report/src/pypi.c
@@ -1,0 +1,149 @@
+/* pypi.c — PyPI JSON-API latest-version detection (python family).
+ *
+ * Many python-* specs have a Source0 on files.pythonhosted.org / pypi.python.org
+ * whose upstream has no usable git tags (e.g. pyjsparser's github mirror is
+ * tagless). The authoritative source is the PyPI JSON API that backs the
+ * /project/<pkg>/#files page:
+ *   GET https://pypi.org/pypi/<pkg>/json
+ *     info.version            -> latest release
+ *     urls[] (latest's files) -> the sdist filename + hashed download URL
+ *
+ * Parsed with PCRE2 (no json-c dependency), same approach as rubygems.c. The
+ * version is info.version (the first "version" key in the document — info is
+ * the leading object). The sdist URL/name are taken from the top-level "urls"
+ * array (the latest version's files), scoped past the "urls": key so the
+ * earlier "releases" map (older versions' files) is never matched.
+ */
+#include "pr_pypi.h"
+
+#include <curl/curl.h>
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
+
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define BODY_CAP_BYTES (32 * 1024 * 1024)   /* releases map can be large */
+
+struct body_buf { char *data; size_t len, cap; int overflow; };
+
+static size_t body_write_cb(void *ptr, size_t size, size_t nmemb, void *userdata)
+{
+    struct body_buf *b = (struct body_buf *)userdata;
+    size_t n = size * nmemb;
+    if (b->overflow) return n;
+    if (b->len + n > BODY_CAP_BYTES) { b->overflow = 1; return n; }
+    if (b->len + n > b->cap) {
+        size_t nc = b->cap ? b->cap * 2 : 65536;
+        while (nc < b->len + n) nc *= 2;
+        char *p = (char *)realloc(b->data, nc);
+        if (!p) { b->overflow = 1; return n; }
+        b->data = p; b->cap = nc;
+    }
+    memcpy(b->data + b->len, ptr, n);
+    b->len += n;
+    return n;
+}
+
+static pcre2_code *RE_VER, *RE_URLS, *RE_SDIST;
+static pthread_once_t g_once = PTHREAD_ONCE_INIT;
+
+static pcre2_code *compile(const char *pat)
+{
+    int err = 0; PCRE2_SIZE off = 0;
+    pcre2_code *re = pcre2_compile((PCRE2_SPTR)pat, PCRE2_ZERO_TERMINATED,
+                                   PCRE2_DOTALL, &err, &off, NULL);
+    if (!re) {
+        PCRE2_UCHAR e[256]; pcre2_get_error_message(err, e, sizeof e);
+        fprintf(stderr, "pypi.c: compile('%s') failed: %s\n", pat, (char *)e);
+        abort();
+    }
+    return re;
+}
+
+static void init_re(void)
+{
+    /* First "version":"X" key — info.version (info is the leading object). */
+    RE_VER  = compile("\"version\"\\s*:\\s*\"([^\"]+)\"");
+    /* Top-level "urls": array start (not "project_urls"). */
+    RE_URLS = compile("\"urls\"\\s*:\\s*\\[");
+    /* A source-archive download URL inside the urls array. */
+    RE_SDIST = compile("\"url\"\\s*:\\s*\"(https://[^\"]+\\.(?:tar\\.gz|tar\\.bz2|tar\\.xz|zip|tgz))\"");
+}
+
+static char *capture(pcre2_code *re, const char *s, size_t len, size_t from,
+                     PCRE2_SIZE *match_end)
+{
+    pcre2_match_data *md = pcre2_match_data_create_from_pattern(re, NULL);
+    if (!md) return NULL;
+    char *out = NULL;
+    int rc = pcre2_match(re, (PCRE2_SPTR)s, len, from, 0, md, NULL);
+    if (rc >= 0) {
+        PCRE2_SIZE *ov = pcre2_get_ovector_pointer(md);
+        if (match_end) *match_end = ov[1];
+        if (rc >= 2 && ov[2] != PCRE2_UNSET) {
+            size_t l = (size_t)(ov[3] - ov[2]);
+            out = (char *)malloc(l + 1);
+            if (out) { memcpy(out, s + ov[2], l); out[l] = '\0'; }
+        } else if (match_end) {
+            /* matched, no capture group requested */
+        }
+    }
+    pcre2_match_data_free(md);
+    return out;
+}
+
+char *pr_pypi_latest_version(const char *package,
+                             char **out_sdist_url, char **out_sdist_name)
+{
+    if (out_sdist_url)  *out_sdist_url  = NULL;
+    if (out_sdist_name) *out_sdist_name = NULL;
+    if (package == NULL || package[0] == '\0') return NULL;
+
+    char *url = NULL;
+    if (asprintf(&url, "https://pypi.org/pypi/%s/json", package) < 0) return NULL;
+
+    struct body_buf body = {0};
+    CURL *c = curl_easy_init();
+    if (!c) { free(url); return NULL; }
+    curl_easy_setopt(c, CURLOPT_URL,            url);
+    curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(c, CURLOPT_TIMEOUT_MS,     20000L);
+    curl_easy_setopt(c, CURLOPT_USERAGENT,      "photonos-package-report/C");
+    curl_easy_setopt(c, CURLOPT_WRITEFUNCTION,  body_write_cb);
+    curl_easy_setopt(c, CURLOPT_WRITEDATA,      &body);
+    curl_easy_setopt(c, CURLOPT_ACCEPT_ENCODING, "");
+    CURLcode rc = curl_easy_perform(c);
+    long status = 0;
+    if (rc == CURLE_OK) curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &status);
+    curl_easy_cleanup(c);
+    free(url);
+    if (rc != CURLE_OK || status < 200 || status >= 300 || body.overflow || body.len == 0) {
+        free(body.data); return NULL;
+    }
+
+    pthread_once(&g_once, init_re);
+
+    char *version = capture(RE_VER, body.data, body.len, 0, NULL);
+
+    if (version && (out_sdist_url || out_sdist_name)) {
+        /* Scope the sdist search to the top-level "urls" array (latest's
+         * files), past the earlier "releases" map. */
+        PCRE2_SIZE urls_end = 0;
+        char *dummy = capture(RE_URLS, body.data, body.len, 0, &urls_end);
+        free(dummy);
+        size_t from = urls_end ? urls_end : 0;
+        char *surl = capture(RE_SDIST, body.data, body.len, from, NULL);
+        if (surl) {
+            char *base = strrchr(surl, '/');
+            char *name = strdup(base ? base + 1 : surl);
+            if (out_sdist_url)  *out_sdist_url  = surl; else free(surl);
+            if (out_sdist_name) *out_sdist_name = name; else free(name);
+        }
+    }
+
+    free(body.data);
+    return version;
+}

--- a/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
+++ b/photonos-package-report/photonos-package-report/tests/unit/CMakeLists.txt
@@ -108,6 +108,7 @@ add_executable(test_phase6
     ${CMAKE_SOURCE_DIR}/src/atom_feed.c
     ${CMAKE_SOURCE_DIR}/src/rubygems.c
     ${CMAKE_SOURCE_DIR}/src/gnome_cache.c
+    ${CMAKE_SOURCE_DIR}/src/pypi.c
     ${CMAKE_SOURCE_DIR}/src/sourceforge.c
     ${CMAKE_SOURCE_DIR}/src/github_tags.c
     ${CMAKE_SOURCE_DIR}/src/hook_dispatch.c


### PR DESCRIPTION
## Summary

Implements the detection workflow you specified: **a spec with a github gitSource that is *not* declared deprecated yet has *no tags/releases* → second path = query the PyPI JSON API.**

Motivating case — **python-pyjsparser**: its Source0Lookup row remaps Source0 to `github.com/PiotrDabkowski/pyjsparser`, but that repo has **0 tags / 0 releases**, so the git path found nothing and the (UpdateAvailable-gated) *"Cannot detect correlating tags"* warning fired → cat 8. The authoritative source is the PyPI JSON API backing `pypi.org/project/pyjsparser/#files` → `info.version = 2.7.1` = current → `(same version)`. Populating UpdateAvailable suppresses the warning (gated on `UpdateAvailable -eq ""` in both PS L4602 and the C `requires_empty_ua` table) → pyjsparser leaves the issue set.

## Implementation
- **New `src/pypi.c`** (`pr_pypi_latest_version`): libcurl GET + PCRE2 extraction of `info.version` and the top-level `urls[]` sdist URL/filename — no json-c dep, same pattern as `rubygems.c` / `gnome_cache.c`.
- **`check_urlhealth.c`**: PyPI fallback right after the git-tag path, gated on `github gitSource + no ArchivationDate + python-* spec + empty UpdateAvailable`. Package name = github repo leaf; a non-PyPI name 404s → no-op. col 10 uses the **raw** sdist filename to match PS byte-for-byte.
- **PS mirror**: identical block before the warning section (`Invoke-RestMethod` + `$pypi.info.version` + `$pypi.urls` sdist), same gate.

## Scope / parity
Scoped to `python-*` specs (where PyPI is the index) to avoid name-collision false positives on non-python tagless repos. Both sides share the gate/logic/raw-filename → **parity-preserving**. Live-tested: pyjsparser → `(same version)`, warning cleared; **docutils correctly untouched** (no github source → outside the "has a github source" scope). ctest 13/13; PS parses clean.

FRD: FRD-006 · ADR: ADR-0001, ADR-0002, ADR-0006 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)