### PR TITLE
phase-M task M84: parity fix — C adopts PyPI sdist URL for python updates (match PS)

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1476,14 +1476,17 @@ char *check_urlhealth(pr_task_t                       *task,
                 }
             } else if (gh_latest != NULL
                        && pr_version_compare(pp, gh_latest) == 0
-                       && pp_gt_cur
-                       && (state.UpdateURL == NULL || state.UpdateURL[0] == '\0')) {
-                /* github detected this SAME update version but could not build a
-                 * working download URL (cat 7 "packaging format changed" — the
-                 * git path cleared UpdateURL + set the warning above). PyPI has
-                 * a valid sdist for the same version: complete the record from
-                 * PyPI and clear the now-obsolete packaging-format warning.
-                 * UpdateAvailable (== pp == github's version) is unchanged. */
+                       && pp_gt_cur) {
+                /* PyPI lists this SAME update version. Adopt PyPI's sdist URL +
+                 * filename (canonical, hash-stable) regardless of whether the
+                 * git path already built a github URL. This is REQUIRED for
+                 * PS parity: PS's dual-source block runs before its URL-build,
+                 * so $UpdateURL is empty there and its repair branch always
+                 * fires -> PS emits the PyPI sdist for python updates. C builds
+                 * the github URL first, so gating on "UpdateURL empty" made C
+                 * keep the github URL -> ~104 col6/col10 strict diffs/branch.
+                 * Dropping that gate aligns C with PS (and clears any obsolete
+                 * packaging-format warning). */
                 if (surl && surl[0]) {
                     free(state.UpdateURL); state.UpdateURL = surl; surl = NULL;
                     int h = urlhealth(state.UpdateURL);


### PR DESCRIPTION
The **ensure-parity** side-by-side cycle caught a regression from M79/M80: ~104 python-* specs/branch differed in col 6 (UpdateURL) + col 10 (UpdateDownloadName) — version matched, but **PS emitted the PyPI sdist URL while C kept the github URL**.

**Root cause (stage ordering):** the M79 dual-source repair is gated on `UpdateURL empty`. PS runs dual-source *before* its URL build → always empty → PS repair always fires → PyPI URL. C builds the github URL *before* dual-source → not empty → C kept github. Same condition, opposite result.

**Fix:** drop the `UpdateURL empty` gate in C's repair so C adopts the PyPI sdist URL+filename whenever PyPI lists the same update version — matching PS. PyPI sdist URLs are content-hash-stable → byte-identical col6/col10 across PS/C. Verified: python-CacheControl/attrs/bcrypt/more-itertools now byte-match the PS snapshot. ctest 13/13.

Residual non-python strict diffs (at-spi2-core/fuse/haproxy/gtest/...) are the pre-existing C-single-attempt vs PS-multi-attempt URL-build gap (deferred M18), not from this session.

Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)