### PR TITLE
phase-M task M115: detection-success col4="200" override applies unconditionally

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -2855,16 +2855,20 @@ char *check_urlhealth(pr_task_t                       *task,
     const char *health_field;
     if (subst_unfinished && !health_overridden_200) {
         health_field = "substitution_unfinished";
+    } else if (health_overridden_200) {
+        /* M111 + M115: PS L2531 (clone-tag success) and L4408 (generic-
+         * scrape success) set `$urlhealth="200"` UNCONDITIONALLY — not
+         * just when the modified Source0 had an unresolved macro brace.
+         * M111 initially only honoured the override on the subst_unfinished
+         * path; M115 extends it to the always-case so col4 mirrors PS for
+         * every spec whose clone-tag/scrape detection succeeded even when
+         * the templated Source0 URL itself 404s (containers-common,
+         * gst-plugins-bad, libnss-ato, pcstat, re2, dtb-raspberrypi,
+         * libmspack, etc.). */
+        health_field = "200";
     } else {
-        /* M111: when subst_unfinished AND a detection path set the
-         * "PS L2531/L4408 override" flag, mirror PS by emitting the
-         * literal "200". Otherwise emit the numeric urlhealth result. */
-        if (subst_unfinished && health_overridden_200) {
-            health_field = "200";
-        } else {
-            snprintf(health_num, sizeof health_num, "%d", health);
-            health_field = health_num;
-        }
+        snprintf(health_num, sizeof health_num, "%d", health);
+        health_field = health_num;
     }
     if (emit_multi_sha) {
         rc = asprintf(&out,


### PR DESCRIPTION
## Summary

PS L2531 sets `\$urlhealth=\"200\"` unconditionally after a successful `git tag -l`, and L4408 does the same after a successful generic-else HTML scrape. M111 added a `health_overridden_200` flag for both detection paths but only consulted it on the `subst_unfinished` col4 emission branch — the always-case still reported the numeric urlhealth result.

The post-M114 classifier (run 26682894498) showed 7+ PS-only clusters that all share the same fingerprint:
- PS col4=200, col5 = warning text (cat5) or empty (cat6/cat7)
- C col4=404, identical col5 (so the detection side already matches PS), but C falls out of cat3/cat5 buckets that require col4=200

These are: `containers-common` (6 branches), `gst-plugins-bad` (5), `libnss-ato` (7), `pcstat` (7), `re2` (6), `dtb-raspberrypi` (6), `libmspack` (7), plus several smaller clusters.

## Fix

Extend M111 so `health_overridden_200` sets col4=\"200\" regardless of `subst_unfinished`. The `subst_unfinished && !override` case still emits the \"substitution_unfinished\" sentinel (M102 behaviour preserved).

```c
if (subst_unfinished && !health_overridden_200) {
    health_field = \"substitution_unfinished\";
} else if (health_overridden_200) {
    health_field = \"200\";          // M115
} else {
    snprintf(health_num, sizeof health_num, \"%d\", health);
    health_field = health_num;
}
```

## Diff sample (containers-common master, run 26682894498)

```
PS: ...,/archive/refs/tags/v4.tar.gz,200,Warning: ... 4 is higher than detected latest version 1.0.1 .,,,containers-common,,,,
C:  ...,/archive/refs/tags/v4.tar.gz,404,Warning: ... 4 is higher than detected latest version 1.0.1 .,,,containers-common,,,,
                                       ^^^ only diff
```

## Risk

A spec whose URL is genuinely dead but whose clone-tag still finds an old tag now reports col4=200 in C — but PS already does this. Net: zero regression vs PS; the URL-dead-but-tag-alive divergence is a parent-PS bug documented in the dual-goal memory.

## Test plan

- [x] `ctest --test-dir build` 13/13 green
- [x] Build green
- [ ] Parity gate
- [ ] Full snapshot validation (auto-triggers post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)