### PR TITLE
phase-M task M85: strip leading 'v' on version prefix only

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -4966,7 +4966,11 @@ function CheckURLHealth {
 
         # exceptions
         # common exception
-        if (($UpdateDownloadName[0] -ieq 'v') -and ($UpdateDownloadName[1] -ne '-')) {$UpdateDownloadName = $UpdateDownloadName.substring(1)}
+        # M85: strip a leading 'v' ONLY when it is a version prefix (followed
+        # by a digit, e.g. "v1.2.3.tar.gz"). A 'v' followed by a letter is a
+        # real word (versioningit, virtualenv, valgrind) — the PyPI sdist path
+        # surfaces such filenames, which the old `-ne '-'` guard mangled.
+        if (($UpdateDownloadName[0] -ieq 'v') -and ($UpdateDownloadName[1] -match '[0-9]')) {$UpdateDownloadName = $UpdateDownloadName.substring(1)}
         # individual exceptions
         if ($currentTask.spec -ilike 'inih.spec') { $UpdateDownloadName = $UpdateDownloadName -ireplace "^r","libinih-"}
         if ($currentTask.spec -ilike 'open-vm-tools.spec') {$UpdateDownloadName = [System.String]::Concat("open-vm-tools-",$UpdateDownloadName)}

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -886,8 +886,14 @@ static char *download_name_post(char *raw, const char *task_name,
     if (raw == NULL) return NULL;
 
 
-    /* L 4770: optional 'v' strip. */
-    if ((raw[0] == 'v' || raw[0] == 'V') && raw[1] && raw[1] != '-') {
+    /* L 4770: optional 'v' strip — strip a leading 'v' ONLY when it is a
+     * version prefix (followed by a digit, e.g. "v1.2.3.tar.gz"). A 'v'
+     * followed by a letter is part of a real word (versioningit,
+     * virtualenv, valgrind) and must be preserved; a 'v' followed by '-'
+     * is left for the L 4792 "v-" rule below. (M85: was `raw[1] != '-'`,
+     * which mangled word-initial 'v' names — the PyPI sdist path now
+     * surfaces such names so PS L 4969 must match this guard.) */
+    if ((raw[0] == 'v' || raw[0] == 'V') && raw[1] >= '0' && raw[1] <= '9') {
         memmove(raw, raw + 1, strlen(raw));
     }
 


### PR DESCRIPTION
## Summary
The "ensure parity" confirmation cycle (PS 26392572981 vs C 26395089967) showed M84 collapsed the python URL regression from ~104 strict diffs/branch to **4**. This PR closes 2 of those 4.

`versioningit` / `virtualenv` diverged on col10 (UpdateDownloadName):
- PS emitted `ersioningit-3.3.0.tar.gz` / `irtualenv-21.3.3.tar.gz`
- C emitted the correct `versioningit-3.3.0.tar.gz` / `virtualenv-21.3.3.tar.gz`

Root cause: the common leading-`v` strip guarded on *"second char != `-`"*, which strips the `v` off any word-initial `v` name. It was parity-neutral while both sides stripped identically, but the **M78 PyPI dual-source** path surfaces the sdist filename only through PS's L4969 post-processing (C's PyPI path sets it directly) → asymmetric strip.

## Fix
Tighten **both** guards (PS L4969 + C `download_name_post`) to strip a leading `v` only when followed by a **digit** (a true version prefix, `v1.2.3.tar.gz`). The `v-…` amdvlk case is still handled by the existing L4792 `v-` rule. Symmetric change → parity preserved on the github-tag paths, restored on the PyPI path, with correct vendor info for `versioningit`/`virtualenv`/`valgrind`-style names.

## Validation
- `ctest` 13/13 green.
- Parity-gate run on PR.

## Remaining python residuals (separate follow-up)
- `python-pyvmomi` — PS leaves url/udn empty; C builds a github URL with the stale name.
- `python-vcs-versioning` — col5 version-detection disagreement.

The ~100 non-python strict diffs are the pre-existing deferred-M18 C-single-attempt vs PS-multi-attempt URL-build gap (signature: C emits "Manufacturer may changed version packaging" while PS builds the URL), confirmed unchanged by M70–M84.

FRD: FRD-011 · ADR: ADR-0001 · PS-source: L4969 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)