### PR TITLE
phase-M task M80: consult PyPI for every python-* spec (clears python cat-6 cluster)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -4569,7 +4569,7 @@ function CheckURLHealth {
     # "Cannot detect correlating tags" warning, which is gated on
     # $UpdateAvailable -eq "", so a hit suppresses it. Mirrors the C M78 block.
     # -------------------------------------------------------------------------------------------------------------------
-    if (($GitSource -ilike "*github.com*") -and ([string]::IsNullOrEmpty($ArchivationDate)) -and ($currentTask.Spec -ilike "python-*")) {
+    if (($currentTask.Spec -ilike "python-*") -and ([string]::IsNullOrEmpty($ArchivationDate))) {
         # PyPI package name = spec minus "python-" prefix and ".spec" suffix.
         # Photon's naming matches the PyPI project name (PyPI lookup is
         # case-insensitive); the github repo leaf can differ (e.g.

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1374,11 +1374,19 @@ char *check_urlhealth(pr_task_t                       *task,
      * -> github kept; PyPI newer than a stale github tag -> PyPI. The
      * pyjsparser-class "Cannot detect correlating tags" warning is gated on
      * UpdateAvailable being empty, so populating it here suppresses it at the
-     * downstream pr_spec_warning() step. PS mirrors this block verbatim. */
+     * downstream pr_spec_warning() step. PS mirrors this block verbatim.
+     *
+     * M80: consult PyPI for EVERY python-* spec that is not deprecated, not
+     * just github-sourced ones. A python package is on PyPI regardless of what
+     * its Source0/Source0Lookup points at (pythonhosted-direct, a sourceforge
+     * mirror, github, …), and the generic scraper can't enumerate most of
+     * those, leaving them in cat 6. The dual-source max keeps the higher of the
+     * already-detected version and PyPI, so correctly-detecting specs are
+     * unaffected; PyPI-only/scrape-failed ones get filled. (The ~552 pinned
+     * python subreleases short-circuit earlier and never reach here.) */
     if (allow_network
-        && row && row->gitSource && strstr(row->gitSource, "github.com") != NULL
-        && (row->ArchivationDate == NULL || row->ArchivationDate[0] == '\0')
-        && task->Spec && strncmp(task->Spec, "python-", 7) == 0) {
+        && task->Spec && strncmp(task->Spec, "python-", 7) == 0
+        && (row == NULL || row->ArchivationDate == NULL || row->ArchivationDate[0] == '\0')) {
 
         const char *cur = state.version ? state.version : "";
         /* github's latest, reconstructed from the git-path result. */


### PR DESCRIPTION
Broadens M78/M79: the PyPI dual-source path was gated on a github gitSource, but many python cat-6 specs aren't github-sourced (pythonhosted-direct, or a sourceforge-mirror override like python-docutils → netix.dl). A python package is on PyPI regardless of its Source0 override, so the gate now fires for **every python-* spec that isn't deprecated**. The dual-source max keeps the higher of the existing detection and PyPI → correctly-detecting specs unchanged; scrape-failed/PyPI-only ones filled. Pinned subreleases short-circuit earlier; rubygem-* excluded.

Live-tested: python-docutils 0.19→0.22.4 (was cat 6), more-itertools/pyjsparser unchanged. Identical in C+PS. ctest 13/13.

Caveat: PyPI name derived from spec name (photon convention matches PyPI); max-only-if-newer limits collision risk.

FRD: FRD-006 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)