### PR TITLE
phase-M task M112: urlhealth no-UA retry on 4xx (PS-parity for UA-gated servers)

### DIFF
--- a/photonos-package-report/photonos-package-report/src/urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/urlhealth.c
@@ -86,8 +86,11 @@ static int needs_browser_fallback(const char *url)
     return 0;
 }
 
-static int curl_head(const char *url, long timeout_ms,
-                     struct curl_slist *headers, long *out_status)
+/* Pass user_agent = NULL to suppress the User-Agent header (mirrors .NET
+ * HttpWebRequest's default behaviour, which PS's urlhealth relies on). */
+static int curl_head_ua(const char *url, long timeout_ms,
+                        struct curl_slist *headers, const char *user_agent,
+                        long *out_status)
 {
     CURL *c = curl_easy_init();
     if (!c) return -1;
@@ -95,7 +98,7 @@ static int curl_head(const char *url, long timeout_ms,
     curl_easy_setopt(c, CURLOPT_NOBODY,        1L);          /* HEAD */
     curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION,1L);
     curl_easy_setopt(c, CURLOPT_TIMEOUT_MS,    timeout_ms);
-    curl_easy_setopt(c, CURLOPT_USERAGENT,     "photonos-package-report/C");
+    if (user_agent) curl_easy_setopt(c, CURLOPT_USERAGENT, user_agent);
     curl_easy_setopt(c, CURLOPT_WRITEFUNCTION, discard_cb);
     if (headers) curl_easy_setopt(c, CURLOPT_HTTPHEADER, headers);
 
@@ -114,9 +117,27 @@ int urlhealth(const char *checkurl)
     if (checkurl == NULL || checkurl[0] == '\0') return 0;
 
     long status = 0;
-    int  rc     = curl_head(checkurl, 120000, NULL, &status);
+    int  rc     = curl_head_ua(checkurl, 120000, NULL,
+                               "photonos-package-report/C", &status);
     if (rc == 0 && status >= 200 && status < 400) {
         return (int)status;
+    }
+
+    /* M112: some upstream HTTP servers (e.g. ftp.altlinux.org) gate by
+     * User-Agent and 404 our default "photonos-package-report/C" while
+     * happily serving the file to a request with no UA header at all.
+     * PS's HttpWebRequest sends no UA by default, so PS sees 200 where
+     * C sees 404 (kbd .tar.bz2 + a few siblings). Retry once with no UA
+     * before declaring the URL dead — matches PS's primary path. Only
+     * fires when the default HEAD returned 4xx/5xx, so URLs that work
+     * with the default UA are unaffected (one extra HEAD on a true 404,
+     * but additive; no false 200 can sneak through). */
+    if (rc == 0 && status >= 400 && status < 600) {
+        long status2 = 0;
+        int rc2 = curl_head_ua(checkurl, 120000, NULL, NULL, &status2);
+        if (rc2 == 0 && status2 >= 200 && status2 < 400) {
+            return (int)status2;
+        }
     }
 
     /* PS L 1480: fallback for netfilter/ftp URLs. */


### PR DESCRIPTION
## Summary

C's default `urlhealth()` HEAD sent `User-Agent: photonos-package-report/C` unconditionally. ftp.altlinux.org (and likely similar Linux-mirror hosts) gates by UA and **404s** our agent string while serving 200 to a request with no UA header. PS's `HttpWebRequest` sends no UA by default, so PS sees 200 where C sees 404 — masking the M81 ext-fallback in the M91 cascade.

**Fix**: when the default HEAD returns 4xx/5xx, retry once with no User-Agent header. If that returns 200/3xx, use it. Additive — URLs that already 200 with the default UA are unaffected (no second probe).

## Investigation data (run 26654847034)

Direct probe of `http://ftp.altlinux.org/pub/people/legion/kbd/kbd-2_10_0.tar.bz2`:

```
HEAD ua=''                                       -> 200
HEAD ua='photonos-package-report/C'              -> 404
HEAD ua='curl/7.88.0'                            -> 404
HEAD ua='Mozilla/5.0 (Windows NT 10.0; ...)'     -> 200
HEAD ua='Mozilla/4.0 (compatible; MSIE 6.0)'     -> 200
HEAD ua='Wget/1.21'                              -> 404
```

PS uses `.NET HttpWebRequest` → no UA → 200. C's default UA → 404.

## Validation (T1 kbd dispatch 26655600445, all 7 branches with fix)

**Before** (M111-full run 26645715897):
```
kbd.spec,...,2.2.0.tar.gz,404,2.10.0,,,kbd,,,Warning: Manufacturer may changed version packaging format.,
```

**After** (this PR):
```
kbd.spec,...,2.2.0.tar.gz,404,2.10.0,http://ftp.altlinux.org/.../kbd-2_10_0.tar.bz2,200,kbd,,kbd-2_10_0.tar.bz2,,
```

Matches PS: col6 + col7 + col10 align; warning cleared on all branches.

## Target impact (C-only specs from post-M111 classifier)

- **kbd** (7 branches): col6 + col10 + warning all flip to PS-aligned (verified)
- **newt** (6.0): likely same altlinux UA gating (to be re-verified via full snapshot)
- **timescaledb14** (6.0+main), **logrotate** (4 branches): cascade may now reach 200 on retry; verify

No expected regressions: the retry only fires on 4xx/5xx, so currently-successful HEADs are untouched.

## Test plan

- [x] `ctest --test-dir build` 13/13 green
- [x] T1 kbd dispatch shows all 7 branches now produce non-empty col6 + col10, no warning
- [x] Build green
- [ ] Parity gate + full snapshot validation (auto-triggers on merge → PS workflow_run cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)