### PR TITLE
T1: --spec / $Spec single-spec investigation mode (PS + C)

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -32,6 +32,9 @@ on:
       strict_col9:
         description: 'M64 TODO-3: count col9 (SHA) toward the strict verdict (PR_STRICT_COL9). Leave false until the shared col9 cache (TODO-1) has been confirmed to hold col9 byte-stable across a PS→C cycle — enabling early spikes strict and resets the 90-day clock.'
         default: 'false'
+      spec:
+        description: 'T1: single-spec investigation mode. Set to a spec basename (e.g. "libev.spec") to compact the C binary''s task list to that one spec across the snapshot''s branches. Diagnostic-only: the resulting .prn has one row per branch and is never a parity verdict.'
+        default: ''
 
 permissions:
   contents: write   # commit the journal back to master
@@ -248,6 +251,13 @@ jobs:
           # (workflow_run) runs → col9 behaves exactly as before this change.
           PR_SHA_CACHE: ${{ github.event.inputs.sha_cache == 'true' && '1' || '' }}
           PR_SHA_CACHE_BASE: ${{ github.event.inputs.sha_cache == 'true' && '/root/.cache/photonos-shared/photon-upstreams' || '' }}
+          # T1: single-spec investigation mode. When set, the C binary
+          # compacts its task list to only that one spec basename (e.g.
+          # "libev.spec"). Diagnostic-only — the resulting .prn has one
+          # row and is never used as a parity verdict. Equivalent to the
+          # `-spec` command-line flag (which `main.c` reads first); the
+          # env makes the workflow input wiring cleaner.
+          PR_SINGLE_SPEC: ${{ github.event.inputs.spec }}
         run: |
           cd repo/photonos-package-report/photonos-package-report
           WDIR="${{ steps.reconstruct.outputs.wdir }}"

--- a/.github/workflows/package-report.yml
+++ b/.github/workflows/package-report.yml
@@ -30,6 +30,9 @@ on:
       upstreams_exclusion_list:
         description: 'Comma-separated substrings (case-insensitive). Matched against TWO keys: (1) leaf of $UpdateDownloadFile (skips tarball fetch into SOURCES_NEW); (2) $repoName from *.git URL (skips clone creation under clones/). Substitution + urlhealth still run; tag detection falls back to non-git path. Default skips firmware (~55 GB/branch) and chromium (~67 GB/branch), and aufs-linux (github.com/sfjro/aufs-linux.git hangs on clone, burning the 4h per-clone timeout).'
         default: 'firmware,chromium,aufs-linux'
+      spec:
+        description: 'T1: single-spec investigation mode. Set to a spec basename (e.g. "libev.spec") to process only that one file across the selected branches — seconds instead of ~40 min. Diagnostic-only: the resulting .prn has one row and is never used as a parity verdict.'
+        default: ''
   schedule:
     # Weekly scan on Sunday at 02:00 UTC
     - cron: '0 2 * * 0'
@@ -222,6 +225,13 @@ jobs:
           fi
           if [ -n "$UPSTREAMS_EXCL" ]; then
             EXTRA_ARGS="$EXTRA_ARGS -UpstreamsExclusionList \"$UPSTREAMS_EXCL\""
+          fi
+          # T1: single-spec investigation mode. When set, ParseDirectory
+          # yields only that one spec basename (e.g. "libev.spec") across
+          # the selected branches. Diagnostic-only — the resulting .prn has
+          # a single row and never feeds the parity verdict.
+          if [ -n "${{ github.event.inputs.spec }}" ]; then
+            EXTRA_ARGS="$EXTRA_ARGS -Spec \"${{ github.event.inputs.spec }}\""
           fi
 
           # Propagate pwsh's exit code. Previously a trailing `echo "exit_code=$?"`

--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -95,6 +95,13 @@ param (
     # Use case: avoid expensive re-downloads + 50–70 GB clones of huge sources
     # (e.g. "firmware,chromium") on every package-report run.
     [string]$UpstreamsExclusionList = "",
+    # T1: single-spec investigation mode. When set to a spec basename
+    # (e.g. "libev.spec"), ParseDirectory yields only that file across the
+    # selected branches. Used to iterate spec-by-spec parity work in
+    # seconds instead of dispatching a full single-branch run per attempt.
+    # Diagnostic-only — the resulting .prn has one row and is not a
+    # parity-gate source.
+    [string]$Spec = "",
     [Parameter(Mandatory = $false)][ValidateNotNull()]$GeneratePh3URLHealthReport=$true,
     [Parameter(Mandatory = $false)][ValidateNotNull()]$GeneratePh4URLHealthReport=$true,
     [Parameter(Mandatory = $false)][ValidateNotNull()]$GeneratePh5URLHealthReport=$true,
@@ -261,6 +268,9 @@ function ParseDirectory {
     $specsPath = Join-Path -Path $WorkingDir -ChildPath $photonDir | Join-Path -ChildPath "SPECS"
     Get-ChildItem -Path $specsPath -Recurse -File -Filter "*.spec" | ForEach-Object {
         $currentFile = $_
+        # T1: single-spec investigation mode — skip every other spec file.
+        # Case-insensitive match on the basename (e.g. "libev.spec").
+        if ($Spec -and ($currentFile.Name -ine $Spec)) { return }
         try
         {
             $Name = Split-Path -Path $currentFile.DirectoryName -Leaf

--- a/photonos-package-report/photonos-package-report/include/pr_types.h
+++ b/photonos-package-report/photonos-package-report/include/pr_types.h
@@ -26,6 +26,11 @@ typedef struct {
     const char *upstreamsDir;                                                  /* L 88  */
     const char *scansDir;                                                      /* L 89  */
     const char *UpstreamsExclusionList;                                        /* L 95  */
+    /* T1: single-spec investigation mode. Spec basename (e.g. "libev.spec");
+     * when non-empty, the urlhealth task list is compacted to just that
+     * one spec. Also readable via PR_SINGLE_SPEC env. Diagnostic-only;
+     * parity verdict still requires a full run. */
+    const char *Spec;
     int GeneratePh3URLHealthReport;                                            /* L 96  */
     int GeneratePh4URLHealthReport;                                            /* L 97  */
     int GeneratePh5URLHealthReport;                                            /* L 98  */

--- a/photonos-package-report/photonos-package-report/src/main.c
+++ b/photonos-package-report/photonos-package-report/src/main.c
@@ -74,6 +74,7 @@ static void usage(const char *progname)
         "  -upstreamsDir <path>                           (default: workingDir/photon-upstreams)\n"
         "  -scansDir <path>                               (default: workingDir/scans)\n"
         "  -UpstreamsExclusionList <csv>                  (e.g. firmware,chromium)\n"
+        "  -spec <name>                                   T1: single-spec mode (e.g. libev.spec); env PR_SINGLE_SPEC also honoured\n"
         "  -GeneratePh3URLHealthReport <true|false>       (default: true)\n"
         "  -GeneratePh4URLHealthReport <true|false>       (default: true)\n"
         "  -GeneratePh5URLHealthReport <true|false>       (default: true)\n"
@@ -109,6 +110,7 @@ int main(int argc, char **argv)
     params.upstreamsDir                          = "";                                                        /* L 88 */
     params.scansDir                              = "";                                                        /* L 89 */
     params.UpstreamsExclusionList                = "";                                                        /* L 95 */
+    params.Spec                                  = env_or("PR_SINGLE_SPEC");                                  /* T1   */
     /* L 96-107: all boolean flags default to $true; values arrive as
      * strings via argv and pass through convert_to_boolean below. We
      * pre-initialise to 1 (true). */
@@ -154,6 +156,7 @@ int main(int argc, char **argv)
         OPT_dump_tasks,                /* Phase 2 parity helper, not in PS. */
         OPT_generate_urlhealth_report, /* Phase 6a end-to-end pipeline.    */
         OPT_throttle_limit,            /* Phase 7 worker count override.   */
+        OPT_spec,                      /* T1: single-spec investigation.   */
     };
     const char *dump_tasks_branch          = NULL;
     const char *generate_urlhealth_branch  = NULL;
@@ -182,6 +185,7 @@ int main(int argc, char **argv)
         { "dump-tasks",                                                         required_argument, 0, OPT_dump_tasks },
         { "generate-urlhealth-report",                                          required_argument, 0, OPT_generate_urlhealth_report },
         { "ThrottleLimit",                                                      required_argument, 0, OPT_throttle_limit },
+        { "spec",                                                               required_argument, 0, OPT_spec },
         { "help",                                                               no_argument,       0, 'h' },
         { 0, 0, 0, 0 },
     };
@@ -224,6 +228,9 @@ int main(int argc, char **argv)
             params.ThrottleLimit = (int)strtol(optarg, NULL, 10);
             if (params.ThrottleLimit < 1)   params.ThrottleLimit = 1;
             if (params.ThrottleLimit > 256) params.ThrottleLimit = 256;
+            break;
+        case OPT_spec:
+            params.Spec = optarg;
             break;
         case 'h':
             usage(argv[0]);
@@ -558,6 +565,34 @@ static int generate_urlhealth_main(const pr_params_t *params, const char *branch
     if (parse_directory(params->workingDir, photon_dir, &list) != 0) {
         pr_task_list_free(&list);
         return 1;
+    }
+
+    /* T1: single-spec investigation mode — compact the task list to only the
+     * one matching spec basename. Case-insensitive. Source: --spec flag or
+     * PR_SINGLE_SPEC env (params->Spec already merges both at init). The
+     * downstream parallel pool / row-emission loops are slot-indexed against
+     * list.count, so we compact in place rather than mid-loop skipping. */
+    if (params->Spec && params->Spec[0]) {
+        size_t kept = 0;
+        for (size_t r = 0; r < list.count; r++) {
+            const char *s = list.items[r].Spec ? list.items[r].Spec : "";
+            if (strcasecmp(s, params->Spec) == 0) {
+                if (kept != r) {
+                    pr_task_free(&list.items[kept]);
+                    list.items[kept] = list.items[r];
+                    memset(&list.items[r], 0, sizeof list.items[r]);
+                }
+                kept++;
+            } else {
+                pr_task_free(&list.items[r]);
+                memset(&list.items[r], 0, sizeof list.items[r]);
+            }
+        }
+        list.count = kept;
+        if (kept == 0) {
+            fprintf(stderr, "single-spec mode: '%s' not found in branch %s\n",
+                    params->Spec, branch);
+        }
     }
 
     /* Source0LookupData (Phase 3a). Loaded once and shared across tasks. */

--- a/photonos-package-report/scans/photonos-diff-report-common-master_202605282158.prn
+++ b/photonos-package-report/scans/photonos-diff-report-common-master_202605282158.prn
@@ -1,0 +1,1 @@
+Spec,photon-common,photon-master

--- a/photonos-package-report/scans/photonos-diff-report-main-master_202605282158.prn
+++ b/photonos-package-report/scans/photonos-diff-report-main-master_202605282158.prn
@@ -1,0 +1,1 @@
+Spec,photon-main,photon-master

--- a/photonos-package-report/scans/photonos-package-report_202605282158.prn
+++ b/photonos-package-report/scans/photonos-package-report_202605282158.prn
@@ -1,0 +1,2 @@
+Spec,SubRelease,photon-3.0,photon-4.0,photon-5.0,photon-6.0,photon-common,photon-dev,photon-master,photon-main
+libev.spec,,4.24-2,4.33-3,4.33-3,4.33-3,,4.33-3,4.33-3,4.33-3

--- a/photonos-package-report/scans/photonos-urlhealth-3.0_202605282158.prn
+++ b/photonos-package-report/scans/photonos-urlhealth-3.0_202605282158.prn
@@ -1,0 +1,2 @@
+Spec,Source0 original,Modified Source0 for url health check,UrlHealth,UpdateAvailable,UpdateURL,HealthUpdateURL,Name,SHAName,UpdateDownloadName,warning,ArchivationDate
+libev.spec,http://dist.schmorp.de/libev/%{name}-%{version}.tar.gz,https://dist.schmorp.de/libev/Attic/libev-4.24.tar.gz,200,4.33,https://dist.schmorp.de/libev/Attic/libev-4.33.tar.gz,200,libev,C662A65360115E0B2598E3E8824CF7B33360C43A96AC9233F6B6EA2873A10102551773CAD0E89E738541E75AF9FD4F3E3C11CD2F251C5703AA24F193128B896B,libev-4.33.tar.gz,,

--- a/photonos-package-report/scans/photonos-urlhealth-issues-5.0_202605282141.md
+++ b/photonos-package-report/scans/photonos-urlhealth-issues-5.0_202605282141.md
@@ -1,0 +1,190 @@
+# Photon OS URL Health Issues - branch 5.0
+
+**Source file:** photonos-urlhealth-5.0_202605282141.prn
+
+**Total packages analyzed:** 1633
+
+**Total packages with issues:** 115
+
+**Vendor-pinned subrelease (frozen for a Photon sub-release) — informational, not an issue:** 590
+
+**VMware-internal Source0 URL (not publicly resolvable) — informational, not an issue:** 15
+
+## Summary
+
+| # | Issue Category | Count | Severity |
+|---|---|---|---|
+| 1 | Source URL blank / macro unresolved (UrlHealth=blank) | 2 | High |
+| 2 | URL substitution unfinished | 3 | High |
+| 3 | Source URL unreachable (UrlHealth=0) | 17 | High |
+| 5 | Version comparison anomaly (UpdateAvailable contains Warning) | 17 | Medium |
+| 6 | Source healthy (UrlHealth=200) but UpdateAvailable and UpdateURL blank | 7 | Medium |
+| 7 | Update version detected but UpdateURL/HealthUpdateURL blank (packaging format changed) | 59 | Medium |
+| 8 | Other warnings (VMware internal URL, unmaintained repo, etc.) | 10 | Low-Medium |
+
+---
+
+## 1. Source URL Blank / Macro Unresolved (UrlHealth=blank)
+
+The Source0 URL contains unexpanded RPM macros or is empty.
+
+| # | Spec | Name | Source0 Original | Fix Suggestion |
+|---|---|---|---|---|
+| 1 | chromium.spec | chromium | `https://github.com/chromium/chromium/archive/%{name}-%{version}.tar.xz` | Verify Source0 URL macro expansion. The %{version} or %{name} macro may not resolve. Provide a direct URL or fix the macro. |
+| 2 | raspberrypi-firmware.spec | raspberrypi-firmware | `%{name}-%{version}.tar.gz` | Verify Source0 URL macro expansion. The %{version} or %{name} macro may not resolve. Provide a direct URL or fix the macro. |
+
+---
+
+## 2. URL Substitution Unfinished
+
+| # | Spec | Name | Source0 Original | Modified Source0 | Fix Suggestion |
+|---|---|---|---|---|---|
+| 1 | alternatives.spec | alternatives | `https://github.com/fedora-sysv/chkconfig/archive/refs/tags/%{src_name}-%{version` | `https://github.com/fedora-sysv/chkconfig/archive/refs/tags/%{src_name}-1.32.tar.` | Fix the Source0 URL pattern. The version/name substitution is incomplete -- check for nested or malformed macros. |
+| 2 | python3-msal.spec | python3-msal | `https://github.com/AzureAD/%{full_name}/archive/%{version}/%{full_name}-%{versio` | `` | Fix the Source0 URL pattern. The version/name substitution is incomplete -- check for nested or malformed macros. |
+| 3 | squid.spec | squid | `https://github.com/squid-cache/squid/archive/refs/tags/%{upstream_name}_%{upstre` | `https://github.com/squid-cache/squid/archive/refs/tags/%{upstream_name}_%{upstre` | Fix the Source0 URL pattern. The version/name substitution is incomplete -- check for nested or malformed macros. |
+
+---
+
+## 3. Source URL Unreachable (UrlHealth=0)
+
+| # | Spec | Name | Modified Source0 | Warning | Fix Suggestion |
+|---|---|---|---|---|---|
+| 1 | cdrkit.spec | cdrkit | `http://gd.tuwien.ac.at/utils/schilling/cdrtoolscdrkit-1.1.11.tar.gz` | Warning: Source0 seems invalid and no other Official source has been found. | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 2 | filesystem.spec | filesystem | `clock` |  | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 3 | hyper-v.spec | hyper-v | `%{name}-%{version}.tar.gz` |  | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 4 | lasso.spec | lasso | `https://dev.entrouvert.org/lasso/lasso-%{version}.tar.gz` |  | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 5 | procps-ng.spec | procps-ng | `https://sourceforge.net/projects/procps-ng/files/Production/procps-4.0.6.tar.gz` |  | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 6 | python-installer.spec | python-installer | `https://github.com/pypa/installer/archive/refs/tags/installer-0.7.0.tar.gz` |  | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 7 | python-ruamel-yaml.spec | python-ruamel-yaml | `https://files.pythonhosted.org/packages/ruamel.yaml-0.19.1.tar.gz` |  | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 8 | python3-Pygments.spec | python3-Pygments | `https://github.com/pygments/pygments/archive/refs/tags/pygments-2.19.2.tar.gz` | Warning: Manufacturer may changed version packaging format. | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 9 | python3-iniconfig.spec | python3-iniconfig | `https://github.com/RonnyPfannschmidt/iniconfig/archive/refs/tags/iniconfig-2.3.0.tar.gz` |  | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 10 | python3-iniparse.spec | python3-iniparse | `http://iniparse.googlecode.com/files/iniparse-%{version}.tar.gz` |  | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 11 | python3-legacy-cgi.spec | python3-legacy-cgi | `legacy_cgi-%{version}.tar.gz` |  | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 12 | python3-markupsafe.spec | python3-markupsafe | `https://github.com/pallets/markupsafe/archive/refs/tags/markupsafe-3.0.3.tar.gz` |  | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 13 | python3-roman-numerals.spec | python3-roman-numerals | `roman_numerals-%{version}.tar.gz` |  | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 14 | python3-trove-classifiers.spec | python3-trove-classifiers | `https://github.com/pypa/trove-classifiers/archive/refs/tags/trove-classifiers-2026.1.14.14.tar.gz` | Warning: Manufacturer may changed version packaging format. | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 15 | python3-wheel.spec | python3-wheel | `https://github.com/pypa/wheel/archive/refs/tags/wheel-0.46.3.tar.gz` | Warning: Manufacturer may changed version packaging format. | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 16 | repmgr18.spec | repmgr | `https://repmgr.org/download/%{srcname}-%{version}.tar.gz` |  | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+| 17 | wal2json18.spec | wal2json | `https://github.com/eulerto/wal2json/archive/refs/tags/wal2json-2.6.tar.gz` |  | URL is unreachable. Check if the domain/host is still active. Find an alternative mirror or upstream source. |
+
+---
+
+## 5. Version Comparison Anomaly
+
+| # | Spec | Name | Version Warning | Fix Suggestion |
+|---|---|---|---|---|
+| 1 | apparmor.spec | apparmor | Warning: apparmor.spec Source0 version 4.1.6 is higher than detected latest version 4.1.0 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 2 | containers-common.spec | containers-common | Warning: containers-common.spec Source0 version 4 is higher than detected latest version 1.0.1 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 3 | dracut.spec | dracut | Warning: dracut.spec Source0 version 109 is higher than detected latest version 059 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 4 | dtb-raspberrypi.spec | dtb-raspberrypi | Warning: dtb-raspberrypi.spec Source0 version 6.1.10.2023.02.28 is higher than detected latest version 1.20230405 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 5 | ibmtpm.spec | ibmtpm | Warning: ibmtpm.spec Source0 version 20240802.183 is higher than detected latest version 2024-08-02 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 6 | libmspack.spec | libmspack | Warning: libmspack.spec Source0 version 0.11alpha is higher than detected latest version 1.11 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 7 | libnss-ato.spec | libnss-ato | Warning: libnss-ato.spec Source0 version 20240514 is higher than detected latest version 0.2.0 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 8 | linux-esx.spec | linux | Warning: linux-esx.spec Source0 version 6.12.87 is higher than detected latest version 6.1.174 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 9 | linux.spec | linux | Warning: linux.spec Source0 version 6.12.87-acvp} is higher than detected latest version 6.1.174 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 10 | lshw.spec | lshw | Warning: lshw.spec Source0 version B.02.20 is higher than detected latest version 02.20 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 11 | mdadm.spec | mdadm | Warning: mdadm.spec Source0 version 4.6 is higher than detected latest version 4.4 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 12 | pcstat.spec | pcstat | Warning: pcstat.spec Source0 version 2.0 is higher than detected latest version 0.0.2 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 13 | perl-Module-ScanDeps.spec | perl-Module-ScanDeps | Warning: perl-Module-ScanDeps.spec Source0 version 1.37 is higher than detected latest version 1.35 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 14 | proto.spec | proto | Warning: proto.spec Source0 version 7.7 is higher than detected latest version 7.0.31 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 15 | re2.spec | re2 | Warning: re2.spec Source0 version 20220601 is higher than detected latest version 2025-11-05 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 16 | syslinux.spec | syslinux | Warning: syslinux.spec Source0 version 6.04 is higher than detected latest version 6.03 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+| 17 | systemd.spec | systemd | Warning: systemd.spec Source0 version 257.13 is higher than detected latest version 256 . | Version comparison heuristic may be confused by version format (date-based, alpha suffixes, etc.). Verify manually. |
+
+---
+
+## 6. Source Healthy but No Update Info (UrlHealth=200, UpdateAvailable=blank)
+
+| # | Spec | Name | Modified Source0 | Fix Suggestion |
+|---|---|---|---|---|
+| 1 | iotop.spec | iotop | `http://guichaz.free.fr/iotop/files/iotop-0.6.tar.gz` | Source URL works but update detection found no newer version. May be correct or the version detection pattern does not match upstream release naming. Verify manually. |
+| 2 | libbsd.spec | libbsd | `https://libbsd.freedesktop.org/releases/libbsd-0.12.2.tar.xz` | Source URL works but update detection found no newer version. May be correct or the version detection pattern does not match upstream release naming. Verify manually. |
+| 3 | libdisplay-info.spec | libdisplay-info | `https://gitlab.freedesktop.org/emersion/libdisplay-info/-/archive/0.3.0/libdisplay-info-0.3.0.tar.gz` | Source URL works but update detection found no newer version. May be correct or the version detection pattern does not match upstream release naming. Verify manually. |
+| 4 | log4cpp.spec | log4cpp | `https://netix.dl.sourceforge.net/project/log4cpp/log4cpp-1.1.x%20%28new%29/log4cpp-1.1/log4cpp-1.1.6` | Source URL works but update detection found no newer version. May be correct or the version detection pattern does not match upstream release naming. Verify manually. |
+| 5 | open-sans-fonts.spec | open-sans-fonts | `https://ftp.debian.org/debian/pool/main/f/fonts-open-sans/fonts-open-sans_1.10.orig.tar.xz` | Source URL works but update detection found no newer version. May be correct or the version detection pattern does not match upstream release naming. Verify manually. |
+| 6 | openjdk25.spec | openjdk | `https://github.com/openjdk/jdk25u/archive/refs/tags/jdk-25.0.2-ga.tar.gz` | Source URL works but update detection found no newer version. May be correct or the version detection pattern does not match upstream release naming. Verify manually. |
+| 7 | python3-hatchling.spec | python3-hatchling | `https://github.com/pypa/hatch/releases/download/hatchling-v1.29.0/hatchling-1.29.0.tar.gz` | Source URL works but update detection found no newer version. May be correct or the version detection pattern does not match upstream release naming. Verify manually. |
+
+---
+
+## 7. Update Version Detected but Update URL Not Constructed (Packaging Format Changed)
+
+| # | Spec | Name | Update Available | Warning | Fix Suggestion |
+|---|---|---|---|---|---|
+| 1 | cronie.spec | cronie | 4.3 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 2 | dos2unix.spec | dos2unix | 7.5.6 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 3 | efivar.spec | efivar | 39 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 4 | erofs-utils.spec | erofs-utils | 20190826 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 5 | expat.spec | expat | 20000512 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 6 | fontconfig.spec | fontconfig | 2.18.0 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 7 | glog.spec | glog | 0.7.1 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 8 | govmomi.spec | govmomi | 0.54.0 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 9 | icu.spec | icu | 78.3 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 10 | kexec-tools.spec | kexec-tools | 20080324 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 11 | libXScrnSaver.spec | libXScrnSaver | 1.2.5 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 12 | libXau.spec | libXau | 1.0.12 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 13 | libXcomposite.spec | libXcomposite | 0.4.7 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 14 | libXdamage.spec | libXdamage | 1.1.7 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 15 | libXdmcp.spec | libXdmcp | 1.1.5 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 16 | libXext.spec | libXext | 1.3.7 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 17 | libXfixes.spec | libXfixes | 6.0.2 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 18 | libXfont2.spec | libXfont2 | 2.0.7 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 19 | libXi.spec | libXi | 1.8.3 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 20 | libXrandr.spec | libXrandr | 1.5.5 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 21 | libXrender.spec | libXrender | 0.9.12 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 22 | libXt.spec | libXt | 1.3.1 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 23 | libXtst.spec | libXtst | 1.2.5 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 24 | libcap.spec | libcap | 20071031 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 25 | libdrm.spec | libdrm | 200-0-1-20020822 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 26 | libfontenc.spec | libfontenc | 1.1.9 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 27 | libpciaccess.spec | libpciaccess | 0.19 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 28 | libslirp.spec | libslirp | 2.5.20200525 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 29 | libtirpc.spec | libtirpc | 1-3-7 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 30 | libxml2.spec | libxml2 | 7.3 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 31 | lxcfs.spec | lxcfs | 7.0.0 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 32 | mesa.spec | mesa | 20090313 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 33 | mozjs.spec | mozjs | 151.0.2 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 34 | ncurses.spec | ncurses | 6.6.20260523 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 35 | nss.spec | nss | 3.124 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 36 | open-vm-tools.spec | open-vm-tools | 2013.09.16-1328054 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 37 | openssh.spec | openssh | .9.9.P2 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 38 | perftest.spec | perftest | 26.01.5 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 39 | perl-IPC-Run.spec | perl-IPC-Run | 20260402 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 40 | perl-List-MoreUtils.spec | perl-List-MoreUtils | 1.400.002 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 41 | perl-URI.spec | perl-URI | 5.36 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 42 | pgaudit15.spec | pgaudit | 18.0 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 43 | pgaudit16.spec | pgaudit | 18.0 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 44 | pgaudit17.spec | pgaudit | 18.0 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 45 | polkit.spec | polkit | 124 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 46 | popt.spec | popt | 1.19- | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 47 | python-google-auth.spec | python-google-auth | 1946 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 48 | python-pyvmomi.spec | python-pyvmomi | 9.1.0.0 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 49 | python-vcs-versioning.spec | python-vcs-versioning | 9.2.2 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 50 | qemu.spec | qemu | /9.0.4 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 51 | scons.spec | scons | 4.10.1 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 52 | spirv-headers.spec | spirv-headers | 1.5.4 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 53 | spirv-tools.spec | spirv-tools | 2026.2 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 54 | tcl.spec | tcl | 9.0.4 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 55 | unixODBC.spec | unixODBC | 2.3.14 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 56 | util-macros.spec | util-macros | 1.20.2 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 57 | vulkan-tools.spec | vulkan-tools | 1.4.352 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 58 | wayland-protocols.spec | wayland-protocols | 1.48 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+| 59 | wireshark.spec | wireshark | 4.6.16 | Warning: Manufacturer may changed version packaging format. | Upstream changed version/packaging format. Update the Source0 URL pattern in the spec to match the new release naming convention. |
+
+---
+
+## 8. Other Warnings
+
+| # | Spec | Name | UrlHealth | UpdateAvailable | Warning | Fix Suggestion |
+|---|---|---|---|---|---|---|
+| 1 | cloud-network-setup.spec | cloud-network-setup | 200 | 0.2.3 | Warning: repo isn't maintained anymore. | Upstream repo is no longer maintained. Consider finding a fork, alternative, or mark package as archived. |
+| 2 | crash.spec | crash | 200 | 9.0.2 | Warning: Source0 seems invalid and no other Official source has been found. | Source0 URL appears invalid and no official source found. Find the correct upstream URL. |
+| 3 | heapster.spec | heapster | 200 | (same version) | Warning: repo isn't maintained anymore. | Upstream repo is no longer maintained. Consider finding a fork, alternative, or mark package as archived. |
+| 4 | http-parser.spec | http-parser | 200 | (same version) | Warning: repo isn't maintained anymore. | Upstream repo is no longer maintained. Consider finding a fork, alternative, or mark package as archived. |
+| 5 | kubernetes-dashboard.spec | kubernetes-dashboard | 200 | 7.14.0 | Warning: repo isn't maintained anymore. | Upstream repo is no longer maintained. Consider finding a fork, alternative, or mark package as archived. |
+| 6 | libtar.spec | libtar | 200 | (same version) | Warning: repo isn't maintained anymore. See https://sources.debian.org/patches/libtar | Upstream repo is no longer maintained. Consider finding a fork, alternative, or mark package as archived. |
+| 7 | motd.spec | motd | 200 |  | Warning: Cannot detect correlating tags from the repo provided. | Tag detection failed. Check if upstream uses a different tagging convention. |
+| 8 | pcre.spec | pcre | 200 |  | Warning: Source0 seems invalid and no other Official source has been found. | Source0 URL appears invalid and no official source found. Find the correct upstream URL. |
+| 9 | python-pycodestyle.spec | python-pycodestyle | 200 | 2.14.0 | Warning: duplicate of python-pam.spec | This spec may be a duplicate. Consider consolidating with the referenced spec. |
+| 10 | python-terminaltables.spec | python-terminaltables | 200 | 3.1.10 | Warning: repo isn't maintained anymore. | Upstream repo is no longer maintained. Consider finding a fork, alternative, or mark package as archived. |
+

--- a/photonos-package-report/scans/photonos-urlhealth-issues-matrix_202605282141.md
+++ b/photonos-package-report/scans/photonos-urlhealth-issues-matrix_202605282141.md
@@ -1,0 +1,145 @@
+# Photon OS URL Health - cross-branch matrix
+
+## Spec-matrix — issue applicability per branch
+
+**115** packages with at least one issue across 1 branches.
+
+Cell legend: severity colour + issue category number(s) — 🔴 High (1,2,3) · 🟠 Medium (4,5,6,7) · 🟡 Low-Medium (8) · 🟢 present & URL health OK · ⚪ not carried · 📌 vendor-pinned subrelease (non-issue) · 🔵 VMware-internal Source0 (non-issue).
+
+| Spec | 5.0 | 5.0/SPECS/90 | 5.0/SPECS/91 |
+|---|---|---|---|
+| alternatives.spec | 🔴2 | ⚪ | ⚪ |
+| apparmor.spec | 🟠5 | 📌 | ⚪ |
+| cdrkit.spec | 🔴3 | ⚪ | ⚪ |
+| chromium.spec | 🔴1 | ⚪ | ⚪ |
+| cloud-network-setup.spec | 🟡8 | ⚪ | ⚪ |
+| containers-common.spec | 🟠5 | ⚪ | ⚪ |
+| crash.spec | 🟡8 | ⚪ | ⚪ |
+| cronie.spec | 🟠7 | ⚪ | ⚪ |
+| dos2unix.spec | 🟠7 | ⚪ | ⚪ |
+| dracut.spec | 🟠5 | 📌 | ⚪ |
+| dtb-raspberrypi.spec | 🟠5 | ⚪ | ⚪ |
+| efivar.spec | 🟠7 | ⚪ | ⚪ |
+| erofs-utils.spec | 🟠7 | ⚪ | ⚪ |
+| expat.spec | 🟠7 | ⚪ | ⚪ |
+| filesystem.spec | 🔴3 | ⚪ | ⚪ |
+| fontconfig.spec | 🟠7 | 📌 | ⚪ |
+| glog.spec | 🟠7 | ⚪ | ⚪ |
+| govmomi.spec | 🟠7 | ⚪ | ⚪ |
+| heapster.spec | 🟡8 | ⚪ | ⚪ |
+| http-parser.spec | 🟡8 | ⚪ | ⚪ |
+| hyper-v.spec | 🔴3 | ⚪ | ⚪ |
+| ibmtpm.spec | 🟠5 | 📌 | ⚪ |
+| icu.spec | 🟠7 | 📌 | ⚪ |
+| iotop.spec | 🟠6 | 📌 | ⚪ |
+| kexec-tools.spec | 🟠7 | ⚪ | ⚪ |
+| kubernetes-dashboard.spec | 🟡8 | 📌 | ⚪ |
+| lasso.spec | 🔴3 | 📌 | ⚪ |
+| libXScrnSaver.spec | 🟠7 | ⚪ | ⚪ |
+| libXau.spec | 🟠7 | ⚪ | ⚪ |
+| libXcomposite.spec | 🟠7 | ⚪ | ⚪ |
+| libXdamage.spec | 🟠7 | ⚪ | ⚪ |
+| libXdmcp.spec | 🟠7 | ⚪ | ⚪ |
+| libXext.spec | 🟠7 | ⚪ | ⚪ |
+| libXfixes.spec | 🟠7 | ⚪ | ⚪ |
+| libXfont2.spec | 🟠7 | ⚪ | ⚪ |
+| libXi.spec | 🟠7 | ⚪ | ⚪ |
+| libXrandr.spec | 🟠7 | ⚪ | ⚪ |
+| libXrender.spec | 🟠7 | ⚪ | ⚪ |
+| libXt.spec | 🟠7 | ⚪ | ⚪ |
+| libXtst.spec | 🟠7 | ⚪ | ⚪ |
+| libbsd.spec | 🟠6 | ⚪ | ⚪ |
+| libcap.spec | 🟠7 | 📌 | ⚪ |
+| libdisplay-info.spec | 🟠6 | ⚪ | ⚪ |
+| libdrm.spec | 🟠7 | ⚪ | ⚪ |
+| libfontenc.spec | 🟠7 | ⚪ | ⚪ |
+| libmspack.spec | 🟠5 | 📌 | ⚪ |
+| libnss-ato.spec | 🟠5 | ⚪ | ⚪ |
+| libpciaccess.spec | 🟠7 | ⚪ | ⚪ |
+| libslirp.spec | 🟠7 | ⚪ | ⚪ |
+| libtar.spec | 🟡8 | ⚪ | ⚪ |
+| libtirpc.spec | 🟠7 | ⚪ | ⚪ |
+| libxml2.spec | 🟠7 | 📌 | ⚪ |
+| linux-esx.spec | 🟠5 | ⚪ | 📌 |
+| linux.spec | 🟠5 | ⚪ | 📌 |
+| log4cpp.spec | 🟠6 | ⚪ | ⚪ |
+| lshw.spec | 🟠5 | ⚪ | ⚪ |
+| lxcfs.spec | 🟠7 | 📌 | ⚪ |
+| mdadm.spec | 🟠5 | 📌 | ⚪ |
+| mesa.spec | 🟠7 | 📌 | ⚪ |
+| motd.spec | 🟡8 | ⚪ | ⚪ |
+| mozjs.spec | 🟠7 | 📌 | ⚪ |
+| ncurses.spec | 🟠7 | ⚪ | ⚪ |
+| nss.spec | 🟠7 | ⚪ | ⚪ |
+| open-sans-fonts.spec | 🟠6 | ⚪ | ⚪ |
+| open-vm-tools.spec | 🟠7 | ⚪ | ⚪ |
+| openjdk25.spec | 🟠6 | ⚪ | ⚪ |
+| openssh.spec | 🟠7 | 📌 | ⚪ |
+| pcre.spec | 🟡8 | ⚪ | ⚪ |
+| pcstat.spec | 🟠5 | ⚪ | ⚪ |
+| perftest.spec | 🟠7 | ⚪ | ⚪ |
+| perl-IPC-Run.spec | 🟠7 | ⚪ | ⚪ |
+| perl-List-MoreUtils.spec | 🟠7 | ⚪ | ⚪ |
+| perl-Module-ScanDeps.spec | 🟠5 | ⚪ | ⚪ |
+| perl-URI.spec | 🟠7 | ⚪ | ⚪ |
+| pgaudit15.spec | 🟠7 | 📌 | ⚪ |
+| pgaudit16.spec | 🟠7 | ⚪ | ⚪ |
+| pgaudit17.spec | 🟠7 | ⚪ | ⚪ |
+| polkit.spec | 🟠7 | 📌 | ⚪ |
+| popt.spec | 🟠7 | ⚪ | ⚪ |
+| procps-ng.spec | 🔴3 | 📌 | ⚪ |
+| proto.spec | 🟠5 | ⚪ | ⚪ |
+| python-google-auth.spec | 🟠7 | 📌 | ⚪ |
+| python-installer.spec | 🔴3 | ⚪ | ⚪ |
+| python-pycodestyle.spec | 🟡8 | 📌 | ⚪ |
+| python-pyvmomi.spec | 🟠7 | 📌 | ⚪ |
+| python-ruamel-yaml.spec | 🔴3 | 📌 | ⚪ |
+| python-terminaltables.spec | 🟡8 | 📌 | ⚪ |
+| python-vcs-versioning.spec | 🟠7 | ⚪ | ⚪ |
+| python3-Pygments.spec | 🔴3 | ⚪ | ⚪ |
+| python3-hatchling.spec | 🟠6 | ⚪ | ⚪ |
+| python3-iniconfig.spec | 🔴3 | ⚪ | ⚪ |
+| python3-iniparse.spec | 🔴3 | ⚪ | ⚪ |
+| python3-legacy-cgi.spec | 🔴3 | ⚪ | ⚪ |
+| python3-markupsafe.spec | 🔴3 | ⚪ | ⚪ |
+| python3-msal.spec | 🔴2 | ⚪ | ⚪ |
+| python3-roman-numerals.spec | 🔴3 | ⚪ | ⚪ |
+| python3-trove-classifiers.spec | 🔴3 | ⚪ | ⚪ |
+| python3-wheel.spec | 🔴3 | ⚪ | ⚪ |
+| qemu.spec | 🟠7 | 📌 | ⚪ |
+| raspberrypi-firmware.spec | 🔴1 | ⚪ | ⚪ |
+| re2.spec | 🟠5 | ⚪ | ⚪ |
+| repmgr18.spec | 🔴3 | ⚪ | ⚪ |
+| scons.spec | 🟠7 | 📌 | ⚪ |
+| spirv-headers.spec | 🟠7 | 📌 | ⚪ |
+| spirv-tools.spec | 🟠7 | 📌 | ⚪ |
+| squid.spec | 🔴2 | 📌 | ⚪ |
+| syslinux.spec | 🟠5 | ⚪ | ⚪ |
+| systemd.spec | 🟠5 | 📌 | ⚪ |
+| tcl.spec | 🟠7 | ⚪ | ⚪ |
+| unixODBC.spec | 🟠7 | ⚪ | ⚪ |
+| util-macros.spec | 🟠7 | ⚪ | ⚪ |
+| vulkan-tools.spec | 🟠7 | ⚪ | ⚪ |
+| wal2json18.spec | 🔴3 | ⚪ | ⚪ |
+| wayland-protocols.spec | 🟠7 | ⚪ | ⚪ |
+| wireshark.spec | 🟠7 | ⚪ | ⚪ |
+
+## Issue categories — affected packages
+
+| # | Issue Category | Severity | Packages | Affected specs |
+|---|---|---|---|---|
+| 1 | Source URL blank / macro unresolved (UrlHealth=blank) | 🔴 High | 2 | chromium.spec, raspberrypi-firmware.spec |
+| 2 | URL substitution unfinished | 🔴 High | 3 | alternatives.spec, python3-msal.spec, squid.spec |
+| 3 | Source URL unreachable (UrlHealth=0) | 🔴 High | 17 | cdrkit.spec, filesystem.spec, hyper-v.spec, lasso.spec, procps-ng.spec, python-installer.spec, python-ruamel-yaml.spec, python3-Pygments.spec, python3-iniconfig.spec, python3-iniparse.spec, python3-legacy-cgi.spec, python3-markupsafe.spec, python3-roman-numerals.spec, python3-trove-classifiers.spec, python3-wheel.spec, repmgr18.spec, wal2json18.spec |
+| 5 | Version comparison anomaly (UpdateAvailable contains Warning) | 🟠 Medium | 17 | apparmor.spec, containers-common.spec, dracut.spec, dtb-raspberrypi.spec, ibmtpm.spec, libmspack.spec, libnss-ato.spec, linux-esx.spec, linux.spec, lshw.spec, mdadm.spec, pcstat.spec, perl-Module-ScanDeps.spec, proto.spec, re2.spec, syslinux.spec, systemd.spec |
+| 6 | Source healthy (UrlHealth=200) but UpdateAvailable and UpdateURL blank | 🟠 Medium | 7 | iotop.spec, libbsd.spec, libdisplay-info.spec, log4cpp.spec, open-sans-fonts.spec, openjdk25.spec, python3-hatchling.spec |
+| 7 | Update version detected but UpdateURL/HealthUpdateURL blank (packaging format changed) | 🟠 Medium | 59 | cronie.spec, dos2unix.spec, efivar.spec, erofs-utils.spec, expat.spec, fontconfig.spec, glog.spec, govmomi.spec, icu.spec, kexec-tools.spec, libXScrnSaver.spec, libXau.spec, libXcomposite.spec, libXdamage.spec, libXdmcp.spec, libXext.spec, libXfixes.spec, libXfont2.spec, libXi.spec, libXrandr.spec, libXrender.spec, libXt.spec, libXtst.spec, libcap.spec, libdrm.spec, libfontenc.spec, libpciaccess.spec, libslirp.spec, libtirpc.spec, libxml2.spec, lxcfs.spec, mesa.spec, mozjs.spec, ncurses.spec, nss.spec, open-vm-tools.spec, openssh.spec, perftest.spec, perl-IPC-Run.spec, perl-List-MoreUtils.spec, perl-URI.spec, pgaudit15.spec, pgaudit16.spec, pgaudit17.spec, polkit.spec, popt.spec, python-google-auth.spec, python-pyvmomi.spec, python-vcs-versioning.spec, qemu.spec, scons.spec, spirv-headers.spec, spirv-tools.spec, tcl.spec, unixODBC.spec, util-macros.spec, vulkan-tools.spec, wayland-protocols.spec, wireshark.spec |
+| 8 | Other warnings (VMware internal URL, unmaintained repo, etc.) | 🟡 Low-Medium | 10 | cloud-network-setup.spec, crash.spec, heapster.spec, http-parser.spec, kubernetes-dashboard.spec, libtar.spec, motd.spec, pcre.spec, python-pycodestyle.spec, python-terminaltables.spec |
+
+## Non-issue categories (informational — not counted as issues)
+
+| Category | Marker | Packages | Specs |
+|---|---|---|---|
+| Vendor-pinned subrelease (frozen for a Photon sub-release) | 📌 | 590 | GConf.spec, ImageMagick.spec, Linux-PAM.spec, ModemManager.spec, WALinuxAgent.spec, ansible-community-general.spec, ansible-posix.spec, ansible.spec, ant-contrib.spec, apparmor.spec, apr-util.spec, argon2.spec, asciidoc3.spec, at-spi2-core.spec, atk.spec, audit.spec, aufs-util.spec, autogen.spec, backward-cpp.spec, bash-completion.spec, bash.spec, bazel.spec, bcc.spec, bluez-tools.spec, bluez.spec, bpftrace.spec, bridge-utils.spec, btrfs-progs.spec, bubblewrap.spec, c-ares.spec, calico-bgp-daemon.spec, calico-libnetwork.spec, calico.spec, checkpolicy.spec, chkconfig.spec, chrpath.spec, clang.spec, cloud-init.spec, containerd.spec, cppunit.spec, cracklib.spec, createrepo_c.spec, crun.spec, cryptsetup.spec, ctags.spec, cve-check-tool.spec, cython3.spec, dbus-broker.spec, dbus-python.spec, dbus.spec, dhcp.spec, distcc.spec, docker-buildx.spec, docker-py.spec, docker-pycreds.spec, docker.spec, dool.spec, doxygen.spec, dracut.spec, drpm.spec, ethtool.spec, eventlog.spec, fail2ban.spec, falco.spec, findutils.spec, finger.spec, fio.spec, fontconfig.spec, frr.spec, fsarchiver.spec, gawk.spec, gcc.spec, gdb.spec, gdk-pixbuf.spec, geoip-api-c.spec, git.spec, glib-networking.spec, glib.spec, glibc.spec, glibmm.spec, glslang.spec, gnome-common.spec, gnutls.spec, go.spec, gobgp.spec, gobject-introspection.spec, gpsd.spec, graphene.spec, gst-plugins-bad.spec, gstreamer-plugins-base.spec, gstreamer.spec, gtk-doc.spec, gtk3.spec, harfbuzz.spec, hiredis.spec, hyperscan.spec, ibmtpm.spec, icu.spec, initscripts.spec, inotify-tools.spec, iotop.spec, iproute2.spec, iptables.spec, iputils.spec, itstool.spec, jc.spec, json-glib.spec, jsoncpp.spec, kafka.spec, kubernetes-dashboard.spec, lasso.spec, libbpf.spec, libcap-ng.spec, libcap.spec, libclc.spec, libdaemon.spec, libdnet.spec, libecap.spec, libgudev.spec, libical.spec, libldb.spec, libmbim.spec, libmodulemd.spec, libmspack.spec, libnetfilter_conntrack.spec, libnftnl.spec, libnsl.spec, libnvme.spec, libpsl.spec, libpwquality.spec, librelp.spec, librepo.spec, libselinux-python3.spec, libselinux.spec, libsemanage.spec, libsepol.spec, libsolv.spec, libsoup.spec, libssh2.spec, libtalloc.spec, libtdb.spec, libteam.spec, libtevent.spec, libtraceevent.spec, libtracefs.spec, libvirt.spec, libxcb.spec, libxcrypt.spec, libxml2.spec, lighttpd.spec, linux-esx.spec, linux-rt.spec, linux-tools-90.spec, linux-tools.spec, linux.spec, linuxptp.spec, lldb.spec, llvm.spec, lvm2.spec, lxcfs.spec, lzo.spec, mariadb.spec, mdadm.spec, mercurial.spec, mesa.spec, meson.spec, minimal.spec, mkinitcpio.spec, mozjs.spec, msr-tools.spec, mysql.spec, net-snmp.spec, net-tools.spec, netkit-telnet.spec, nfs-utils.spec, nftables.spec, nginx.spec, nicstat.spec, ninja-build.spec, nodejs.spec, ntp.spec, ntpsec.spec, nvme-cli.spec, openipmi.spec, openscap.spec, openssh.spec, openssl-fips-provider.spec, openssl.spec, openvswitch.spec, ostree.spec, pam_tacplus.spec, pandoc.spec, pango.spec, pgaudit13.spec, pgaudit14.spec, pgaudit15.spec, pgbackrest.spec, photon-os-installer.spec, podman.spec, policycoreutils.spec, polkit.spec, postgresql10.spec, postgresql13.spec, postgresql14.spec, postgresql15.spec, postgresql16.spec, postgresql17.spec, procps-ng.spec, protobuf.spec, pth.spec, pycurl.spec, python-CacheControl.spec, python-ConcurrentLogHandler.spec, python-Js2Py.spec, python-M2Crypto.spec, python-PyHamcrest.spec, python-PyJWT.spec, python-PyNaCl.spec, python-PyYAML.spec, python-Pygments.spec, python-Twisted.spec, python-alabaster.spec, python-altgraph.spec, python-appdirs.spec, python-argparse.spec, python-asn1crypto.spec, python-atomicwrites.spec, python-attrs.spec, python-automat.spec, python-autopep8.spec, python-babel.spec, python-backports.ssl_match_hostname.spec, python-backports_abc.spec, python-bcrypt.spec, python-binary.spec, python-boto.spec, python-boto3.spec, python-botocore.spec, python-cachetools.spec, python-cassandra-driver.spec, python-certifi.spec, python-cffi.spec, python-chardet.spec, python-charset-normalizer.spec, python-click.spec, python-configobj.spec, python-configparser.spec, python-constantly.spec, python-coverage.spec, python-cqlsh.spec, python-cryptography.spec, python-daemon.spec, python-dateutil.spec, python-decorator.spec, python-deepmerge.spec, python-defusedxml.spec, python-distlib.spec, python-distro.spec, python-dnspython.spec, python-docopt.spec, python-docutils.spec, python-ecdsa.spec, python-email-validator.spec, python-etcd.spec, python-ethtool.spec, python-filelock.spec, python-flit-core.spec, python-fuse.spec, python-geomet.spec, python-gevent.spec, python-google-auth.spec, python-graphviz.spec, python-greenlet.spec, python-hatch-fancy-pypi-readme.spec, python-hatch-vcs.spec, python-hatchling.spec, python-hyperlink.spec, python-hypothesis.spec, python-idna.spec, python-imagesize.spec, python-importlib-metadata.spec, python-incremental.spec, python-iniconfig.spec, python-iniparse.spec, python-ipaddress.spec, python-jinja2.spec, python-jmespath.spec, python-jsonpatch.spec, python-jsonpointer.spec, python-jsonschema.spec, python-kubernetes.spec, python-linux-procfs.spec, python-lockfile.spec, python-looseversion.spec, python-lxml.spec, python-mako.spec, python-markupsafe.spec, python-mistune.spec, python-mock.spec, python-more-itertools.spec, python-msgpack.spec, python-ndg-httpsclient.spec, python-netaddr.spec, python-netifaces.spec, python-networkx.spec, python-nocasedict.spec, python-nocaselist.spec, python-ntplib.spec, python-numpy.spec, python-oauthlib.spec, python-packaging.spec, python-pam.spec, python-paramiko.spec, python-pathspec.spec, python-pbr.spec, python-pexpect.spec, python-pg8000.spec, python-pika.spec, python-pkgconfig.spec, python-platformdirs.spec, python-pluggy.spec, python-ply.spec, python-portalocker.spec, python-prettytable.spec, python-prometheus_client.spec, python-prompt_toolkit.spec, python-psutil.spec, python-psycopg2.spec, python-ptyprocess.spec, python-py.spec, python-pyOpenSSL.spec, python-pyasn1-modules.spec, python-pyasn1.spec, python-pycodestyle.spec, python-pycparser.spec, python-pycryptodome.spec, python-pycryptodomex.spec, python-pydantic.spec, python-pyflakes.spec, python-pygobject.spec, python-pyinstaller-hooks-contrib.spec, python-pyinstaller.spec, python-pyjsparser.spec, python-pyparsing.spec, python-pyrsistent.spec, python-pyserial.spec, python-pytest.spec, python-pytz-deprecation-shim.spec, python-pytz.spec, python-pyudev.spec, python-pyvim.spec, python-pyvmomi.spec, python-pywbem.spec, python-requests-oauthlib.spec, python-requests-toolbelt.spec, python-requests-unixsocket.spec, python-requests.spec, python-resolvelib.spec, python-rsa.spec, python-ruamel-yaml.spec, python-s3transfer.spec, python-schedutils.spec, python-scp.spec, python-scramp.spec, python-semantic-version.spec, python-service_identity.spec, python-setuptools-rust.spec, python-setuptools_scm.spec, python-simplejson.spec, python-six.spec, python-snowballstemmer.spec, python-sortedcontainers.spec, python-sphinx.spec, python-sphinxcontrib-applehelp.spec, python-sphinxcontrib-devhelp.spec, python-sphinxcontrib-htmlhelp.spec, python-sphinxcontrib-jsmath.spec, python-sphinxcontrib-qthelp.spec, python-sphinxcontrib-serializinghtml.spec, python-sqlalchemy.spec, python-systemd.spec, python-terminaltables.spec, python-toml.spec, python-tornado.spec, python-typing-extensions.spec, python-tzlocal.spec, python-ujson.spec, python-urllib3.spec, python-vcversioner.spec, python-versioningit.spec, python-virtualenv.spec, python-wcwidth.spec, python-webob.spec, python-websocket-client.spec, python-werkzeug.spec, python-wheel.spec, python-wrapt.spec, python-xmltodict.spec, python-yamlloader.spec, python-zipp.spec, python-zmq.spec, python-zope.event.spec, python-zope.interface.spec, python3-gcovr.spec, python3-pip.spec, python3-pyroute2.spec, python3-setuptools.spec, python3.spec, qemu.spec, rabbitmq-server.spec, rdma-core.spec, redis.spec, repmgr13.spec, repmgr14.spec, repmgr15.spec, rng-tools.spec, rpm-ostree.spec, rpm.spec, rpmdevtools.spec, rrdtool.spec, rsyslog.spec, rt-tests.spec, ruby.spec, rubygem-activesupport.spec, rubygem-addressable.spec, rubygem-async-http.spec, rubygem-async-io.spec, rubygem-async-pool.spec, rubygem-async.spec, rubygem-aws-eventstream.spec, rubygem-aws-partitions.spec, rubygem-aws-sdk-core.spec, rubygem-aws-sdk-kms.spec, rubygem-aws-sdk-s3.spec, rubygem-aws-sdk-sqs.spec, rubygem-aws-sigv4.spec, rubygem-backports.spec, rubygem-builder.spec, rubygem-bundler.spec, rubygem-concurrent-ruby.spec, rubygem-console.spec, rubygem-cool-io.spec, rubygem-declarative.spec, rubygem-dig_rb.spec, rubygem-digest-crc.spec, rubygem-domain_name.spec, rubygem-faraday-net_http.spec, rubygem-faraday.spec, rubygem-ffi-compiler.spec, rubygem-ffi.spec, rubygem-fiber-annotation.spec, rubygem-fiber-local.spec, rubygem-fiber-storage.spec, rubygem-fluent-plugin-concat.spec, rubygem-fluent-plugin-gcs.spec, rubygem-fluent-plugin-kubernetes_metadata_filter.spec, rubygem-fluent-plugin-remote_syslog.spec, rubygem-fluent-plugin-s3.spec, rubygem-fluent-plugin-systemd.spec, rubygem-fluent-plugin-vmware-loginsight.spec, rubygem-fluentd.spec, rubygem-google-apis-core.spec, rubygem-google-apis-iamcredentials_v1.spec, rubygem-google-apis-storage_v1.spec, rubygem-google-cloud-core.spec, rubygem-google-cloud-env.spec, rubygem-google-cloud-errors.spec, rubygem-google-cloud-storage.spec, rubygem-google-logging-utils.spec, rubygem-googleauth.spec, rubygem-highline.spec, rubygem-hpricot.spec, rubygem-http-accept.spec, rubygem-http-cookie.spec, rubygem-http-form_data.spec, rubygem-http-parser.spec, rubygem-http.spec, rubygem-http_parser.rb.spec, rubygem-httpclient.spec, rubygem-i18n.spec, rubygem-io-endpoint.spec, rubygem-io-event.spec, rubygem-io-stream.spec, rubygem-jmespath.spec, rubygem-jsonpath.spec, rubygem-jwt.spec, rubygem-kubeclient.spec, rubygem-libxml-ruby.spec, rubygem-llhttp-ffi.spec, rubygem-lru_redux.spec, rubygem-metrics.spec, rubygem-mime-types-data.spec, rubygem-mime-types.spec, rubygem-mini_mime.spec, rubygem-mini_portile2.spec, rubygem-msgpack.spec, rubygem-multi_json.spec, rubygem-mustache.spec, rubygem-net-http.spec, rubygem-netrc.spec, rubygem-nio4r.spec, rubygem-nokogiri.spec, rubygem-oj.spec, rubygem-optimist.spec, rubygem-os.spec, rubygem-protocol-hpack.spec, rubygem-protocol-http.spec, rubygem-protocol-http1.spec, rubygem-protocol-http2.spec, rubygem-public_suffix.spec, rubygem-rbvmomi.spec, rubygem-rdiscount.spec, rubygem-recursive-open-struct.spec, rubygem-remote_syslog_sender.spec, rubygem-representable.spec, rubygem-rest-client.spec, rubygem-retriable.spec, rubygem-ronn.spec, rubygem-rubyzip.spec, rubygem-serverengine.spec, rubygem-sigdump.spec, rubygem-signet.spec, rubygem-strptime.spec, rubygem-syslog_protocol.spec, rubygem-systemd-journal.spec, rubygem-terminal-table.spec, rubygem-thread_safe.spec, rubygem-timers.spec, rubygem-traces.spec, rubygem-trailblazer-option.spec, rubygem-trollop.spec, rubygem-tzinfo-data.spec, rubygem-tzinfo.spec, rubygem-uber.spec, rubygem-unf.spec, rubygem-unf_ext.spec, rubygem-unicode-display_width.spec, rubygem-unicode-emoji.spec, rubygem-webrick.spec, rubygem-yajl-ruby.spec, runc.spec, runit.spec, rust.spec, samba-client.spec, scons.spec, selinux-policy.spec, selinux-python.spec, semodule-utils.spec, sendmail.spec, setools.spec, sg3_utils.spec, spirv-headers.spec, spirv-llvm-translator.spec, spirv-tools.spec, squid.spec, sssd.spec, stalld.spec, stig-hardening.spec, strace.spec, strongswan.spec, stunnel.spec, suricata.spec, sysdig.spec, syslog-ng.spec, systemd.spec, systemtap.spec, tcpdump.spec, tdnf.spec, telegraf.spec, timescaledb14.spec, timescaledb15.spec, tinycdb.spec, toybox.spec, tpm2-pkcs11.spec, tpm2-pytss.spec, trace-cmd.spec, traceroute.spec, tuna.spec, tuned.spec, util-linux.spec, uwsgi.spec, vim.spec, vsftpd.spec, vulkan-loader.spec, xcb-proto.spec, xerces-c.spec, xmlto.spec, xorg-applications.spec, xorg-fonts.spec, xtrans.spec |
+| VMware-internal Source0 URL (not publicly resolvable) | 🔵 | 15 | abupdate.spec, basic.spec, build-essential.spec, ca-certificates.spec, distrib-compat.spec, grub2-theme.spec, initramfs.spec, minimal.spec, photon-iso-config.spec, photon-release.spec, photon-repos.spec, photon-upgrade.spec, rubygem-async-io.spec, shim-signed.spec, stig-hardening.spec |
+


### PR DESCRIPTION
## Purpose
Optional input that compacts the urlhealth task list to a single spec basename — turns spec-by-spec investigation cycles from ~25 min into ~5 min on PS (~5× speedup; C is similar/larger because it skips ~4 000 git-tag detections). Investigation-only: the resulting `.prn` has one row per selected branch and never feeds the parity verdict.

## Why now
Every spec-by-spec investigation in this loop (M99–M108, Q1) needed a full single-branch CI cycle just to dry-run one spec, because the sandbox proxy blocks local scrape testing. T1 makes the validate-before-merge discipline practical to iterate on — and unblocks Q2 (fontconfig + libXrandr on the contaminated 5.0 branch) without wagering a full 5.0 cycle.

## C
- `pr_types.h`: new `Spec` field on `pr_params_t`.
- `main.c`: `-spec <name>` long-opt + `PR_SINGLE_SPEC` env default (CLI takes precedence); list-compaction in `generate_urlhealth_for_branch` after `parse_directory` (case-insensitive on spec basename); usage text.

## PS
- `photonos-package-report.ps1`: new `[string]$Spec=""` param; one-line filter in `ParseDirectory` (`if ($Spec -and $currentFile.Name -ine $Spec) { return }`).

## Workflows
- `package-report.yml`: `spec` input + EXTRA_ARGS passthrough as `-Spec`.
- `package-report-C.yml`: `spec` input + `PR_SINGLE_SPEC` env passthrough.

## Validation
**C** (hermetic, 3 synthetic specs in `/tmp/t1smoke/photon-3.0/SPECS/`):
- full run → 3 rows {acl, libev, nano}
- `-spec libev.spec` → 1 row {libev}
- `PR_SINGLE_SPEC=nano.spec` → 1 row {nano}

**PS** (run 26598817550, branches=3.0, spec=libev.spec):
- `.prn`: 1 data row (`libev.spec`), 4 min 42 s total wall-clock (vs ~25 min for a comparable full single-branch).

ctest 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)