### PR TITLE
phase-M task M79: M78 follow-on — PyPI URL repair + spec-name pkg derivation (C/PS parity)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -4570,8 +4570,12 @@ function CheckURLHealth {
     # $UpdateAvailable -eq "", so a hit suppresses it. Mirrors the C M78 block.
     # -------------------------------------------------------------------------------------------------------------------
     if (($GitSource -ilike "*github.com*") -and ([string]::IsNullOrEmpty($ArchivationDate)) -and ($currentTask.Spec -ilike "python-*")) {
-        if ($GitSource -match "/([^/]+)\.git$") {
-            $pypiName = $matches[1]
+        # PyPI package name = spec minus "python-" prefix and ".spec" suffix.
+        # Photon's naming matches the PyPI project name (PyPI lookup is
+        # case-insensitive); the github repo leaf can differ (e.g.
+        # python-filelock -> repo "py-filelock" but PyPI "filelock").
+        $pypiName = $currentTask.spec -replace '^python-','' -replace '\.spec$',''
+        if ($pypiName -ne "") {
             if ($version -is [PSCustomObject]) { [string]$version = [string]$version.version }
             # github's latest, reconstructed from the git-path $UpdateAvailable.
             $ghLatest = $null
@@ -4592,10 +4596,24 @@ function CheckURLHealth {
                             $UpdateDownloadName = $sdist.filename
                         }
                     }
+                    elseif (($null -ne $ghLatest) -and ((Compare-VersionStrings -Namelatest $pp -Version $ghLatest) -eq 0) -and $ppGtCur -and ($UpdateURL -eq "")) {
+                        # github detected this same update version but defers URL
+                        # construction to the later stage, which fails for it
+                        # (cat 7). Fill the URL from PyPI's sdist now; that stage
+                        # is gated on $UpdateURL -eq "" so it then skips and the
+                        # packaging-format warning is never emitted. ($UpdateAvailable
+                        # already == $pp == github's version.)
+                        $sdist = $pypi.urls | Where-Object { $_.packagetype -eq 'sdist' } | Select-Object -First 1
+                        if ($sdist) {
+                            $UpdateURL = $sdist.url
+                            $HealthUpdateURL = urlhealth($UpdateURL)
+                            $UpdateDownloadName = $sdist.filename
+                        }
+                    }
                     elseif (($null -eq $ghLatest) -and ((Compare-VersionStrings -Namelatest $pp -Version $version) -eq 0)) {
                         $UpdateAvailable = "(same version)"
                     }
-                    # else: github's version >= PyPI -> keep the git-path result.
+                    # else: github's version >= PyPI (and URL ok, or PyPI not newer) -> keep the git-path result.
                 }
             }
             catch {

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1392,7 +1392,18 @@ char *check_urlhealth(pr_task_t                       *task,
             gh_latest = strdup(cur);                     /* github latest == current */
         }
 
-        char *pkg = pr_extract_repo_name(row->gitSource);
+        /* PyPI package name = spec minus "python-" prefix and ".spec" suffix.
+         * Photon's naming convention matches the PyPI project name (PyPI lookup
+         * is case-insensitive); the github repo leaf can differ, e.g.
+         * python-filelock -> repo "py-filelock" but PyPI "filelock". */
+        char *pkg = NULL;
+        {
+            const char *s = task->Spec + 7;            /* gate guarantees "python-" */
+            size_t sl = strlen(s);
+            if (sl > 5 && strcmp(s + sl - 5, ".spec") == 0) sl -= 5;
+            pkg = (char *)malloc(sl + 1);
+            if (pkg) { memcpy(pkg, s, sl); pkg[sl] = '\0'; }
+        }
         char *surl = NULL, *sname = NULL;
         char *pp = pkg ? pr_pypi_latest_version(pkg, &surl, &sname) : NULL;
 
@@ -1414,11 +1425,34 @@ char *check_urlhealth(pr_task_t                       *task,
                      * too, so col 10 stays byte-identical. */
                     free(state.UpdateDownloadName); state.UpdateDownloadName = sname; sname = NULL;
                 }
+            } else if (gh_latest != NULL
+                       && pr_version_compare(pp, gh_latest) == 0
+                       && pp_gt_cur
+                       && (state.UpdateURL == NULL || state.UpdateURL[0] == '\0')) {
+                /* github detected this SAME update version but could not build a
+                 * working download URL (cat 7 "packaging format changed" — the
+                 * git path cleared UpdateURL + set the warning above). PyPI has
+                 * a valid sdist for the same version: complete the record from
+                 * PyPI and clear the now-obsolete packaging-format warning.
+                 * UpdateAvailable (== pp == github's version) is unchanged. */
+                if (surl && surl[0]) {
+                    free(state.UpdateURL); state.UpdateURL = surl; surl = NULL;
+                    int h = urlhealth(state.UpdateURL);
+                    char b[16]; snprintf(b, sizeof b, "%d", h);
+                    free(state.HealthUpdateURL); state.HealthUpdateURL = strdup(b);
+                }
+                if (sname && sname[0]) {
+                    free(state.UpdateDownloadName); state.UpdateDownloadName = sname; sname = NULL;
+                }
+                if (state.Warning && strstr(state.Warning, "packaging format") != NULL) {
+                    free(state.Warning); state.Warning = dup_or_empty("");
+                }
             } else if (gh_latest == NULL && pr_version_compare(pp, cur) == 0) {
                 /* github found nothing and PyPI == current -> (same version). */
                 free(state.UpdateAvailable); state.UpdateAvailable = dup_or_empty("(same version)");
             }
-            /* else: github's version >= PyPI -> keep the git-path result. */
+            /* else: github's version >= PyPI (and URL ok, or PyPI not newer)
+             * -> keep the git-path result. */
         }
         free(gh_latest); free(pp); free(surl); free(sname); free(pkg);
     }


### PR DESCRIPTION
Follow-on to M78 (you said yes), both mirrored in C and PS:

**1. PyPI URL repair.** When github detected an update but couldn't build a working download URL (cat 7 "packaging format changed") and PyPI lists the *same* version, complete the record from PyPI's sdist (UpdateURL + HealthUpdateURL + UpdateDownloadName) and clear the obsolete warning → cat 7 becomes a clean downloadable update. C clears the already-set warning; PS fills the URL so its later URL-build stage (gated on empty) skips and never sets the warning — different mechanism, **identical final .prn**.

**2. Spec-name package derivation.** PyPI name now comes from the spec (`python-<name>.spec` → `<name>`) instead of the github repo leaf — photon naming matches PyPI (case-insensitive), whereas the repo can differ (`python-filelock` → repo `py-filelock` but PyPI `filelock`, which 404'd before).

**Validation:** filelock 3.8.0→3.29.0 and more-itertools 8.14.0→11.1.0 now clean updates (URL filled, huurl 200, warning cleared); pyjsparser still `(same version)`. PyPI-unreachable → keeps github's result (graceful). ctest 13/13; PS parses.

FRD: FRD-006 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)