### PR TITLE
phase-M task M121: pr_version_compare Rule 8 only consults str_value for PR_VER_STRING

### DIFF
--- a/photonos-package-report/photonos-package-report/src/version.c
+++ b/photonos-package-report/photonos-package-report/src/version.c
@@ -453,11 +453,22 @@ int pr_version_compare(const char *a, const char *b)
     }
     /* Rule 8: String fallback — compare .Value as strings. PS uses
      *   $v1.Value -gt $v2.Value
-     * which on mixed types coerces both via the left-hand operand. We
-     * use the raw `str_value` we always kept. */
+     * where .Value is set ONLY for the String type (the other-type
+     * hashtables hold .Components / .Date / .Value-as-int-or-double).
+     * For non-STRING types, $v.Value is $null and PS coerces it to "".
+     *
+     * M121: previously we read `str_value` for every type (we always
+     * keep it as a raw input copy), which made Rule 8 do a lexicographic
+     * strcmp on the original inputs. For STANDARD vs STRING (e.g.
+     * "21.0.6" STANDARD vs "21.0.12+4" STRING for openjdk21), that
+     * compared "21.0.6" vs "21.0.12+4" at byte 5 and returned -1 (latest
+     * < Source0), triggering a bogus packaging-format warning. PS
+     * compares "21.0.12+4" vs "" → +1 (latest > Source0, newer detected).
+     * Mirror that exactly: only consult str_value for PR_VER_STRING. */
     {
-        int c = strcmp(v1.str_value ? v1.str_value : "",
-                       v2.str_value ? v2.str_value : "");
+        const char *s1 = (v1.type == PR_VER_STRING && v1.str_value) ? v1.str_value : "";
+        const char *s2 = (v2.type == PR_VER_STRING && v2.str_value) ? v2.str_value : "";
+        int c = strcmp(s1, s2);
         if      (c > 0) result = 1;
         else if (c < 0) result = -1;
         else            result = 0;


### PR DESCRIPTION
## Summary

PS Rule 8 compares `\$v1.Value -gt \$v2.Value` where `.Value` is set ONLY for the String type. For non-STRING types (StandardVersion / Integer / Decimal / DateVersion / VersionDate), `\$v.Value` is `\$null` and PS coerces it to "" in the string-comparison context.

C's `pr_version_parse` always populated `str_value = strdup(s)` (raw input copy), so Rule 8 read both sides verbatim and did a lexicographic strcmp on the originals.

## Symptom

```
pr_version_compare(\"21.0.12+4\", \"21.0.6\"):
  v1 = STRING,   str_value = \"21.0.12+4\"
  v2 = STANDARD, str_value = \"21.0.6\"
  PS Rule 8: \"21.0.12+4\" > \$null → coerces null to \"\" → +1
  C  Rule 8: strcmp(\"21.0.12+4\", \"21.0.6\") → -1 (because '1' < '6' at byte index 5)
```

→ rc=-1 → caller emits the spurious `Source0 version 21.0.6 is higher than detected latest version 21.0.12+4` warning even though Get-HighestJdkVersion correctly found the latest. Surfaced in run 26690726041 (post-M120), where openjdk17 3.0 + openjdk21 6.0/dev/master kept the warning even though M117+M119 had the right tag.

## Fix

Only read `str_value` when `type == PR_VER_STRING`; otherwise treat as empty. Matches PS exactly.

## Risk

No other rule references `str_value`, so the change is strictly scoped to Rule 8 — the mixed-type fallback. STANDARD-vs-STANDARD, INT-vs-INT, etc. paths are unchanged.

## Test plan

- [x] `ctest --test-dir build` 13/13 green
- [x] Build green
- [ ] Parity gate
- [ ] Full snapshot validation — expect openjdk17 3.0 + openjdk21 (6.0/dev/master) to drop their packaging-format warning, col5 stays at the clean detected version, no col6/col10 churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)