### PR TITLE
summary: link each release to its Broadcom techdocs page

### DIFF
--- a/.github/workflows/vcenter-cve-drift.yml
+++ b/.github/workflows/vcenter-cve-drift.yml
@@ -170,15 +170,30 @@ jobs:
           def med(v):
               return int(statistics.median(v)) if v else 0
 
+          def techdocs_link(src):
+              # The scraper stores the Broadcom techdocs page URL on every
+              # record; render it as a short Markdown link ("8-0", "7-0", ...)
+              # so readers can jump from the summary to the upstream release
+              # notes for that release's major version.
+              if not src:
+                  return ""
+              # Pull the "/vsphere/<X>-<Y>/" segment out of the URL for the
+              # link label; fall back to a generic label if not present.
+              import re
+              m = re.search(r"/vsphere/(\d+)-(\d+)/", src)
+              label = f"{m.group(1)}.{m.group(2)}" if m else "techdocs"
+              return f"[{label}]({src})"
+
           print("### Per-release drift summary")
           print("")
-          print("| Release | Date | CVEs | Med. Drift (Pub) | Med. Drift (Mod) |")
-          print("|---|---|---:|---:|---:|")
+          print("| Release | Date | CVEs | Med. Drift (Pub) | Med. Drift (Mod) | Techdocs |")
+          print("|---|---|---:|---:|---:|---|")
           for r in rows:
               print(
                   f"| {r['vcenter_release']} | {r['vcenter_release_date']} "
                   f"| {len(r['drift_values'])} | {med(r['drift_values'])} "
-                  f"| {med(r['modified_drift_values'])} |"
+                  f"| {med(r['modified_drift_values'])} "
+                  f"| {techdocs_link(r.get('source_url'))} |"
               )
           PY
             {

--- a/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/database/views.py
+++ b/vCenter-CVE-drift-analyzer/src/vcenter_cve_drift/database/views.py
@@ -50,14 +50,17 @@ def get_drift_values_by_release(conn: sqlite3.Connection) -> dict[str, dict]:
     """Return per-release metadata and raw drift values for median calculation.
 
     Returns both published-based and modified-based drift value lists.
-    Excludes pre-fixed CVEs.
+    Excludes pre-fixed CVEs. Each per-release dict also carries the
+    Broadcom techdocs `source_url` so renderers (e.g. the workflow's job
+    summary) can link back to the upstream release-notes page.
     """
     cursor = conn.execute("""
         SELECT
             vcenter_release,
             vcenter_release_date,
             nvd_to_vcenter_drift_days AS drift_days,
-            nvd_modified_to_vcenter_drift_days AS modified_drift_days
+            nvd_modified_to_vcenter_drift_days AS modified_drift_days,
+            source_url
         FROM DriftAnalysis
         WHERE nvd_to_vcenter_drift_days IS NOT NULL
             AND vcenter_release_date IS NOT NULL
@@ -73,6 +76,7 @@ def get_drift_values_by_release(conn: sqlite3.Connection) -> dict[str, dict]:
                 "vcenter_release_date": row[1],
                 "drift_values": [],
                 "modified_drift_values": [],
+                "source_url": row[4],
             }
         by_release[name]["drift_values"].append(row[2])
         if row[3] is not None:

--- a/vCenter-CVE-drift-analyzer/tests/test_report.py
+++ b/vCenter-CVE-drift-analyzer/tests/test_report.py
@@ -89,6 +89,15 @@ def test_drift_values_by_release_has_date(report_db):
     assert by_release["vCenter 8.0U1c"]["vcenter_release_date"] == "2023-07-27"
 
 
+def test_drift_values_by_release_carries_source_url(report_db):
+    """source_url flows through so the workflow's job-summary table can link
+    each release row back to its Broadcom techdocs release-notes page."""
+    by_release = get_drift_values_by_release(report_db)
+    for name in ("vCenter 8.0b", "vCenter 8.0U1c", "vCenter 8.0U3"):
+        assert "source_url" in by_release[name]
+        assert by_release[name]["source_url"]  # non-empty
+
+
 def test_median_odd():
     assert _median([1, 3, 5]) == 3
 


### PR DESCRIPTION
Adds a **Techdocs** column to the workflow's "Per-release drift summary" Markdown table (the one rendered in the GitHub Actions Summary tab), right after `Med. Drift (Mod)`. Each row now ends with a clickable short link to the upstream Broadcom techdocs release-notes page for that release's major version.

Example rendered row:

```
| vCenter Server 8.0 Update 3j | 2026-05-27 | 169 | 122 | 54 | [8.0](https://techdocs.broadcom.com/.../vsphere/8-0/release-notes/vcenter-server-appliance-photonos-security-patches.html) |
```

### Plumbing

`get_drift_values_by_release` now also returns `source_url`. The `DriftAnalysis` view already exposed it via `vr.source_url`; the query just hadn't selected it. The workflow's inline Python derives the label (`7.0` / `8.0` / `9.0`) from the `/vsphere/<X>-<Y>/` segment of the URL — no hard-coded URL map duplicated from `config.py`.

### Verification

- 102 tests pass (new `test_drift_values_by_release_carries_source_url`).
- YAML parses cleanly.
- Simulated the inline Python against the latest `drift.db`: every of the 19 releases gets a correct `[7.0]` / `[8.0]` / `[9.0]` link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)