### PR TITLE
phase-M task M88: fix M87 use-after-null emptying python udn

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1474,6 +1474,14 @@ char *check_urlhealth(pr_task_t                       *task,
                     int h = urlhealth(state.UpdateURL);
                     char b[16]; snprintf(b, sizeof b, "%d", h);
                     free(state.HealthUpdateURL); state.HealthUpdateURL = strdup(b);
+                    if (sname && sname[0]) {
+                        /* Raw PyPI sdist filename; PS uses $sdist.filename
+                         * verbatim too, so col 10 stays byte-identical. (M88:
+                         * set here, inside the surl block — `surl` is nulled
+                         * above, so a later `if (surl ...)` guard would never
+                         * fire and the udn would wrongly stay empty.) */
+                        free(state.UpdateDownloadName); state.UpdateDownloadName = sname; sname = NULL;
+                    }
                     if (state.Warning && strstr(state.Warning, "packaging format") != NULL) {
                         free(state.Warning); state.Warning = dup_or_empty("");
                     }
@@ -1492,11 +1500,6 @@ char *check_urlhealth(pr_task_t                       *task,
                     free(state.UpdateDownloadName); state.UpdateDownloadName = dup_or_empty("");
                     free(state.Warning);
                     state.Warning = strdup("Warning: Manufacturer may changed version packaging format.");
-                }
-                if (surl && surl[0] && sname && sname[0]) {
-                    /* Raw PyPI sdist filename; PS uses $sdist.filename verbatim
-                     * too, so col 10 stays byte-identical. */
-                    free(state.UpdateDownloadName); state.UpdateDownloadName = sname; sname = NULL;
                 }
             } else if (gh_latest != NULL
                        && pr_version_compare(pp, gh_latest) == 0


### PR DESCRIPTION
## Summary
**Regression fix.** M87 (#212) introduced a use-after-null: the PyPI sdist-filename assignment was gated on `if (surl && surl[0] && sname && sname[0])`, but `surl` is set to `NULL` a few lines earlier when its ownership transfers to `state.UpdateURL`. The guard therefore never fired, leaving `UpdateDownloadName` (col10) **empty** for every python spec in the "PyPI strictly ahead of github" branch that ships an sdist.

The M85/M86/M87 confirmation cycle (5.0) caught it: python strict-diff rows **2 → 14**, all col10 — e.g.:
```
python-build       PS[build-1.5.0.tar.gz]      C[]
python-docutils    PS[docutils-0.22.4.tar.gz]  C[]
python-cqlsh       PS[cqlsh-6.2.2.tar.gz]      C[python-cqlsh-6.2.1.tar.gz]
```
(URL/version matched — only the download name was dropped.)

## Fix
Set the udn **inside** the `if (surl && surl[0])` block before `surl` is nulled, mirroring the already-parity-validated `pp==gh` branch. `sname` is a separate pointer (not consumed by the url assignment), so the assignment is sound.

## Validation
- `ctest` 13/13 (note: ctest didn't catch M87 — covered only by the full parity cycle).
- 5.0 confirmation cycle to follow; expect python strict back to 1 (vcs-versioning only).

FRD: FRD-011 · ADR: ADR-0001 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)