### PR TITLE
phase-M task M86: clear stale URL when PyPI version has no sdist

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1474,11 +1474,27 @@ char *check_urlhealth(pr_task_t                       *task,
                     int h = urlhealth(state.UpdateURL);
                     char b[16]; snprintf(b, sizeof b, "%d", h);
                     free(state.HealthUpdateURL); state.HealthUpdateURL = strdup(b);
+                } else {
+                    /* M86: PyPI is newest but ships NO sdist (wheels-only, e.g.
+                     * pyvmomi) and github has no tag for this version (pp >
+                     * gh_latest). PS reports the version but leaves UpdateURL
+                     * empty — it builds URLs from github tags AFTER the dual-
+                     * source version bump and finds none. The git-tag path here
+                     * already built a github URL for the OLDER version; clear it
+                     * so col6/col7 match PS's empty cells. */
+                    free(state.UpdateURL); state.UpdateURL = dup_or_empty("");
+                    free(state.HealthUpdateURL); state.HealthUpdateURL = dup_or_empty("");
                 }
                 if (sname && sname[0]) {
                     /* Raw PyPI sdist filename; PS uses $sdist.filename verbatim
                      * too, so col 10 stays byte-identical. */
                     free(state.UpdateDownloadName); state.UpdateDownloadName = sname; sname = NULL;
+                } else {
+                    /* No sdist -> PS leaves UpdateDownloadName empty too. */
+                    free(state.UpdateDownloadName); state.UpdateDownloadName = dup_or_empty("");
+                }
+                if (state.Warning && strstr(state.Warning, "packaging format") != NULL) {
+                    free(state.Warning); state.Warning = dup_or_empty("");
                 }
             } else if (gh_latest != NULL
                        && pr_version_compare(pp, gh_latest) == 0


### PR DESCRIPTION
## Summary
Third of the 4 residual python strict diffs from the parity-confirmation cycle.

`python-pyvmomi`: PyPI version `9.1.0.0` exists but **only as wheels — no sdist**, and github has no tag for it. PS reports the version with empty url/udn; C kept the stale github URL (`github.com/vmware/pyvmomi…`) + name `python-pyvmomi-9.0.0.0.tar.gz` that the git-tag path built for the older version → strict col6/col10 diff.

## Fix
In C's "PyPI is newest" branch, when there is no sdist, clear `UpdateURL`/`HealthUpdateURL`/`UpdateDownloadName` (and any obsolete packaging warning) to match PS's empty cells. Safe within this branch because `pp > gh_latest` means github has no tag for the version → PS's later URL-build also yields empty. C-only (PS already emits empty via build-after-bump ordering).

## Validation
- `ctest` 13/13 green. Parity-gate on PR.

## Remaining
- `python-vcs-versioning` — borderline github current-vs-latest call (PyPI `vcs-versioning`=1.1.1 is the wrong package; real upstream at 9.x); low-value, likely transient → deferred.
- ~100 non-python = pre-existing deferred-M18 URL-build-retry floor.

FRD: FRD-011 · ADR: ADR-0001 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)