### PR TITLE
phase-M task M119: fix jdk.c leading-dot parse (strtok_r ate empty tokens)

### DIFF
--- a/photonos-package-report/photonos-package-report/src/jdk.c
+++ b/photonos-package-report/photonos-package-report/src/jdk.c
@@ -80,21 +80,35 @@ static void parse_one(const char *version, int default_major, const char *filter
     char *build_part   = NULL;
     if (plus) { *plus = '\0'; build_part = plus + 1; }
 
-    /* PS L 1675-1690: parse dotted version or bare major. */
+    /* PS L 1675-1690: parse dotted version or bare major.
+     *
+     * M119: PS uses [string].Split(".") which preserves empty tokens
+     * (".0.32" → ["", "0", "32"]). strtok_r collapses consecutive
+     * delimiters and skips leading ones (".0.32" → ["0", "32"]),
+     * shifting the slot mapping so the version-leading-dot case (which
+     * is the common one because the filter prefix ate "jdk-11" off
+     * "jdk-11.0.32+2") silently wrote major=0 then minor=32. The
+     * comparator then ranked "jdk-11+28" (parses as 11.0.0+28) ABOVE
+     * "jdk-11.0.32+2" (parses as 0.32.0+2). Replace strtok_r with a
+     * manual split that mirrors .Split(".") exactly. */
     if (strchr(version_part, '.') != NULL) {
-        /* Dotted: 11.0.28 etc. */
-        char *save = NULL;
-        char *tok = strtok_r(version_part, ".", &save);
-        int   idx = 0;
-        while (tok) {
-            size_t tlen = strlen(tok);
-            if (all_digit(tok, tlen)) {
-                int v = parse_int(tok);
+        const char *cur = version_part;
+        int idx = 0;
+        while (1) {
+            const char *dot = strchr(cur, '.');
+            size_t tlen = dot ? (size_t)(dot - cur) : strlen(cur);
+            if (tlen > 0 && all_digit(cur, tlen)) {
+                char buf[32];
+                size_t cl = tlen < sizeof buf - 1 ? tlen : sizeof buf - 1;
+                memcpy(buf, cur, cl);
+                buf[cl] = '\0';
+                int v = parse_int(buf);
                 if      (idx == 0) out->major = v;
                 else if (idx == 1) out->minor = v;
                 else if (idx == 2) out->patch = v;
             }
-            tok = strtok_r(NULL, ".", &save);
+            if (!dot) break;
+            cur = dot + 1;
             idx++;
         }
     } else if (all_digit(version_part, strlen(version_part))) {


### PR DESCRIPTION
## Summary

`parse_one` in `src/jdk.c` used `strtok_r(\"...\", \".\")` to split the dotted version. `strtok_r` collapses consecutive delimiters and skips leading ones, so for the common case where the filter prefix `\"jdk-11\"` is stripped from a tag like `jdk-11.0.32+2-ga` (leaving `version_part = \".0.32\"`), strtok_r returned `[\"0\", \"32\"]` — only 2 tokens — and assigned `major=0`, `minor=32` instead of (default major=11), minor=0, patch=32.

PS uses `[string].Split(\".\")` which preserves empty tokens: `.0.32` → `[\"\", \"0\", \"32\"]`. The first empty slot leaves major at the default (MajorRelease=11), then minor=0, patch=32 fall correctly into place.

The `cmp_jdk_desc` descending comparator then ranked `jdk-11+28` (parses as `major=11, build=28`) **above** `jdk-11.0.32+2-ga` (parses as `major=0, minor=32, build=2, is_ga=1`) — so M117 wired the right function but it still returned the wrong winner.

## Diff (run 26689248789, openjdk21 master)

```
PS:  ...,200,21.0.12+4,/archive/refs/tags/jdk-21.0.12+4.tar.gz,200,openjdk,<SHA>,jdk-21.0.12+4.tar.gz,,
C:   ...,200,Warning: openjdk21.spec Source0 version 21.0.6 is higher than detected latest version 21-ga .,,,openjdk,,,,
                                                                                                ^^^^ wrong winner (21-ga ranked above 21.0.12+4)
```

## Fix

Replace `strtok_r` with a manual split that walks `cur..dot..end` and preserves empty tokens, mirroring PS `Split(\".\")` exactly:

```c
const char *cur = version_part;
int idx = 0;
while (1) {
    const char *dot = strchr(cur, '.');
    size_t tlen = dot ? (size_t)(dot - cur) : strlen(cur);
    if (tlen > 0 && all_digit(cur, tlen)) {
        // ... assign major/minor/patch by idx ...
    }
    if (!dot) break;
    cur = dot + 1;
    idx++;
}
```

Now `.0.32` produces idx=0 (empty, no assignment → major stays at default 11), idx=1 (\"0\" → minor=0), idx=2 (\"32\" → patch=32).

## Target impact

openjdk11 + openjdk17 (7 branches each) + openjdk21 (6 branches): col5 flips from broken \"Warning: ... <bad-version>\" to a proper `11.0.X+Y` / `17.0.X+Y` / `21.0.X+Y` form, col6/col10 follow through the M91 cascade.

## Test plan

- [x] `ctest --test-dir build` 13/13 green
- [x] Build green
- [ ] Parity gate
- [ ] Full snapshot validation post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)