### PR TITLE
phase-M task M124: fix M122 path derivation — thread working_dir to check_urlhealth

### DIFF
--- a/photonos-package-report/photonos-package-report/include/pr_check_urlhealth.h
+++ b/photonos-package-report/photonos-package-report/include/pr_check_urlhealth.h
@@ -43,9 +43,16 @@
  * created — mirrors PS PR #84 (PS L 2376-2392, 3665-3679, 4020-4034).
  * Pass NULL/"" to disable. Tag detection falls through cleanly to
  * the no-`.git` path. */
+/* M124: `working_dir` is the operator's --workingDir (root of the
+ * photon-<branch>/SPECS trees). Used ONLY by the M122 ModifySpecFile
+ * port to locate the source spec file and place SPECS_NEW_C/ alongside.
+ * The other paths (clone_root, exclusion_list) already point at the
+ * upstream-clones tree which can sit under a different root. Pass NULL
+ * to disable the modify-spec side-effect (mirrors PR_MODIFY_SPEC unset). */
 char *check_urlhealth(pr_task_t                       *task,
                       const pr_source0_lookup_table_t *lookup_table,
                       const char                      *clone_root,
-                      const char                      *exclusion_list);
+                      const char                      *exclusion_list,
+                      const char                      *working_dir);
 
 #endif /* PR_CHECK_URLHEALTH_H */

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -1624,7 +1624,8 @@ static char *version_cut(const char *task_version)
 char *check_urlhealth(pr_task_t                       *task,
                       const pr_source0_lookup_table_t *lookup_table,
                       const char                      *clone_root,
-                      const char                      *exclusion_list)
+                      const char                      *exclusion_list,
+                      const char                      *working_dir)
 {
     if (task == NULL || task->Spec == NULL) return NULL;
 
@@ -3029,69 +3030,72 @@ char *check_urlhealth(pr_task_t                       *task,
      */
     const int emit_multi_sha = getenv("PR_EMIT_MULTI_SHA") != NULL;
 
-    /* M122 / PS L 5219-5222: when an update was detected AND the
+    /* M122 / M124 / PS L 5219-5222: when an update was detected AND the
      * candidate URL HEAD'd 200, PS calls ModifySpecFile to rewrite the
      * spec file under SPECS_NEW/<Name>/. C mirrors that under
      * SPECS_NEW_C (parallel dir so PS's authoritative output stays
      * byte-stable for the 90-day-green journal). Gated by env var
      * PR_MODIFY_SPEC — default OFF for parity-safe rollout.
      *
-     * Source/upstream dirs derived from clone_root: clone_root is
-     * "<wd>/<photonDir>/clones"; strip "/clones" to get the photonDir
-     * prefix root (== upstreams_dir for the writes here). The PS
-     * WorkingDir vs UpstreamsDir distinction maps to the same root in
-     * the C workflow's filesystem layout (parity-reconstruct.sh
-     * collapses them under PARITY_CACHE_ROOT). */
+     * M124: `working_dir` carries the operator's --workingDir (root of
+     * the photon-<branch>/SPECS trees) directly. Earlier M122 tried to
+     * derive it from clone_root but parity-reconstruct.sh puts the
+     * SPECS trees under <WDIR>/photon-<branch>/ while the upstream
+     * clones live under <WDIR>/photon-upstreams/photon-<branch>/clones
+     * — those roots differ, so the derivation produced the wrong path
+     * and modify_spec couldn't find the source spec file. The photonDir
+     * still comes from clone_root because that's where the per-branch
+     * leaf is unambiguous. */
     if (getenv("PR_MODIFY_SPEC") != NULL
         && state.HealthUpdateURL && strcmp(state.HealthUpdateURL, "200") == 0
         && state.UpdateAvailable && state.UpdateAvailable[0]
         && strstr(state.UpdateAvailable, "Warning:") == NULL
         && strstr(state.UpdateAvailable, "(same version)") == NULL
         && strstr(state.UpdateAvailable, "Info:") == NULL
+        && working_dir && working_dir[0]
         && clone_root && clone_root[0]) {
         const char *suffix = "/clones";
         size_t crl = strlen(clone_root);
         size_t sl  = strlen(suffix);
         if (crl > sl && strcmp(clone_root + crl - sl, suffix) == 0) {
-            char base_dir[1024];
-            size_t base_len = crl - sl;
-            if (base_len < sizeof base_dir) {
-                memcpy(base_dir, clone_root, base_len);
-                base_dir[base_len] = '\0';
-                /* base_dir is "<root>/<photonDir>". Split off photonDir. */
-                char *last = strrchr(base_dir, '/');
-                if (last) {
-                    *last = '\0';
-                    const char *photon_dir = last + 1;
-                    /* Build a sha_line for the spec's preferred algorithm
-                     * — PS L 5198-5202. C's state.SHAValue holds the
-                     * computed hash already. */
-                    const char *alg_name = "sha512";
-                    for (size_t li = 0; li < task->content_lines; li++) {
-                        const char *cl = task->content[li];
-                        if (cl == NULL) continue;
-                        if (strstr(cl, "%define sha1")   != NULL) { alg_name = "sha1";   break; }
-                        if (strstr(cl, "%define sha256") != NULL) { alg_name = "sha256"; break; }
-                        if (strstr(cl, "%define sha512") != NULL) { alg_name = "sha512"; break; }
-                    }
-                    char *sha_line = NULL;
-                    if (state.SHAValue && state.SHAValue[0]) {
-                        if (asprintf(&sha_line, "%%define %s %s=%s",
-                                     alg_name, task->Name ? task->Name : "",
-                                     state.SHAValue) < 0) sha_line = NULL;
-                    } else {
-                        /* PS L 5218: " " sentinel when SHA computation failed. */
-                        sha_line = strdup(" ");
-                    }
-                    int is_openjdk8 = spec_eq(task->Spec, "openjdk8.spec");
-                    /* netcat CommitId not yet plumbed through state; pass NULL
-                     * for now. PS netcat-specific behaviour stays unchanged
-                     * because the call site below uses the same NULL default. */
-                    pr_modify_spec_file(task, base_dir, base_dir, photon_dir,
-                                        state.UpdateAvailable, sha_line,
-                                        is_openjdk8, NULL, "SPECS_NEW_C");
-                    free(sha_line);
+            /* Extract photonDir from clone_root: "<...>/<photonDir>/clones". */
+            const char *end = clone_root + crl - sl;
+            const char *start = end - 1;
+            while (start > clone_root && start[-1] != '/') start--;
+            size_t pdlen = (size_t)(end - start);
+            if (pdlen > 0 && pdlen < 64) {
+                char photon_dir[64];
+                memcpy(photon_dir, start, pdlen);
+                photon_dir[pdlen] = '\0';
+                /* Build sha_line — PS L 5198-5202. C's state.SHAValue
+                 * holds the computed hash already. */
+                const char *alg_name = "sha512";
+                for (size_t li = 0; li < task->content_lines; li++) {
+                    const char *cl = task->content[li];
+                    if (cl == NULL) continue;
+                    if (strstr(cl, "%define sha1")   != NULL) { alg_name = "sha1";   break; }
+                    if (strstr(cl, "%define sha256") != NULL) { alg_name = "sha256"; break; }
+                    if (strstr(cl, "%define sha512") != NULL) { alg_name = "sha512"; break; }
                 }
+                char *sha_line = NULL;
+                if (state.SHAValue && state.SHAValue[0]) {
+                    if (asprintf(&sha_line, "%%define %s %s=%s",
+                                 alg_name, task->Name ? task->Name : "",
+                                 state.SHAValue) < 0) sha_line = NULL;
+                } else {
+                    /* PS L 5218: " " sentinel when SHA computation failed. */
+                    sha_line = strdup(" ");
+                }
+                int is_openjdk8 = spec_eq(task->Spec, "openjdk8.spec");
+                /* netcat CommitId not yet plumbed through state; pass NULL
+                 * for now. PS netcat-specific behaviour stays unchanged. */
+                pr_modify_spec_file(task,
+                                    working_dir,   /* source: SPECS tree */
+                                    working_dir,   /* output: SPECS_NEW_C alongside SPECS */
+                                    photon_dir,
+                                    state.UpdateAvailable, sha_line,
+                                    is_openjdk8, NULL, "SPECS_NEW_C");
+                free(sha_line);
             }
         }
     }

--- a/photonos-package-report/photonos-package-report/src/main.c
+++ b/photonos-package-report/photonos-package-report/src/main.c
@@ -647,16 +647,17 @@ static int generate_urlhealth_main(const pr_params_t *params, const char *branch
     if (params->ThrottleLimit <= 1) {
         for (size_t i = 0; i < list.count; i++) {
             rows[i] = check_urlhealth(&list.items[i], &lut, clone_root,
-                                      exclusion_list);
+                                      exclusion_list, params->workingDir);
         }
     } else {
-        /* Per-task closure capturing (task, lut, clone_root, exclusion_list)
-         * so the worker function only takes one `void *`. */
+        /* Per-task closure capturing (task, lut, clone_root, exclusion_list,
+         * working_dir) so the worker function only takes one `void *`. */
         typedef struct {
             pr_task_t                       *task;
             const pr_source0_lookup_table_t *lut;
             const char                      *clone_root;
             const char                      *exclusion_list;
+            const char                      *working_dir;
         } closure_t;
         closure_t *closures = (closure_t *)calloc(list.count, sizeof *closures);
         if (!closures) {
@@ -670,7 +671,7 @@ static int generate_urlhealth_main(const pr_params_t *params, const char *branch
                      pr_task_list_free(&list); return 1; }
         for (size_t i = 0; i < list.count; i++) {
             closures[i] = (closure_t){ &list.items[i], &lut, clone_root,
-                                       exclusion_list };
+                                       exclusion_list, params->workingDir };
         }
         /* Worker thunk — declared inline via a static helper. */
         extern void *pr_check_urlhealth_worker(void *arg);  /* below */
@@ -700,18 +701,19 @@ static int generate_urlhealth_main(const pr_params_t *params, const char *branch
 }
 
 /* Phase 7 worker thunk. Closure: { pr_task_t *, source0 lookup,
- * clone_root, exclusion_list }. Returns a malloc'd row string the
- * parent collects. */
+ * clone_root, exclusion_list, working_dir }. Returns a malloc'd row
+ * string the parent collects. */
 typedef struct {
     pr_task_t                       *task;
     const pr_source0_lookup_table_t *lut;
     const char                      *clone_root;
     const char                      *exclusion_list;
+    const char                      *working_dir;
 } pr_check_urlhealth_closure_t;
 
 void *pr_check_urlhealth_worker(void *arg)
 {
     pr_check_urlhealth_closure_t *c = (pr_check_urlhealth_closure_t *)arg;
     return (void *)check_urlhealth(c->task, c->lut, c->clone_root,
-                                   c->exclusion_list);
+                                   c->exclusion_list, c->working_dir);
 }

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase6.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase6.c
@@ -236,7 +236,7 @@ static void test_check_urlhealth_shape(void)
     t.Version = (char *)"2.10";
     t.url     = (char *)"";
 
-    char *row = check_urlhealth(&t, NULL, NULL, NULL);
+    char *row = check_urlhealth(&t, NULL, NULL, NULL, NULL);
     if (!row) { failures++; fprintf(stderr, "  FAIL: NULL row\n"); return; }
     EXPECT_INT(count_commas(row), 11);  /* 12 cols → 11 commas */
     /* Starts with the spec basename. */


### PR DESCRIPTION
## Summary

M122 validation run 26695536040 emitted:
\`\`\`
##[warning]modify_spec: source spec file not found, skipping:
  /root/.cache/photonos-parity/parity-c-wd/photon-upstreams/photon-3.0/SPECS/libev/libev.spec
\`\`\`

libev.spec wasn't there because the C workflow's parity-reconstruct.sh lays out the **photon branch clones at \`<WDIR>/photon-<branch>/SPECS/...\`** while the **upstream clones live at \`<WDIR>/photon-upstreams/photon-<branch>/clones\`** — different roots. M122 derived its working_dir from clone_root (the upstream tree) by stripping \`/clones\` + \`/<photonDir>\`, which landed at \`photon-upstreams\` — the wrong tree.

## Fix

Thread \`params->workingDir\` all the way through to \`check_urlhealth\` and forward it to \`pr_modify_spec_file\`. clone_root still supplies the photonDir component (its leaf is unambiguous), but the source SPECS root now comes from the CLI's \`--workingDir\` directly.

After:
- SPECS source: \`<workingDir>/<photonDir>/SPECS/<Name>/<spec>\`
- SPECS_NEW_C output: \`<workingDir>/<photonDir>/SPECS_NEW_C/<Name>/<base>-<Update>.spec\`

## Touches

| File | Change |
|---|---|
| \`include/pr_check_urlhealth.h\` | new \`working_dir\` param (NULL-disables modify_spec) |
| \`src/check_urlhealth.c\` | same param at function; photonDir-only extraction from clone_root |
| \`src/main.c\` | pass \`params->workingDir\` at both sync + pool call sites + closure |
| \`tests/unit/test_phase6.c\` | extend NULL-arg call to 5 args |

## Risk

Additive signature param. Old behaviour preserved when \`working_dir == NULL\`, exactly what test_phase6 passes today. Modify-spec still gated by PR_MODIFY_SPEC env (default OFF).

## Test plan

- [x] ctest 14/14 green
- [x] Build green
- [ ] Re-dispatch T1 libev with \`modify_spec=true\` → expect \`SPECS_NEW_C/libev/libev-4.33.spec\` artifact byte-comparable against PS's \`SPECS_NEW/libev/libev-4.33.spec\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)