### PR TITLE
phase-M task M98: libevent Source0Lookup replaceStrings (cat6 -> same version)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -803,7 +803,7 @@ libedit.spec,https://www.thrysoee.dk/editline/libedit-20251016-3.1.tar.gz
 libepoxy.spec,https://github.com/anholt/libepoxy/archive/refs/tags/%{version}.tar.gz,https://github.com/anholt/libepoxy.git
 libestr.spec,https://github.com/rsyslog/libestr/archive/refs/tags/v%{version}.tar.gz,https://github.com/rsyslog/libestr.git
 libev.spec,https://dist.schmorp.de/libev/Attic/libev-%{version}.tar.gz
-libevent.spec,https://github.com/libevent/libevent/releases/download/release-%{version}-stable/libevent-%{version}-stable.tar.gz,https://github.com/libevent/libevent.git,,^release-[\d.]+-stable$
+libevent.spec,https://github.com/libevent/libevent/releases/download/release-%{version}-stable/libevent-%{version}-stable.tar.gz,https://github.com/libevent/libevent.git,,^release-[\d.]+-stable$,"release-,-stable"
 libfastjson.spec,https://github.com/rsyslog/libfastjson/archive/refs/tags/v%{version}.0.tar.gz,https://github.com/rsyslog/libfastjson.git
 libffi.spec,https://github.com/libffi/libffi/archive/refs/tags/v%{version}.tar.gz,https://github.com/libffi/libffi.git
 libfido2.spec,https://github.com/Yubico/libfido2/archive/refs/tags/%{version}.tar.gz,https://github.com/Yubico/libfido2.git


### PR DESCRIPTION
## Summary
From run 26439367700's cat6 list. **libevent** was cat6 (UrlHealth=200, no UpdateAvailable) on every branch — persistent (also cat6 in the clean run 26433294030, so not transient).

**Root cause (verified):** the lookup row has `customRegex ^release-[\d.]+-stable$` (correctly keeps `release-2.1.12-stable`, excludes `release-2.2.1-alpha`/`-beta`) but **no replaceStrings** — so the kept candidate retains `release-`/`-stable`, has alpha chars, and the no-alpha filter drops it → empty col5.

**Fix:** add `replaceStrings "release-,-stable"` to libevent's row → version `2.1.12` is isolated → equals the current spec version → `(same version)`.

## Lowest-impact / parity
- Keyed to `libevent.spec` (case-sensitive `.IndexOf`) → **blast radius is exactly one spec**; cannot touch any working spec.
- Dual-goal: PS and C read the **same** lookup row + identical replaceStrings logic → both produce `(same version)` → parity preserved.
- Verified locally: libevent git-tag detection → uh=200, `(same version)` (was empty). ctest 13/13.

FRD: FRD-003 · ADR: ADR-0005 · PS-source: L806 · Parity: strict

🤖 Generated with [Claude Code](https://claude.com/claude-code)