### PR TITLE
vCenter scraper: parse 2-digit-year dates (fixes 7.0 Update 3f)

### DIFF
--- a/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/scrapers/vcenter.py
+++ b/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/scrapers/vcenter.py
@@ -55,10 +55,13 @@ def _normalize_date(date_str: str) -> str | None:
     if not date_str:
         return None
     date_str = date_str.strip()
-    # Try parsing common formats
+    # Try parsing common formats. The 2-digit-year variants (%y) cover
+    # techdocs typos such as "12 July 22" (vCenter Server 7.0 Update 3f);
+    # 4-digit-year formats are tried first so they always win when present.
     from datetime import datetime
     for fmt in ("%d %B %Y", "%B %d, %Y", "%d %b %Y", "%b %d, %Y",
-                "%Y-%m-%d", "%m/%d/%Y", "%d/%m/%Y"):
+                "%Y-%m-%d", "%m/%d/%Y", "%d/%m/%Y",
+                "%d %B %y", "%B %d, %y", "%d %b %y", "%b %d, %y"):
         try:
             dt = datetime.strptime(date_str, fmt)
             return dt.strftime("%Y-%m-%d")

--- a/vCenter-CVE-drift-analyzer/tests/test_scrapers.py
+++ b/vCenter-CVE-drift-analyzer/tests/test_scrapers.py
@@ -30,6 +30,13 @@ def test_normalize_date_empty():
     assert _normalize_date(None) is None
 
 
+def test_normalize_date_two_digit_year():
+    # techdocs typo on the 7.0 page (vCenter Server 7.0 Update 3f).
+    assert _normalize_date("12 July 22") == "2022-07-12"
+    # 4-digit years must still win unchanged.
+    assert _normalize_date("12 July 2022") == "2022-07-12"
+
+
 def test_cve_pattern():
     text = "CVE-2023-38545 CVE-2024-28182 some text CVE-2021-43527"
     matches = CVE_PATTERN.findall(text)


### PR DESCRIPTION
Completes the vSphere 7.0 coverage. The 7.0 techdocs page writes the **Update 3f** release date as `12 July 22` (2-digit year). `_normalize_date` had no `%y` format, so it returned the raw string; the non-ISO value produced NULL drift and dropped 3f from the rendered report.

Adds `%y` format variants (tried *after* the 4-digit-year formats, so existing 4-digit dates are unaffected). Verified live: 3f now resolves to `2022-07-12`. 23 scraper tests pass (new `test_normalize_date_two_digit_year`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)