### PR TITLE
phase-M task M78: dual-source (github + PyPI) detection for python packages — C/PS feature parity

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -4557,24 +4557,34 @@ function CheckURLHealth {
     }
     }
     # -------------------------------------------------------------------------------------------------------------------
-    # Second-path detection: PyPI JSON API for python packages whose github
-    # source has no tags/releases and is not declared deprecated. The PyPI JSON
-    # API is the metadata backing pypi.org/project/<pkg>/#files: info.version +
-    # the latest sdist file. Runs BEFORE the "Cannot detect correlating tags"
-    # warning below, so a successful lookup suppresses that warning (it is gated
-    # on $UpdateAvailable -eq ""). Mirrors the C-side pr_pypi fallback.
+    # Dual-source detection for python packages (M78). A developer may publish a
+    # release to github, to PyPI, or to both, so for a python-* spec with a
+    # github source that is not declared deprecated (no ArchivationDate) consult
+    # BOTH sources and report the HIGHER version. The git path above produced
+    # github's view in $UpdateAvailable (a version / "(same version)" / "" / a
+    # regression Warning); reconstruct github's latest from it, query the PyPI
+    # JSON API (the metadata backing pypi.org/project/<pkg>/#files), and adopt
+    # PyPI only when it is strictly newer than both $version AND github's latest.
+    # Subsumes the one-way fallback (github-tagless -> PyPI). Runs before the
+    # "Cannot detect correlating tags" warning, which is gated on
+    # $UpdateAvailable -eq "", so a hit suppresses it. Mirrors the C M78 block.
     # -------------------------------------------------------------------------------------------------------------------
-    if (($UpdateAvailable -eq "") -and ($GitSource -ilike "*github.com*") -and ([string]::IsNullOrEmpty($ArchivationDate)) -and ($currentTask.Spec -ilike "python-*")) {
+    if (($GitSource -ilike "*github.com*") -and ([string]::IsNullOrEmpty($ArchivationDate)) -and ($currentTask.Spec -ilike "python-*")) {
         if ($GitSource -match "/([^/]+)\.git$") {
             $pypiName = $matches[1]
+            if ($version -is [PSCustomObject]) { [string]$version = [string]$version.version }
+            # github's latest, reconstructed from the git-path $UpdateAvailable.
+            $ghLatest = $null
+            if (($UpdateAvailable -ne "") -and ($UpdateAvailable -ne "(same version)") -and (-not $UpdateAvailable.StartsWith("Warning:"))) { $ghLatest = $UpdateAvailable }
+            elseif ($UpdateAvailable -eq "(same version)") { $ghLatest = $version }
             try {
                 $pypi = Invoke-RestMethod -Uri "https://pypi.org/pypi/$pypiName/json" -TimeoutSec 10 -ErrorAction Stop
-                $NameLatest = $pypi.info.version
-                if (-not [string]::IsNullOrEmpty($NameLatest)) {
-                    if ($version -is [PSCustomObject]) { [string]$version = [string]$version.version }
-                    $result = Compare-VersionStrings -Namelatest $NameLatest -Version $version
-                    if ($result -gt 0) {
-                        $UpdateAvailable = $NameLatest
+                $pp = $pypi.info.version
+                if (-not [string]::IsNullOrEmpty($pp)) {
+                    $ppGtCur = ((Compare-VersionStrings -Namelatest $pp -Version $version) -gt 0)
+                    $ppGtGh  = ($null -eq $ghLatest) -or ((Compare-VersionStrings -Namelatest $pp -Version $ghLatest) -gt 0)
+                    if ($ppGtCur -and $ppGtGh) {
+                        $UpdateAvailable = $pp
                         $sdist = $pypi.urls | Where-Object { $_.packagetype -eq 'sdist' } | Select-Object -First 1
                         if ($sdist) {
                             $UpdateURL = $sdist.url
@@ -4582,16 +4592,14 @@ function CheckURLHealth {
                             $UpdateDownloadName = $sdist.filename
                         }
                     }
-                    elseif ($result -lt 0) {
-                        $UpdateAvailable = "Warning: " + $currentTask.spec + " Source0 version " + $version + " is higher than detected latest version " + $NameLatest + " ."
-                    }
-                    else {
+                    elseif (($null -eq $ghLatest) -and ((Compare-VersionStrings -Namelatest $pp -Version $version) -eq 0)) {
                         $UpdateAvailable = "(same version)"
                     }
+                    # else: github's version >= PyPI -> keep the git-path result.
                 }
             }
             catch {
-                # PyPI lookup failed (name not on PyPI -> 404, network, etc.); leave empty.
+                # PyPI lookup failed (name not on PyPI -> 404, network, etc.); keep github's result.
             }
         }
     }

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1361,59 +1361,66 @@ char *check_urlhealth(pr_task_t                       *task,
         }
     }
 
-    /* M77: PyPI JSON-API fallback — the "second path" for python packages.
-     * Workflow: a spec whose gitSource is a github repo that is NOT declared
-     * deprecated (no ArchivationDate) yet exposes no tags/releases leaves the
-     * git path above with UpdateAvailable empty. For a python-* spec, fall
-     * through to the authoritative PyPI metadata (the JSON API backing
-     * pypi.org/project/<pkg>/#files): info.version + the latest sdist file.
-     * The PyPI package name is the github repo leaf (== PyPI name for these);
-     * a non-PyPI name simply 404s -> no-op. Mirrors PS L4602: the pyjsparser-
-     * class "Cannot detect correlating tags" warning is gated on
-     * UpdateAvailable being empty, so populating it here suppresses that
-     * warning at the downstream pr_spec_warning() step. */
+    /* M78: dual-source detection for python packages. A developer may publish
+     * a release to github, to PyPI, or to both, so for a python-* spec with a
+     * github gitSource that is NOT declared deprecated (no ArchivationDate)
+     * consult BOTH sources and report the HIGHER version. The git-tag path
+     * above already produced github's view in state.UpdateAvailable (a version
+     * / "(same version)" / empty / a regression Warning); we reconstruct
+     * github's latest from it, query PyPI (the JSON API backing
+     * pypi.org/project/<pkg>/#files), and adopt PyPI only when it is strictly
+     * newer than both the current version AND github's latest. This subsumes
+     * the one-way fallback: github-tagless (pyjsparser) -> PyPI; github newer
+     * -> github kept; PyPI newer than a stale github tag -> PyPI. The
+     * pyjsparser-class "Cannot detect correlating tags" warning is gated on
+     * UpdateAvailable being empty, so populating it here suppresses it at the
+     * downstream pr_spec_warning() step. PS mirrors this block verbatim. */
     if (allow_network
-        && (state.UpdateAvailable == NULL || state.UpdateAvailable[0] == '\0')
         && row && row->gitSource && strstr(row->gitSource, "github.com") != NULL
         && (row->ArchivationDate == NULL || row->ArchivationDate[0] == '\0')
         && task->Spec && strncmp(task->Spec, "python-", 7) == 0) {
 
-        char *pkg = pr_extract_repo_name(row->gitSource);
-        if (pkg) {
-            char *surl = NULL, *sname = NULL;
-            char *latest = pr_pypi_latest_version(pkg, &surl, &sname);
-            if (latest && latest[0]) {
-                int rc = pr_version_compare(latest, state.version ? state.version : "");
-                free(state.UpdateAvailable);
-                if (rc == 1) {
-                    state.UpdateAvailable = dup_or_empty(latest);
-                    if (surl && surl[0]) {
-                        free(state.UpdateURL);
-                        state.UpdateURL = surl; surl = NULL;
-                        int h = urlhealth(state.UpdateURL);
-                        char b[16]; snprintf(b, sizeof b, "%d", h);
-                        free(state.HealthUpdateURL); state.HealthUpdateURL = strdup(b);
-                    }
-                    if (sname && sname[0]) {
-                        /* Raw PyPI sdist filename (e.g. "pyjsparser-2.7.1.tar.gz");
-                         * the PS mirror uses $sdist.filename verbatim too, so
-                         * col 10 stays byte-identical. */
-                        free(state.UpdateDownloadName);
-                        state.UpdateDownloadName = sname; sname = NULL;
-                    }
-                } else if (rc == -1) {
-                    char *warn = NULL;
-                    if (asprintf(&warn,
-                            "Warning: %s Source0 version %s is higher than detected latest version %s .",
-                            task->Spec, state.version ? state.version : "", latest) < 0) warn = NULL;
-                    state.UpdateAvailable = warn ? warn : dup_or_empty("");
-                } else {
-                    state.UpdateAvailable = dup_or_empty("(same version)");
-                }
-            }
-            free(latest); free(surl); free(sname);
-            free(pkg);
+        const char *cur = state.version ? state.version : "";
+        /* github's latest, reconstructed from the git-path result. */
+        char *gh_latest = NULL;
+        if (state.UpdateAvailable && state.UpdateAvailable[0]
+            && strcmp(state.UpdateAvailable, "(same version)") != 0
+            && strncmp(state.UpdateAvailable, "Warning:", 8) != 0) {
+            gh_latest = strdup(state.UpdateAvailable);   /* github found a newer ver */
+        } else if (state.UpdateAvailable
+                   && strcmp(state.UpdateAvailable, "(same version)") == 0) {
+            gh_latest = strdup(cur);                     /* github latest == current */
         }
+
+        char *pkg = pr_extract_repo_name(row->gitSource);
+        char *surl = NULL, *sname = NULL;
+        char *pp = pkg ? pr_pypi_latest_version(pkg, &surl, &sname) : NULL;
+
+        if (pp && pp[0]) {
+            int pp_gt_cur = (pr_version_compare(pp, cur) == 1);
+            int pp_gt_gh  = (gh_latest == NULL)
+                            || (pr_version_compare(pp, gh_latest) == 1);
+            if (pp_gt_cur && pp_gt_gh) {
+                /* PyPI is the newest of the three -> developer released to PyPI. */
+                free(state.UpdateAvailable); state.UpdateAvailable = strdup(pp);
+                if (surl && surl[0]) {
+                    free(state.UpdateURL); state.UpdateURL = surl; surl = NULL;
+                    int h = urlhealth(state.UpdateURL);
+                    char b[16]; snprintf(b, sizeof b, "%d", h);
+                    free(state.HealthUpdateURL); state.HealthUpdateURL = strdup(b);
+                }
+                if (sname && sname[0]) {
+                    /* Raw PyPI sdist filename; PS uses $sdist.filename verbatim
+                     * too, so col 10 stays byte-identical. */
+                    free(state.UpdateDownloadName); state.UpdateDownloadName = sname; sname = NULL;
+                }
+            } else if (gh_latest == NULL && pr_version_compare(pp, cur) == 0) {
+                /* github found nothing and PyPI == current -> (same version). */
+                free(state.UpdateAvailable); state.UpdateAvailable = dup_or_empty("(same version)");
+            }
+            /* else: github's version >= PyPI -> keep the git-path result. */
+        }
+        free(gh_latest); free(pp); free(surl); free(sname); free(pkg);
     }
 
     /* M34 / FRD-020: rubygems.org JSON-API update detection.


### PR DESCRIPTION
## Investigation (the scenario you raised)

A developer may update **github only, PyPI only, or both**:
- For actively-maintained packages, github and PyPI **agree** (verified: pyparsing/more-itertools/filelock match on both).
- They **diverge** when only one side is updated: github tagless (pyjsparser → PyPI has 2.7.1), or a **stale github tag while PyPI is newer**.
- Deprecation signals: github API `archived`, PyPI `yanked`/Development-Status, and the maintainer-set Source0Lookup `ArchivationDate`.

**M77 handled only one direction** (github-tagless → PyPI fallback) and missed "PyPI newer than a stale github tag".

## Fix — dual-source max (C + PS, identical)

For a `python-*` spec with a github gitSource that is **not** deprecated (no `ArchivationDate`), consult **both** and report the **higher** version:
1. reconstruct github's latest from the git-path result;
2. query PyPI (`info.version` + sdist — the metadata behind `pypi.org/project/<pkg>/#files`);
3. adopt PyPI **only when strictly newer than both** the current version and github's latest; else keep github.

Subsumes the fallback (github-tagless → PyPI; github-newer → github; PyPI-newer-than-stale-tag → PyPI). Deprecation (`ArchivationDate`) skips the block, respecting a maintainer-signalled pin.

Implemented **identically in C and PS** (same gate, reconstruction, max rule, sdist selection, raw col-10 filename) → **feature-parity-compliant**.

## Validation
- pyjsparser → `(same version)` (warning cleared)
- more-itertools / filelock → **unchanged** (github == PyPI, no spurious override → no regression for synced specs)
- ctest 13/13; PS parses clean

FRD: FRD-006 · ADR: ADR-0001, ADR-0002, ADR-0006 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)