### PR TITLE
Revert chart pre_fixed filter (chart shows totals, drift tables show subset)

### DIFF
--- a/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/database/views.py
+++ b/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/database/views.py
@@ -4,12 +4,13 @@ import sqlite3
 
 
 def get_drift_summary_by_release(conn: sqlite3.Connection) -> list[dict]:
-    # Aligns with get_drift_values_by_release: both exclude pre-fixed CVEs
-    # (those already at/above the upstream fix per the NVD CPE range) so the
-    # "CVEs" column in the ASCII chart's per-release detail table matches the
-    # count in the drift-summary tables instead of double-counting CVEs that
-    # the report's "Pre-fixed CVEs (excluded from drift rankings)" section
-    # already lists separately.
+    # Intentionally does NOT filter pre_fixed: the ASCII chart's per-release
+    # detail reports the total count of CVEs addressed by each release, which
+    # is a different (informational) metric from the drift-ranking tables.
+    # Pre-fixed CVEs are already accounted for separately in the
+    # "Pre-fixed CVEs (excluded from drift rankings)" section, and the
+    # drift-tables row uses get_drift_values_by_release for the
+    # drift-eligible subset.
     cursor = conn.execute("""
         SELECT
             vcenter_release,
@@ -23,7 +24,6 @@ def get_drift_summary_by_release(conn: sqlite3.Connection) -> list[dict]:
             ROUND(AVG(base_score), 1) as avg_cvss_score
         FROM DriftAnalysis
         WHERE nvd_to_vcenter_drift_days IS NOT NULL
-            AND pre_fixed = 0
         GROUP BY vcenter_release, vcenter_release_date
         ORDER BY vcenter_release_date
     """)

--- a/vCenter-CVE-drift-analyzer/tests/test_ascii_chart.py
+++ b/vCenter-CVE-drift-analyzer/tests/test_ascii_chart.py
@@ -143,19 +143,54 @@ def test_xaxis_labels_use_upd_abbreviation():
     assert "Upd3j" in label_line or "Upd3v" in label_line or "Upd3" in label_line
 
 
-def test_chart_summary_excludes_pre_fixed(chart_db):
-    """The ASCII chart's per-release detail must use the same pre_fixed=0
-    filter as the report's drift-summary tables — otherwise a release shows
-    a higher CVE count in the chart than in the rest of the report."""
+def test_chart_summary_counts_include_pre_fixed():
+    """The ASCII chart's per-release detail intentionally reports the total
+    CVEs addressed by the release (including pre-fixed). The drift-ranking
+    tables report a different subset (drift-eligible, pre_fixed=0), and the
+    two counts legitimately differ -- pre-fixed CVEs are documented in the
+    "Pre-fixed CVEs (excluded from drift rankings)" section, not omitted
+    from the chart's total."""
+    from vcenter_cve_drift.database.operations import upsert_cve_cpe
+    from vcenter_cve_drift.analysis.version_check import check_prefixed_cves
     from vcenter_cve_drift.database.views import (
         get_drift_summary_by_release,
         get_drift_values_by_release,
     )
 
-    chart_rows = {r["vcenter_release"]: r["cve_count"] for r in get_drift_summary_by_release(chart_db)}
-    drift_rows = {name: len(d["drift_values"]) for name, d in get_drift_values_by_release(chart_db).items()}
-    # Every release that appears in either query agrees on count.
-    for name in set(chart_rows) | set(drift_rows):
-        assert chart_rows.get(name, 0) == drift_rows.get(name, 0), (
-            f"CVE count mismatch for {name}: chart={chart_rows.get(name)} drift={drift_rows.get(name)}"
-        )
+    conn = init_database(":memory:")
+    # Two CVEs against one release. One has a CPE range that flags it as
+    # pre-fixed (shipped version >= upstream fix); the other has no CPE.
+    for cve in ("CVE-2024-1111", "CVE-2024-2222"):
+        upsert_nvd_cve(conn, {
+            "cve_id": cve, "nvd_published": "2024-01-01T00:00:00",
+            "nvd_last_modified": "2024-06-01T00:00:00", "base_score": 7.0,
+        })
+        upsert_vcenter_release(conn, {
+            "source_url": "url", "vcenter_release": "vCenter 8.0U3",
+            "release_date": "2024-09-01", "build_number": "999",
+            "affected_package": "openssl",
+            "new_package_version": "3.0.16-1.ph4", "cve_id": cve,
+        })
+    # The shipped openssl 3.0.16 sits above the upstream fix "3.0.0" -> the
+    # version_check pass marks CVE-2024-1111 as pre_fixed=1.
+    upsert_cve_cpe(conn, "CVE-2024-1111", {
+        "cpe_uri": "cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*",
+        "version_end_excluding": "3.0.0",
+        "vulnerable": 1,
+    })
+    conn.commit()
+    check_prefixed_cves(conn)
+    refresh_drift_view(conn)
+
+    chart = {r["vcenter_release"]: r["cve_count"]
+             for r in get_drift_summary_by_release(conn)}
+    drift = {name: len(d["drift_values"])
+             for name, d in get_drift_values_by_release(conn).items()}
+    conn.close()
+
+    # Chart reports the total (2); drift table reports only the non-pre-fixed
+    # subset (1). The deliberate gap is exactly the pre-fixed count, which is
+    # listed separately in the "Pre-fixed CVEs (excluded from drift rankings)"
+    # section of the report.
+    assert chart["vCenter 8.0U3"] == 2
+    assert drift["vCenter 8.0U3"] == 1


### PR DESCRIPTION
Per [user feedback](this conversation), withdraw the `AND pre_fixed = 0` filter that #232 added to `get_drift_summary_by_release`. The ASCII chart's per-release detail is meant to show the **total** CVEs addressed by each release (e.g. 3j: 209), and that's a different, informational metric from the drift-ranking subset (3j: 169). Pre-fixed CVEs are already documented separately in the "Pre-fixed CVEs (excluded from drift rankings)" section; aligning the counts hid the total scope without adding anything.

The deliberate divergence on the real DB:

| Release | Chart (total) | Drift (subset) | Pre-fixed |
|---|---:|---:|---:|
| 8.0 Update 3j | 209 | 169 | 40 |
| 8.0 Update 3i | 489 | 440 | 49 |
| 8.0 Update 3e | 252 | 100 | 152 |

Keeps the unrelated `Update ` → `Upd` x-axis abbreviation from #232 (so `8.0 Upd3j` survives column truncation). Replaces the consistency test with one that locks in the intentional gap. 45 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)