### PR TITLE
vcenter-cve-drift: render summary as Markdown for mobile

### DIFF
--- a/.github/workflows/vcenter-cve-drift.yml
+++ b/.github/workflows/vcenter-cve-drift.yml
@@ -138,14 +138,59 @@ jobs:
       - name: Generate job summary
         if: always()
         run: |
-          echo "## vCenter CVE Drift Analysis" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Run**: ${{ steps.analysis.outputs.datetime }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [ -f "${{ steps.analysis.outputs.report_file }}" ]; then
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            cat "${{ steps.analysis.outputs.report_file }}" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          # The previous summary dumped the whole 38 KB text report inside one
+          # triple-backtick code fence. Desktop Chrome rendered it, but the
+          # Summary tab silently fails on GitHub mobile (Chrome / Safari on
+          # iPhone) because the ASCII timeline lines (~190 chars wide) and the
+          # large total size both trip the mobile Markdown renderer.
+          # Render an inline Markdown table of the per-release drift summary so
+          # mobile gets usable content natively, and tuck the full text report
+          # inside a collapsible <details> block.
+          {
+            echo "## vCenter CVE Drift Analysis"
+            echo ""
+            echo "**Run:** ${{ steps.analysis.outputs.datetime }}"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "${{ steps.analysis.outputs.report_file }}" ] \
+             && [ -f "$WORK_DIR/drift.db" ]; then
+            cd "$TOOL_DIR"
+            WORK_DIR="$WORK_DIR" PYTHONPATH=src python3 - >> "$GITHUB_STEP_SUMMARY" <<'PY'
+          import os, statistics
+          from vcenter_cve_drift.database.models import init_database
+          from vcenter_cve_drift.database.views import get_drift_values_by_release
+
+          conn = init_database(os.environ["WORK_DIR"] + "/drift.db")
+          rows = sorted(
+              get_drift_values_by_release(conn).values(),
+              key=lambda r: r["vcenter_release_date"] or "",
+          )
+          conn.close()
+
+          def med(v):
+              return int(statistics.median(v)) if v else 0
+
+          print("### Per-release drift summary")
+          print("")
+          print("| Release | Date | CVEs | Med. Drift (Pub) | Med. Drift (Mod) |")
+          print("|---|---|---:|---:|---:|")
+          for r in rows:
+              print(
+                  f"| {r['vcenter_release']} | {r['vcenter_release_date']} "
+                  f"| {len(r['drift_values'])} | {med(r['drift_values'])} "
+                  f"| {med(r['modified_drift_values'])} |"
+              )
+          PY
+            {
+              echo ""
+              echo "<details><summary>Full text report</summary>"
+              echo ""
+              echo '```'
+              cat "${{ steps.analysis.outputs.report_file }}"
+              echo '```'
+              echo ""
+              echo "</details>"
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Commit report to repository


### PR DESCRIPTION
## Problem

The workflow's "Generate job summary" step dumped the entire ~38 KB text report inside a single triple-backtick code fence. Desktop Chrome rendered it, but the **Summary tab on GitHub mobile (Chrome/Safari on iPhone) silently failed to render** — the wide ASCII timeline lines (~190 chars) plus the total code-fence size trip the mobile Markdown renderer. To a mobile user the dynamically-created report looked "gone" even though `drift-report_*.txt` was still committed to the repo.

## Fix

Replace the single-code-fence dump with mobile-friendly Markdown:

- `## vCenter CVE Drift Analysis` heading + `**Run:**` line.
- An inline **Markdown table** of the per-release drift summary, rendered from the run's `drift.db` (release, date, CVE count, median pub/mod drift) — GitHub mobile renders this natively.
- The full text report (including the wide ASCII timeline) tucked inside a `<details><summary>Full text report</summary>` block so it doesn't block rendering of the rest.

Verified locally: YAML parses cleanly, the inline python produces a 19-row Markdown table from a real `drift.db` (7.0 Update 3f, 7.0 Update 3v, 8.0 Update 3j all present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)