### PR TITLE
phase-M task M116: mirror health_overridden_200 into `health` for downstream consumers

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1798,8 +1798,12 @@ char *check_urlhealth(pr_task_t                       *task,
                                            &names, &n) == 0 && n > 0) {
                         /* M111: mirror PS L2531/L3869 — successful `git
                          * tag -l` sets `$urlhealth = "200"` before any
-                         * version compare. */
+                         * version compare.
+                         * M116: also mirror that into the in-memory
+                         * `health` so downstream consumers (L2828 clear
+                         * logic, gate checks) see the PS-equivalent state. */
                         health_overridden_200 = 1;
+                        health = 200;
                         /* Apply replaceStrings from Source0Lookup row
                          * (PS L 2151). For clang/llvm specs this
                          * strips the `llvmorg-` prefix off tag names
@@ -2513,8 +2517,9 @@ char *check_urlhealth(pr_task_t                       *task,
              * returns non-empty hrefs, PS sets `$urlhealth = "200"`
              * (bypassing L2627 substitution_unfinished). Applies only to
              * this generic branch; the _eligible branches above (moz,
-             * gh, sf, ao, …) have their own per-path PS behaviour. */
-            if (scrape_ok && n > 0) health_overridden_200 = 1;
+             * gh, sf, ao, …) have their own per-path PS behaviour.
+             * M116: also mirror into `health` (see clone-tag site). */
+            if (scrape_ok && n > 0) { health_overridden_200 = 1; health = 200; }
         }
         if (scrape_ok && n > 0) {
             if (!used_atom && !used_sf && !used_gh && !used_moz && !used_gnome) {


### PR DESCRIPTION
## Summary

M115 made the col4 emission honor `health_overridden_200`, but the in-memory `health` variable kept its raw urlhealth-probe value. Downstream PS-equivalent consumers in the same function still read `health` directly — most notably the L2828 stale-Source0 clear:

```c
if (state.UpdateAvailable == "" && health != 200) {
    state.Source0 = "";   // clears col3 even though col4 was overridden to 200
}
```

PS reads `\$urlhealth` (set to "200" by the L2531/L4408 override), so PS does NOT clear. C did, blanking col3.

## Symptom (cbindgen 5.0 / main, run 26684734410)

```
PS:  ...,/archive/refs/tags/v0.29.2.tar.gz,200,0.29.3,/archive/refs/tags/v0.29.3.tar.gz,200,cbindgen,<SHA>,cbindgen-0.29.3.tar.gz,,
C:   ...,                                  ,200,         ,                                ,    ,cbindgen,    ,                     ,,
                                            ^^^               ^^^                                                            ^^^ all cleared by L2828
```

## Fix

At both override sites (M111 clone-tag success + generic-scrape success), set `health = 200` alongside the flag:

```c
health_overridden_200 = 1;
health = 200;          // M116
```

## Risk

Additive: only fires when the override was already valid. Specs without a clone-tag/scrape success path don't enter these blocks at all. Same risk profile as M115 — keeps C aligned with PS's `\$urlhealth` mutations.

## Test plan

- [x] `ctest --test-dir build` 13/13 green
- [x] Build green
- [ ] Parity gate
- [ ] Full snapshot validation (auto-triggers post-merge); expect cbindgen 5.0+main col3+col5+col6+col10 populated, matching PS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)