### PR TITLE
phase-M task M113: add timescaledb14 to gh_tag_normalize_allowed

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -218,7 +218,7 @@ static int gh_tag_normalize_allowed(const char *spec)
 {
     static const char *const list[] = {
         "valkey.spec", "liblognorm.spec", "rpm-sequoia.spec", "tinydir.spec",
-        "timescaledb15.spec", "timescaledb16.spec",
+        "timescaledb14.spec", "timescaledb15.spec", "timescaledb16.spec",
         "timescaledb17.spec", "timescaledb18.spec", NULL,
     };
     for (int i = 0; list[i]; i++)


### PR DESCRIPTION
## Summary

Single-string addition. `gh_tag_normalize_allowed` covered timescaledb15-18 but not 14 — same github repo (timescale/timescaledb), same tag format (bare `2.27.1`, no name prefix, no `v` prefix). Without this, C's col6/col10 stay empty + packaging-format warning on 6.0 and main while PS shows the right URL.

## Diff vs PS (run 26681361589)

**6.0**
```
PS: ...,/archive/refs/tags/2.19.2.tar.gz,200,2.27.1,...,/archive/refs/tags/2.27.1.tar.gz,200,timescaledb,<SHA>,timescaledb-2.27.1.tar.gz,,
C:  ...,/archive/refs/tags/timescaledb-2.19.2.tar.gz,404,2.27.1,,,timescaledb,,,Warning: Manufacturer may changed version packaging format.,
```

## Test plan

- [x] `ctest --test-dir build` 13/13 green
- [x] Build green
- [ ] Parity gate
- [ ] Full snapshot validation (auto-triggers post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)