### PR TITLE
workflow: always run full import — drop seed-only first-run path

### DIFF
--- a/.github/workflows/photon-commits-db.yml
+++ b/.github/workflows/photon-commits-db.yml
@@ -65,14 +65,16 @@ jobs:
           echo "limit=$LIMIT" >> "$GITHUB_OUTPUT"
           echo "limit_source=$SRC" >> "$GITHUB_OUTPUT"
 
-          # Check if this is the first run (no photon-commits-db artifact exists)
+          # Informational: report whether a prior photon-commits-db artifact
+          # exists. The import path runs unconditionally regardless of this
+          # value -- importer.py is idempotent (INSERT OR IGNORE on
+          # UNIQUE(branch, commit_hash)), so re-running on a populated DB
+          # only adds new commits.
           EXISTING=$(gh api /repos/${{ github.repository }}/actions/artifacts \
             --jq '[.artifacts[] | select(.name == "photon-commits-db")] | length' 2>/dev/null || echo 0)
           if [ "$EXISTING" -eq 0 ]; then
-            echo "first_run=true" >> "$GITHUB_OUTPUT"
-            echo "First run detected -- will seed and upload initial database"
+            echo "No prior photon-commits-db artifact found (bootstrap run)"
           else
-            echo "first_run=false" >> "$GITHUB_OUTPUT"
             echo "Existing photon-commits-db artifact(s) found: $EXISTING"
           fi
 
@@ -114,83 +116,25 @@ jobs:
             echo "seeded=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # First run: compress and upload the seed DB, then stop
-      - name: Compress seed database (first run)
-        if: steps.quota.outputs.first_run == 'true' && steps.seed.outputs.seeded == 'true'
-        id: compress_seed
-        run: |
-          echo "Compressing seed database with gzip -9..."
-          tar -cf - photon_commits.db | gzip -9 > photon_commits.db.tar.gz
-          SIZE=$(stat -c%s photon_commits.db.tar.gz)
-          AVAIL=${{ steps.quota.outputs.available }}
-          echo "Compressed size: $(numfmt --to=iec $SIZE)"
-          echo "Available quota: $(numfmt --to=iec $AVAIL)"
-          echo "compressed_size=$SIZE" >> "$GITHUB_OUTPUT"
-          if [ "$SIZE" -gt "$AVAIL" ]; then
-            echo "::error::Compressed DB ($SIZE bytes) exceeds available storage ($AVAIL bytes)"
-            exit 1
-          fi
-
-      - name: Upload seed database (first run)
-        if: steps.quota.outputs.first_run == 'true' && steps.seed.outputs.seeded == 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ env.ARTIFACT_NAME }}
-          path: photon_commits.db.tar.gz
-          retention-days: 90
-
-      - name: Generate seed summary (first run)
-        if: steps.quota.outputs.first_run == 'true' && steps.seed.outputs.seeded == 'true'
-        run: |
-          python3 repo/docsystem/.factory/skills/photon-import/importer.py \
-            --db-path photon_commits.db \
-            --check | tee db-status.json
-
-          python3 << 'SUMMARY_EOF'
-          import json, os
-
-          status = {}
-          if os.path.exists('db-status.json'):
-              status = json.load(open('db-status.json'))
-
-          branches = status.get('branches', {})
-          summary_path = os.environ.get('GITHUB_STEP_SUMMARY', '/dev/null')
-          with open(summary_path, 'a') as s:
-              s.write("# Photon Commits Database (Initial Seed Upload)\n\n")
-              total = sum(b.get('commits', 0) for b in branches.values())
-              s.write(f"**Total commits**: {total:,}  \n")
-              compressed = os.path.getsize('photon_commits.db.tar.gz') if os.path.exists('photon_commits.db.tar.gz') else 0
-              raw = os.path.getsize('photon_commits.db') if os.path.exists('photon_commits.db') else 0
-              s.write(f"**Raw size**: {raw/1024/1024:.0f} MB  \n")
-              s.write(f"**Compressed size**: {compressed/1024/1024:.0f} MB  \n\n")
-              if branches:
-                  s.write("## Branch Status\n\n")
-                  s.write("| Branch | Commits | Latest Commit |\n")
-                  s.write("|--------|---------|---------------|\n")
-                  for name in sorted(branches):
-                      info = branches[name]
-                      latest = (info.get('latest') or 'N/A')[:19]
-                      s.write(f"| {name} | {info.get('commits', 0):,} | {latest} |\n")
-              s.write("\n---\n*Seed database uploaded as `photon-commits-db` artifact (tar.gz).*\n")
-          SUMMARY_EOF
-
-      # First run ends here -- skip import
       - name: Check database status (pre-import)
-        if: steps.quota.outputs.first_run == 'false'
         run: |
           python3 repo/docsystem/.factory/skills/photon-import/importer.py \
             --db-path photon_commits.db \
             --check
 
       - name: Estimate upload size and check quota
-        if: steps.quota.outputs.first_run == 'false'
         id: precheck
         run: |
           # Estimate: compressed DB will be ~22% of raw size (measured ratio)
+          # Use the larger of (current seeded size) and (post-import projection
+          # = seed + typical weekly delta of ~50 MB raw) to avoid an artificially
+          # low estimate that lets a doomed run start. The authoritative size
+          # check still happens after compression below.
           RAW=$(stat -c%s photon_commits.db 2>/dev/null || echo 0)
-          ESTIMATED_COMPRESSED=$((RAW * 22 / 100))
+          PROJECTED_RAW=$((RAW + 52428800))
+          ESTIMATED_COMPRESSED=$((PROJECTED_RAW * 22 / 100))
           AVAIL=${{ steps.quota.outputs.available }}
-          echo "Estimated compressed upload: $(numfmt --to=iec $ESTIMATED_COMPRESSED)"
+          echo "Estimated compressed upload: $(numfmt --to=iec $ESTIMATED_COMPRESSED) (raw projection $(numfmt --to=iec $PROJECTED_RAW))"
           echo "Available quota: $(numfmt --to=iec $AVAIL)"
           if [ "$ESTIMATED_COMPRESSED" -gt "$AVAIL" ]; then
             echo "::error::Estimated upload ($ESTIMATED_COMPRESSED bytes) exceeds available storage ($AVAIL bytes). Clean up old artifacts first."
@@ -199,7 +143,6 @@ jobs:
           echo "Quota check passed"
 
       - name: Import commits
-        if: steps.quota.outputs.first_run == 'false'
         run: |
           BRANCHES="${{ github.event.inputs.branches || '3.0 4.0 5.0 6.0 common master' }}"
           SINCE="${{ github.event.inputs.since_date }}"
@@ -212,7 +155,6 @@ jobs:
           python3 repo/docsystem/.factory/skills/photon-import/importer.py $ARGS
 
       - name: Check database status (post-import)
-        if: steps.quota.outputs.first_run == 'false'
         id: post
         run: |
           python3 repo/docsystem/.factory/skills/photon-import/importer.py \
@@ -220,7 +162,6 @@ jobs:
             --check | tee db-status.json
 
       - name: Compress database
-        if: steps.quota.outputs.first_run == 'false'
         run: |
           echo "Compressing database with gzip -9..."
           tar -cf - photon_commits.db | gzip -9 > photon_commits.db.tar.gz
@@ -233,7 +174,7 @@ jobs:
           fi
 
       - name: Generate summary
-        if: always() && steps.quota.outputs.first_run == 'false'
+        if: always()
         run: |
           python3 << 'SUMMARY_EOF'
           import json, os
@@ -265,7 +206,6 @@ jobs:
           SUMMARY_EOF
 
       - name: Upload photon_commits.db
-        if: steps.quota.outputs.first_run == 'false'
         uses: actions/upload-artifact@v7
         with:
           name: ${{ env.ARTIFACT_NAME }}


### PR DESCRIPTION
## What

Make `photon-commits-db.yml` always run the full seed → import → upload pipeline. Drop the `first_run`-gated seed-only branch.

## Why

Run [26385301486](https://github.com/dcasota/photonos-scripts/actions/runs/26385301486) produced a 108 MB artifact (seed only, ~17K commits) because no prior `photon-commits-db` artifact existed → workflow entered the first-run path, which skips `Import commits`.

Run [26015422320](https://github.com/dcasota/photonos-scripts/actions/runs/26015422320) produced the expected 352 MB artifact (~46K commits) via the normal import path.

The `importer.py` is idempotent (INSERT OR IGNORE on UNIQUE(branch, commit_hash)), so always running the import — bootstrap or not — produces the same full DB regardless of prior-artifact state. The first-run path is therefore redundant and silently regresses output when artifacts get cleaned up.

## Changes

- Removed `if: steps.quota.outputs.first_run == 'false'` gate from `Check pre-import`, `Estimate upload`, `Import commits`, `Check post-import`, `Compress`, `Generate summary`, `Upload`.
- Deleted the three `(first run)` duplicates: `Compress seed database`, `Upload seed database`, `Generate seed summary`.
- The artifact-count check now logs informationally only (no consumers).
- Pre-import quota estimate adds a 50 MB raw-delta projection before applying the 22% ratio, so the pre-check doesn't green-light a run that grows past quota after import. The post-compress hard check (`SIZE > AVAIL → exit 1`) still gates the actual upload.

## Test plan

- [ ] After merge, trigger via `workflow_dispatch` and confirm the artifact is ~370 MB.
- [ ] Manually delete all `photon-commits-db` artifacts, trigger again, confirm the artifact is still ~370 MB (the regression scenario).
- [ ] Confirm the artifact's DB has ~46K commits via `sqlite3 photon_commits.db 'SELECT COUNT(*) FROM commits;'`.
