### PR TITLE
vCenter scraper: detect grouped/per-patch releases + add 7.0 page

### DIFF
--- a/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/config.py
+++ b/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/config.py
@@ -11,6 +11,7 @@ PHOTON_SECURITY_UPDATES_PAGES = [
 ]
 
 VCENTER_PATCH_URLS = [
+    "https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/7-0/release-notes/vcenter-server-appliance-photonos-security-patches.html",
     "https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/8-0/release-notes/vcenter-server-appliance-photonos-security-patches.html",
     "https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere/9-0/release-notes/vcenter-server-appliance-photonos-security-patches.html",
 ]

--- a/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/scrapers/vcenter.py
+++ b/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/scrapers/vcenter.py
@@ -13,6 +13,37 @@ logger = logging.getLogger(__name__)
 CVE_PATTERN = re.compile(r"CVE-\d{4}-\d{4,}")
 DATE_PATTERN = re.compile(r"\d{1,2}\s+\w+\s+\d{4}")
 
+# A patch/release identifier such as "vCenter Server 8.0 Update 3j" or
+# "vCenter Server 7.0 Update 3v". Broadcom techdocs sometimes group several
+# patch tables under a single section heading (e.g. "vSphere 7.0 Update 3"),
+# so the authoritative per-row identity lives in the "Patch Name" column.
+RELEASE_NAME_PATTERN = re.compile(
+    r"(?:vCenter Server|vCenter|vSphere)\s+\d+\.\d+[A-Za-z0-9 .]*",
+    re.IGNORECASE,
+)
+
+
+def _release_name_from_patch(patch_name: str) -> str | None:
+    """Derive a normalized release name from a 'Patch Name' cell.
+
+    Returns e.g. "vCenter Server 7.0 Update 3v" for a cell like
+    "vCenter Server 7.0 Update 3v (Security fixes for Photon OS)", or None
+    when the cell does not name a release.
+    """
+    if not patch_name:
+        return None
+    # Drop trailing parenthetical descriptions like "(Security fixes...)".
+    candidate = patch_name.split("(")[0]
+    match = RELEASE_NAME_PATTERN.search(candidate)
+    if not match:
+        return None
+    name = match.group(0)
+    # Repair spacing typos seen on the techdocs pages, e.g. "Update 3 l" /
+    # "Update 3 q" -> "Update 3l" / "Update 3q".
+    name = re.sub(r"(Update\s+\d+)\s+([A-Za-z])\b", r"\1\2", name)
+    name = re.sub(r"\s+", " ", name).strip()
+    return name or None
+
 
 def _fetch_page(url: str) -> BeautifulSoup:
     resp = requests.get(url, headers=HTTP_HEADERS, timeout=HTTP_TIMEOUT)
@@ -105,7 +136,8 @@ def parse_vcenter_patches(url: str) -> list[dict]:
     for elem in all_elements:
         if elem.name in ("h2", "h3"):
             text = elem.get_text(strip=True)
-            if "vCenter" in text or "vcenter" in text.lower():
+            lowered = text.lower()
+            if "vcenter" in lowered or "vsphere" in lowered:
                 current_release_name = text
             continue
 
@@ -158,6 +190,10 @@ def parse_vcenter_patches(url: str) -> list[dict]:
 
             release_date = None
             build_number = None
+            # Each patch occupies its own <table>, so the release name derived
+            # from the Patch Name column persists across that table's rows
+            # (covers rows whose Patch Name cell is blank or not row-spanned).
+            table_release_name = None
 
             for row in grid[1:]:
                 if len(row) <= cve_col:
@@ -182,6 +218,17 @@ def parse_vcenter_patches(url: str) -> list[dict]:
                 if not cves:
                     continue
 
+                # The "Patch Name" column is the authoritative per-row release
+                # identity. It distinguishes patches that share a section
+                # heading (e.g. multiple 7.0 patch tables under "vSphere 7.0
+                # Update 3"). Fall back to the heading when absent (e.g. the
+                # 3-column 9.0 tables, which carry no Patch Name column).
+                if patch_col is not None and len(row) > patch_col:
+                    derived = _release_name_from_patch(row[patch_col].strip())
+                    if derived:
+                        table_release_name = derived
+                release_name = table_release_name or current_release_name
+
                 if not pkg:
                     pkg = "unknown"
 
@@ -192,7 +239,7 @@ def parse_vcenter_patches(url: str) -> list[dict]:
                     for cve in cves:
                         records.append({
                             "source_url": url,
-                            "vcenter_release": current_release_name,
+                            "vcenter_release": release_name,
                             "release_date": release_date,
                             "build_number": build_number,
                             "affected_package": single_pkg,

--- a/vCenter-CVE-drift-analyzer/tests/test_scrapers.py
+++ b/vCenter-CVE-drift-analyzer/tests/test_scrapers.py
@@ -5,7 +5,8 @@ import pytest
 from unittest.mock import patch, MagicMock
 from vcenter_cve_drift.scrapers.vcenter import (
     _normalize_date, _expand_rowspan, _normalize_release_name,
-    _match_release_date, parse_vcenter_patches, CVE_PATTERN,
+    _match_release_date, _release_name_from_patch, parse_vcenter_patches,
+    CVE_PATTERN,
 )
 from vcenter_cve_drift.scrapers.photon import (
     CVE_PATTERN as PHOTON_CVE_PATTERN,
@@ -248,6 +249,59 @@ def test_match_release_date():
     assert _match_release_date("vCenter Server 8.0 Update 3i", date_map) == "2026-02-24"
     assert _match_release_date("vCenter Server 8.0 Update 3i(Security fixes)", date_map) == "2026-02-24"
     assert _match_release_date("nonexistent", date_map) is None
+
+
+def test_release_name_from_patch():
+    assert _release_name_from_patch(
+        "vCenter Server 7.0 Update 3v (Security fixes for Photon OS)"
+    ) == "vCenter Server 7.0 Update 3v"
+    # Spacing typos seen on techdocs ("Update 3 l", "Update 3 q") are repaired.
+    assert _release_name_from_patch(
+        "vCenter Server 7.0 Update 3 l(Security fixes)"
+    ) == "vCenter Server 7.0 Update 3l"
+    assert _release_name_from_patch(
+        "vCenter Server 8.0 Update 3j (Security fixes for Photon OS)"
+    ) == "vCenter Server 8.0 Update 3j"
+    # Cells that do not name a release yield None (fall back to heading).
+    assert _release_name_from_patch("") is None
+    assert _release_name_from_patch("Security fixes for Photon OS") is None
+
+
+# A 7.0-style page: multiple patch tables grouped under one non-"vCenter"
+# section heading. The release identity must come from the Patch Name column,
+# and a row with a blank Patch Name cell inherits its table's release.
+VCENTER_GROUPED_HTML = """
+<html><body>
+<h2>vSphere 7.0 Update 3</h2>
+<table>
+<tr><th>Release Date</th><th>Build Number</th><th>Patch Name</th><th>Affected Package</th><th>New Package Version</th><th>CVEs Addressed</th></tr>
+<tr><td rowspan="2">20 May 2025</td><td rowspan="2">24730281</td><td>vCenter Server 7.0 Update 3v (Security fixes for Photon OS)</td><td>vim</td><td>9.2.0136</td><td>CVE-2025-1111</td></tr>
+<tr><td></td><td>curl</td><td>8.7.1</td><td>CVE-2025-2222</td></tr>
+</table>
+<table>
+<tr><th>Release Date</th><th>Build Number</th><th>Patch Name</th><th>Affect Package</th><th>New Package Version</th><th>CVEs Addressed</th></tr>
+<tr><td>30 March 2023</td><td>21477706</td><td>vCenter Server 7.0 Update 3 l(Security fixes)</td><td>openssl</td><td>3.0.16</td><td>CVE-2023-3333</td></tr>
+</table>
+</body></html>
+"""
+
+
+@patch("vcenter_cve_drift.scrapers.vcenter._fetch_page")
+def test_parse_vcenter_grouped_heading(mock_fetch):
+    mock_fetch.return_value = BeautifulSoup(VCENTER_GROUPED_HTML, "lxml")
+    records = parse_vcenter_patches("https://example.com/7.0")
+
+    releases = {r["vcenter_release"] for r in records}
+    # Derived from the Patch Name column, not the "vSphere 7.0 Update 3" heading.
+    assert releases == {
+        "vCenter Server 7.0 Update 3v",
+        "vCenter Server 7.0 Update 3l",
+    }
+    # The blank-Patch-Name curl row inherits its table's derived release.
+    curl = [r for r in records if r["affected_package"] == "curl"]
+    assert len(curl) == 1
+    assert curl[0]["vcenter_release"] == "vCenter Server 7.0 Update 3v"
+    assert curl[0]["release_date"] == "2025-05-20"
 
 
 VCENTER_MULTI_PKG_HTML = """


### PR DESCRIPTION
## Problem

The latest `vcenter-cve-drift.yml` run finished successfully but did **not** detect:
- **vCenter Server 8.0 Update 3j** (latest 8.0 patch on the techdocs page)
- **Any vSphere 7.0 updates** (3v, 3d, 3f, 3i, 3l, 3o, 3q, and Update 2c)

## Root cause

1. The **7.0 patch page was never configured** in `VCENTER_PATCH_URLS` — only 8.0 and 9.0 were scraped.
2. `parse_vcenter_patches` bound each table's release name to its **preceding h2/h3 heading**, and only headings containing `"vCenter"`. The 7.0 page groups several per-patch tables under a single heading `"vSphere 7.0 Update 3"` (which contains no `"vCenter"`), so every distinct 7.0 patch collapsed into one generic bucket.

## Fix

- Derive the release identity **per-row from the authoritative "Patch Name" column** (e.g. `vCenter Server 7.0 Update 3v`), repairing the techdocs spacing typos (`Update 3 l` → `Update 3l`) and persisting it across a table for blank / non-row-spanned cells.
- Fall back to the section heading for the **3-column 9.0 tables** that carry no Patch Name column (unchanged behavior there).
- Track `vSphere` section headings too.
- Add the **7.0 URL** to `VCENTER_PATCH_URLS`.

## Verification

Against the live techdocs pages:

| Page | Releases now detected |
|------|-----------------------|
| 7.0  | Update 2c, 3d, 3f, 3i, 3l, 3o, 3q, 3v |
| 8.0  | …, Update 3h, 3i, **3j** |
| 9.0  | 9.0.1, 9.0.2 (unchanged) |

`pytest tests/test_scrapers.py` → 22 passed, including new cases for `_release_name_from_patch` and grouped-heading parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)