### PR TITLE
chart: align CVE counts with drift tables; abbreviate "Update" on x-axis

### DIFF
--- a/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/database/views.py
+++ b/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/database/views.py
@@ -4,6 +4,12 @@ import sqlite3
 
 
 def get_drift_summary_by_release(conn: sqlite3.Connection) -> list[dict]:
+    # Aligns with get_drift_values_by_release: both exclude pre-fixed CVEs
+    # (those already at/above the upstream fix per the NVD CPE range) so the
+    # "CVEs" column in the ASCII chart's per-release detail table matches the
+    # count in the drift-summary tables instead of double-counting CVEs that
+    # the report's "Pre-fixed CVEs (excluded from drift rankings)" section
+    # already lists separately.
     cursor = conn.execute("""
         SELECT
             vcenter_release,
@@ -17,6 +23,7 @@ def get_drift_summary_by_release(conn: sqlite3.Connection) -> list[dict]:
             ROUND(AVG(base_score), 1) as avg_cvss_score
         FROM DriftAnalysis
         WHERE nvd_to_vcenter_drift_days IS NOT NULL
+            AND pre_fixed = 0
         GROUP BY vcenter_release, vcenter_release_date
         ORDER BY vcenter_release_date
     """)

--- a/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/output/ascii_chart.py
+++ b/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/output/ascii_chart.py
@@ -78,10 +78,18 @@ def render_drift_timeline(conn: sqlite3.Connection, height: int = 20) -> str:
         date_line += label.center(col_width)
     lines.append(date_line)
 
-    # Release name labels -- shortened, centered in each column
+    # Release name labels -- shortened, centered in each column.
+    # Abbreviate "Update " -> "Upd" (no trailing space) so the patch letter
+    # (e.g. "3j") survives the col_width truncation. The previous "Updat"
+    # truncation hid the very identifier that distinguishes patches.
     name_line = " " * (y_label_width + 2)
     for r in releases:
-        short = r["vcenter_release"].replace("vCenter Server ", "").replace("vCenter ", "")
+        short = (
+            r["vcenter_release"]
+            .replace("vCenter Server ", "")
+            .replace("vCenter ", "")
+            .replace("Update ", "Upd")
+        )
         short = short[:col_width - 1]
         name_line += short.center(col_width)
     lines.append(name_line)

--- a/vCenter-CVE-drift-analyzer/tests/test_ascii_chart.py
+++ b/vCenter-CVE-drift-analyzer/tests/test_ascii_chart.py
@@ -91,3 +91,71 @@ def test_render_detail_table_columns(chart_db):
     assert "Max Pub" in output
     assert "Max Mod" in output
     assert "Avg CVSS" in output
+
+
+def test_xaxis_labels_use_upd_abbreviation():
+    """The x-axis release labels under each column abbreviate "Update" to
+    "Upd " so the patch identifier (e.g. "3j") survives the col_width
+    truncation instead of getting cut after "Updat"."""
+    conn = init_database(":memory:")
+    # Many releases force a narrow per-column width, exercising the truncation.
+    for i, (name, date) in enumerate([
+        ("vCenter Server 8.0 Update 3j", "2026-05-27"),
+        ("vCenter Server 7.0 Update 3v", "2025-05-20"),
+        ("vCenter Server 8.0 Update 3i", "2026-02-24"),
+        ("vCenter Server 8.0 Update 3h", "2025-12-15"),
+        ("vCenter Server 8.0 Update 3g", "2025-07-29"),
+        ("vCenter Server 8.0 Update 3e", "2025-04-10"),
+        ("vCenter Server 7.0 Update 3q", "2024-05-21"),
+        ("vCenter Server 7.0 Update 3o", "2023-09-28"),
+    ]):
+        cve = f"CVE-2024-{i:04d}"
+        upsert_nvd_cve(conn, {
+            "cve_id": cve,
+            "nvd_published": "2024-01-01T00:00:00",
+            "nvd_last_modified": "2024-06-01T00:00:00",
+            "base_score": 7.0,
+        })
+        upsert_vcenter_release(conn, {
+            "source_url": "url",
+            "vcenter_release": name,
+            "release_date": date,
+            "build_number": "999",
+            "affected_package": "openssl",
+            "new_package_version": "3.0-1.ph4",
+            "cve_id": cve,
+        })
+    conn.commit()
+    refresh_drift_view(conn)
+    output = render_drift_timeline(conn)
+    conn.close()
+    # The x-axis labels line carries the abbreviated names; the per-release
+    # detail table at the bottom keeps the full "Update" spelling. Check the
+    # abbreviation appears in the x-axis row by scanning lines that contain
+    # ONLY release-label fragments (no spelled-out "Update").
+    lines = output.splitlines()
+    arrow = next(l for l in lines if "-> time" in l)
+    label_line = lines[lines.index(arrow) + 2]  # arrow -> date -> name labels
+    assert "Upd" in label_line
+    assert "Updat" not in label_line
+    # The patch letter ("3j", "3v", ...) must survive truncation, i.e. the
+    # abbreviation has no trailing space before the patch letter.
+    assert "Upd3j" in label_line or "Upd3v" in label_line or "Upd3" in label_line
+
+
+def test_chart_summary_excludes_pre_fixed(chart_db):
+    """The ASCII chart's per-release detail must use the same pre_fixed=0
+    filter as the report's drift-summary tables — otherwise a release shows
+    a higher CVE count in the chart than in the rest of the report."""
+    from vcenter_cve_drift.database.views import (
+        get_drift_summary_by_release,
+        get_drift_values_by_release,
+    )
+
+    chart_rows = {r["vcenter_release"]: r["cve_count"] for r in get_drift_summary_by_release(chart_db)}
+    drift_rows = {name: len(d["drift_values"]) for name, d in get_drift_values_by_release(chart_db).items()}
+    # Every release that appears in either query agrees on count.
+    for name in set(chart_rows) | set(drift_rows):
+        assert chart_rows.get(name, 0) == drift_rows.get(name, 0), (
+            f"CVE count mismatch for {name}: chart={chart_rows.get(name)} drift={drift_rows.get(name)}"
+        )


### PR DESCRIPTION
## Two ASCII-chart cleanups so the chart agrees with the rest of the report

### 1. CVE counts in the chart's per-release detail were higher than in the drift tables

`get_drift_summary_by_release` (used only by the ASCII chart) filtered on `drift IS NOT NULL` but lacked the `pre_fixed = 0` filter that every drift-ranking query already applies. Result: pre-fixed CVEs were counted **both** in the chart detail row *and* separately in the "Pre-fixed CVEs (excluded from drift rankings)" section. For example, **8.0 Update 3j showed 209 in the chart vs 169 in the drift tables** — the 40-CVE gap was the count of pre-fixed CVEs. Adding `pre_fixed = 0` aligns every per-release CVE count across the report.

### 2. X-axis release labels lost the patch letter

The label row truncated each release name to `col_width-1` (~9 chars), so `vCenter Server 8.0 Update 3j` → `8.0 Update 3j` still got cut after `Updat` and lost the patch identifier itself. Replace `Update ` → `Upd` (no trailing space) so `8.0 Upd3j` / `7.0 Upd3v` survive truncation.

### Before / after on the real chart

```
before: 7.0 Updat 7.0 Updat 7.0 Updat ... 8.0 Updat 8.0 Updat
after : 7.0 Upd2c 7.0 Upd3d 7.0 Upd3f ... 8.0 Upd3i 8.0 Upd3j
```

### Verification

- 68 tests pass (incl. `test_xaxis_labels_use_upd_abbreviation` and `test_chart_summary_excludes_pre_fixed`).
- Against the real `drift.db` from the latest run, every release now has identical CVE counts between `get_drift_summary_by_release` and `get_drift_values_by_release` — 3j: **169 = 169** (was 209 vs 169).

🤖 Generated with [Claude Code](https://claude.com/claude-code)