### PR TITLE
libaio: fix Source0Lookup macro typo {version} → %{version}

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -795,7 +795,7 @@ lapack.spec,https://github.com/Reference-LAPACK/lapack/archive/refs/tags/v%{vers
 lasso.spec,https://dev.entrouvert.org/lasso/lasso-%{version}.tar.gz
 less.spec,https://github.com/gwsw/less/archive/refs/tags/v%{version}.tar.gz,https://github.com/gwsw/less.git
 leveldb.spec,https://github.com/google/leveldb/archive/refs/tags/v%{version}.tar.gz,https://github.com/google/leveldb.git
-libaio.spec,https://pagure.io/libaio/archive/libaio-{version}/libaio-libaio-{version}.tar.gz,https://pagure.io/libaio.git
+libaio.spec,https://pagure.io/libaio/archive/libaio-%{version}/libaio-libaio-%{version}.tar.gz,https://pagure.io/libaio.git
 libarchive.spec,https://github.com/libarchive/libarchive/archive/refs/tags/v%{version}.tar.gz,https://github.com/libarchive/libarchive.git
 libatomic_ops.spec,https://github.com/ivmai/libatomic_ops/archive/refs/tags/v%{version}.tar.gz,https://github.com/ivmai/libatomic_ops.git
 libbpf.spec,https://github.com/libbpf/libbpf/archive/refs/tags/v%{version}.tar.gz,https://github.com/libbpf/libbpf.git


### PR DESCRIPTION
## Root cause (autonomous-cycle spec #1)
The Source0LookupData row for `libaio.spec` (L798) was the **only** entry among ~800 that used `{version}` (no `%` prefix). PS's standard `%{...}` substitution leaves it literal; the modified Source0 carries `{version}` through detection, triggering C's M102 `substitution_unfinished` sentinel on all 7 branches.

PS still emitted `col4=200` via the L2531 clone-tag override (urlhealth=200 set after `git tag -l` succeeds, bypassing the later L2627 substitution_unfinished check). C strictly applies M102 → `cat2` flagged in the classifier.

Strict columns (col5 / col6 / col10) already matched between PS and C even pre-fix, so this was a **soft col4 + cat2 misclassification**, not a real divergence.

## Fix
Change L798 from `{version}` → `%{version}`. The `extract-source0-lookup.sh + csv-to-c-string.sh` CMake chain auto-regenerates the embedded `source0_lookup_data.h`, so both PS and C consume the corrected row.

## Validation (T1 PS run 26644749360 + T1 C run 26644760822, branch 3.0)
PS and C now produce identical strict-column output:

| col | PS | C |
|---|---|---|
| 3 (modified Source0) | `…/archive/libaio-0.3.110/libaio-libaio-0.3.110.tar.gz` | same ✓ |
| 5 (UpdateAvailable) | `0.3.113` | same ✓ |
| 6 (UpdateURL) | `…/archive/libaio-0.3.113/libaio-libaio-0.3.113.tar.gz` | same ✓ |
| 7 (HealthUpdateURL) | `200` | same ✓ |
| 10 (DownloadName) | `libaio-libaio-0.3.113.tar.gz` | same ✓ |
| 4 (UrlHealth, **soft**) | `200` (L2531 clone-tag override) | `404` (probe of resolved URL) |

cat2 misclassification cleared. col4 soft diff is the M102-vs-PS-L2531 mismatch class shared with apache-tomcat (separate spec, separate PR).

**Dual-goal bonus:** col6 + col10 move from the dead `fedorahosted.org` URL to the canonical `pagure.io` URL — vendor-info-quality improvement.

Single Source0Lookup row touched → zero blast radius outside libaio.spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)