### PR TITLE
phase-M task M94: gtest col5 keeps the leading 'v' (PS L4853)

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1476,6 +1476,17 @@ char *check_urlhealth(pr_task_t                       *task,
                                             task, state.Source0 ? state.Source0 : "",
                                             state.version ? state.version : "",
                                             latest, &built);
+                                /* M94 / PS L4853: gtest reports col5 with the
+                                 * leading 'v' (PS mutates $UpdateAvailable in
+                                 * place). col6/col10 already carry the 'v' via
+                                 * the cascade; mirror it into col5. gtest-only. */
+                                if (spec_eq(task->Spec, "gtest.spec")) {
+                                    char *t = NULL;
+                                    if (asprintf(&t, "v%s", latest) >= 0) {
+                                        free(state.UpdateAvailable);
+                                        state.UpdateAvailable = t;
+                                    }
+                                }
                                 free(state.UpdateURL);
                                 free(state.HealthUpdateURL);
                                 if (h == 200) {
@@ -2195,6 +2206,18 @@ char *check_urlhealth(pr_task_t                       *task,
                                 state.version ? state.version : "",
                                 latest, &built);
                     if (built == NULL) built = dup_or_empty("");
+                    /* M94 / PS L4853: gtest reports col5 with the leading 'v'
+                     * (PS mutates $UpdateAvailable in place). col6/col10 carry
+                     * the 'v' via the cascade; mirror it into col5. gtest-only.
+                     * gtest reaches detection via the HTML tags-page scrape, so
+                     * the mutation belongs here (the git-tag site mirrors it). */
+                    if (spec_eq(task->Spec, "gtest.spec")) {
+                        char *t = NULL;
+                        if (asprintf(&t, "v%s", latest) >= 0) {
+                            free(state.UpdateAvailable);
+                            state.UpdateAvailable = t;
+                        }
+                    }
                     /* M46: apparmor launchpad series-dir fixup (idempotent once
                      * the versionshort cascade has set the series dir). */
                     if (h == 200 && built[0] && spec_eq(task->Spec, "apparmor.spec"))


### PR DESCRIPTION
## Summary
gtest was the last clean reasoning-debuggable residual on 5.0: PS col5 = `v1.17.0`, C col5 = `1.17.0` (col6/col10 already match via M91).

PS's URL-build block mutates `$UpdateAvailable` **in place** for gtest (L4850-4853: `$UpdateAvailable = "v" + $UpdateAvailable`), so the emitted col5 carries the `v`. M91's C cascade prepends `v` only on a local copy for the URL, leaving `state.UpdateAvailable` v-stripped.

Fix: for gtest, set `state.UpdateAvailable = "v"+latest` after the cascade — `spec_eq(gtest)`-gated (zero blast radius), at both the scrape site (gtest's HTML tags-page path) and the git-tag site.

## Validation
`ctest` 13/13. gtest-gated → cannot regress any other spec; col5 change is deterministic. (gtest detection uses an HTML scrape that the sandbox proxy blocks locally, so confirmed via the gate + next authoritative cycle rather than a local run.)

FRD: FRD-011 · ADR: ADR-0001 · PS-source: L4850-4853 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)