### PR TITLE
phase-M task M125: optional FirstName/LastName/EmailAddress for ModifySpecFile changelog entry

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -38,6 +38,15 @@ on:
       modify_spec:
         description: 'M122: enable the C-side ModifySpecFile port. When true, the binary writes the bumped .spec under SPECS_NEW_C/<Name>/<basename>-<Update>.spec (parallel to PS''s SPECS_NEW/, never overwriting it). Default false until the SPECS_NEW_C vs SPECS_NEW diff is operator-confirmed byte-identical.'
         default: 'false'
+      first_name:
+        description: 'M125: First name of the changelog-entry author injected by ModifySpecFile. Leave empty for the legacy "First" default.'
+        default: ''
+      last_name:
+        description: 'M125: Last name of the changelog-entry author. Leave empty for the legacy "Last" default.'
+        default: ''
+      email_address:
+        description: 'M125: Email address of the changelog-entry author. Leave empty for the legacy "firstname.lastname@broadcom.com" default.'
+        default: ''
 
 permissions:
   contents: write   # commit the journal back to master
@@ -267,6 +276,12 @@ jobs:
           # PS's SPECS_NEW/ is untouched. Operator-validates via the upload
           # step + diff before flipping the default ON in a future PR.
           PR_MODIFY_SPEC: ${{ github.event.inputs.modify_spec == 'true' && '1' || '' }}
+          # M125: changelog-author overrides — empty values keep the
+          # legacy "First Last <firstname.lastname@broadcom.com>" string,
+          # so unset inputs leave PS+C byte-stable for the parity gate.
+          PR_FIRST_NAME: ${{ github.event.inputs.first_name }}
+          PR_LAST_NAME: ${{ github.event.inputs.last_name }}
+          PR_EMAIL_ADDRESS: ${{ github.event.inputs.email_address }}
         run: |
           cd repo/photonos-package-report/photonos-package-report
           WDIR="${{ steps.reconstruct.outputs.wdir }}"

--- a/.github/workflows/package-report.yml
+++ b/.github/workflows/package-report.yml
@@ -33,6 +33,15 @@ on:
       spec:
         description: 'T1: single-spec investigation mode. Set to a spec basename (e.g. "libev.spec") to process only that one file across the selected branches — seconds instead of ~40 min. Diagnostic-only: the resulting .prn has one row and is never used as a parity verdict.'
         default: ''
+      first_name:
+        description: 'M125: First name of the changelog-entry author injected by ModifySpecFile when an update is detected. Leave empty for the legacy "First" default.'
+        default: ''
+      last_name:
+        description: 'M125: Last name of the changelog-entry author. Leave empty for the legacy "Last" default.'
+        default: ''
+      email_address:
+        description: 'M125: Email address of the changelog-entry author. Leave empty for the legacy "firstname.lastname@broadcom.com" default.'
+        default: ''
   schedule:
     # Weekly scan on Sunday at 02:00 UTC
     - cron: '0 2 * * 0'
@@ -232,6 +241,19 @@ jobs:
           # a single row and never feeds the parity verdict.
           if [ -n "${{ github.event.inputs.spec }}" ]; then
             EXTRA_ARGS="$EXTRA_ARGS -Spec \"${{ github.event.inputs.spec }}\""
+          fi
+
+          # M125: optional changelog-author overrides. Each only added to
+          # EXTRA_ARGS when the operator supplied a non-empty value so the
+          # PS-side default strings stay byte-stable for legacy invocations.
+          if [ -n "${{ github.event.inputs.first_name }}" ]; then
+            EXTRA_ARGS="$EXTRA_ARGS -FirstName \"${{ github.event.inputs.first_name }}\""
+          fi
+          if [ -n "${{ github.event.inputs.last_name }}" ]; then
+            EXTRA_ARGS="$EXTRA_ARGS -LastName \"${{ github.event.inputs.last_name }}\""
+          fi
+          if [ -n "${{ github.event.inputs.email_address }}" ]; then
+            EXTRA_ARGS="$EXTRA_ARGS -EmailAddress \"${{ github.event.inputs.email_address }}\""
           fi
 
           # Propagate pwsh's exit code. Previously a trailing `echo "exit_code=$?"`

--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -115,7 +115,14 @@ param (
     [Parameter(Mandatory = $false)][ValidateNotNull()]$GeneratePhMaintoPhMasterDiffHigherPackageVersionReport=$true,
     [Parameter(Mandatory = $false)][ValidateNotNull()]$GeneratePh5toPh6DiffHigherPackageVersionReport=$true,
     [Parameter(Mandatory = $false)][ValidateNotNull()]$GeneratePh4toPh5DiffHigherPackageVersionReport=$true,
-    [Parameter(Mandatory = $false)][ValidateNotNull()]$GeneratePh3toPh4DiffHigherPackageVersionReport=$true
+    [Parameter(Mandatory = $false)][ValidateNotNull()]$GeneratePh3toPh4DiffHigherPackageVersionReport=$true,
+    # M125: optional changelog-author parameters used by ModifySpecFile when
+    # an update is detected. Current hardcoded strings ("First", "Last",
+    # "firstname.lastname@broadcom.com") are kept as defaults so legacy
+    # invocations remain byte-identical.
+    [string]$FirstName="First",
+    [string]$LastName="Last",
+    [string]$EmailAddress="firstname.lastname@broadcom.com"
 )
 
 # Convert string parameters to boolean (needed when using -File with $true/$false)
@@ -1422,7 +1429,13 @@ function ModifySpecFile {
     $object=get-content $SpecFile
 
     $DateEntry = use-culture -Culture en-US {(get-date -UFormat "%a") + " " + (get-date).ToString("MMM") + " " + (get-date -UFormat "%d %Y") }
-    $line1=[system.string]::concat("* ",$DateEntry," ","First Last <firstname.lastname@broadcom.com> ",$Update,"-1")
+    # M125: changelog author/email pulled from script-globals set by the
+    # top-level param block; defaults preserve the legacy "First Last
+    # <firstname.lastname@broadcom.com>" string when callers don't override.
+    $authorFirst = if ($null -ne $global:firstName    -and $global:firstName    -ne "") { $global:firstName }    else { "First" }
+    $authorLast  = if ($null -ne $global:lastName     -and $global:lastName     -ne "") { $global:lastName }     else { "Last" }
+    $authorMail  = if ($null -ne $global:emailAddress -and $global:emailAddress -ne "") { $global:emailAddress } else { "firstname.lastname@broadcom.com" }
+    $line1=[system.string]::concat("* ",$DateEntry," ",$authorFirst," ",$authorLast," <",$authorMail,"> ",$Update,"-1")
 
     $skip=$false
     $FileModified = @()
@@ -5528,6 +5541,13 @@ $throttleLimit = 20 # Set a hard cap to prevent overloading the system
 
 # Set global variables from script parameters
 $global:workingDir = $workingDir
+
+# M125: propagate changelog-author params to a script-global scope so
+# ModifySpecFile can pick them up without changing its signature (and
+# without threading them through CheckURLHealth / GenerateUrlHealthReports).
+$global:firstName    = $FirstName
+$global:lastName     = $LastName
+$global:emailAddress = $EmailAddress
 
 # Validate workingDir exists
 if (-not (Test-Path -Path $global:workingDir -PathType Container)) {

--- a/photonos-package-report/photonos-package-report/src/modify_spec.c
+++ b/photonos-package-report/photonos-package-report/src/modify_spec.c
@@ -149,13 +149,25 @@ int pr_modify_spec_file(const pr_task_t *task,
     }
     if (task->content == NULL || task->content_lines == 0) return -1;
 
-    /* PS L 1425: $line1 = "* <DateEntry> First Last <fl@broadcom.com>
-     *                       <Update>-1". */
+    /* PS L 1425: $line1 = "* <DateEntry> <First> <Last> <<email>> <Update>-1".
+     *
+     * M125: changelog author + email are pulled from env vars
+     * PR_FIRST_NAME / PR_LAST_NAME / PR_EMAIL_ADDRESS (set by the
+     * workflow input or the operator's shell). Defaults preserve the
+     * legacy hardcoded "First Last <firstname.lastname@broadcom.com>"
+     * string when env is unset — byte-identical to the pre-M125 line. */
+    const char *first_name = getenv("PR_FIRST_NAME");
+    const char *last_name  = getenv("PR_LAST_NAME");
+    const char *email_addr = getenv("PR_EMAIL_ADDRESS");
+    if (first_name == NULL || first_name[0] == '\0') first_name = "First";
+    if (last_name  == NULL || last_name[0]  == '\0') last_name  = "Last";
+    if (email_addr == NULL || email_addr[0] == '\0') email_addr = "firstname.lastname@broadcom.com";
+
     char date_entry[64];
     format_date_entry(date_entry, sizeof date_entry);
     char *line1 = NULL;
-    if (asprintf(&line1, "* %s First Last <firstname.lastname@broadcom.com> %s-1",
-                 date_entry, update_avail) < 0) return -1;
+    if (asprintf(&line1, "* %s %s %s <%s> %s-1",
+                 date_entry, first_name, last_name, email_addr, update_avail) < 0) return -1;
 
     /* Build the Version: replacement string. PS L 1432 splits on
      * openjdk8: openjdk8 → "1.8.0.<Update>"; default → "<Update>". */

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase6g.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase6g.c
@@ -204,6 +204,75 @@ static void test_subversion_and_commit_id(const char *tmp)
     free_task(t);
 }
 
+/* M125: changelog-author env-var overrides. The defaults must produce
+ * the legacy "First Last <firstname.lastname@broadcom.com>" string;
+ * setting any subset of PR_FIRST_NAME / PR_LAST_NAME / PR_EMAIL_ADDRESS
+ * must show through, and remaining unset slots keep their defaults. */
+static void test_changelog_author_default(const char *tmp)
+{
+    fprintf(stderr, "[test_changelog_author_default]\n");
+    /* Ensure env is unset so defaults apply. */
+    unsetenv("PR_FIRST_NAME"); unsetenv("PR_LAST_NAME"); unsetenv("PR_EMAIL_ADDRESS");
+    const char *lines[] = {
+        "Name:           foo",
+        "Version:        1.0",
+        "Release:        1%{?dist}",
+        "Source0:        https://example.com/foo-%{version}.tar.gz",
+        "%define sha512 foo=OLD",
+        "%changelog",
+    };
+    pr_task_t *t = make_task("foo", "foo.spec", tmp, "photon-master",
+                             lines, sizeof lines / sizeof lines[0]);
+    int rc = pr_modify_spec_file(t, tmp, tmp, "photon-master",
+                                 "2.0", "%define sha512 foo=NEW",
+                                 0, NULL, "SPECS_NEW_C");
+    EXPECT(rc == 0);
+    char out_path[1024];
+    snprintf(out_path, sizeof out_path,
+             "%s/photon-master/SPECS_NEW_C/foo/foo-2.0.spec", tmp);
+    char *body = slurp(out_path);
+    EXPECT(body != NULL);
+    if (body) {
+        EXPECT(strstr(body, "First Last <firstname.lastname@broadcom.com> 2.0-1") != NULL);
+        free(body);
+    }
+    free_task(t);
+}
+
+static void test_changelog_author_override(const char *tmp)
+{
+    fprintf(stderr, "[test_changelog_author_override]\n");
+    setenv("PR_FIRST_NAME",    "Ada",                  1);
+    setenv("PR_LAST_NAME",     "Lovelace",             1);
+    setenv("PR_EMAIL_ADDRESS", "ada@example.com",      1);
+    const char *lines[] = {
+        "Name:           bar",
+        "Version:        0.1",
+        "Release:        1%{?dist}",
+        "Source0:        https://example.com/bar-%{version}.tar.gz",
+        "%define sha512 bar=OLD",
+        "%changelog",
+    };
+    pr_task_t *t = make_task("bar", "bar.spec", tmp, "photon-6.0",
+                             lines, sizeof lines / sizeof lines[0]);
+    int rc = pr_modify_spec_file(t, tmp, tmp, "photon-6.0",
+                                 "0.2", "%define sha512 bar=NEW",
+                                 0, NULL, "SPECS_NEW_C");
+    EXPECT(rc == 0);
+    char out_path[1024];
+    snprintf(out_path, sizeof out_path,
+             "%s/photon-6.0/SPECS_NEW_C/bar/bar-0.2.spec", tmp);
+    char *body = slurp(out_path);
+    EXPECT(body != NULL);
+    if (body) {
+        EXPECT(strstr(body, "Ada Lovelace <ada@example.com> 0.2-1") != NULL);
+        EXPECT(strstr(body, "First Last <firstname.lastname@broadcom.com>") == NULL);
+        free(body);
+    }
+    free_task(t);
+    unsetenv("PR_FIRST_NAME"); unsetenv("PR_LAST_NAME"); unsetenv("PR_EMAIL_ADDRESS");
+}
+
 static void test_asc_suffix_strip(const char *tmp)
 {
     fprintf(stderr, "[test_asc_suffix_strip]\n");
@@ -240,6 +309,8 @@ int main(void)
     test_default_spec(tmpdir);
     test_openjdk8_version(tmpdir);
     test_subversion_and_commit_id(tmpdir);
+    test_changelog_author_default(tmpdir);
+    test_changelog_author_override(tmpdir);
     test_asc_suffix_strip(tmpdir);
 
     /* Cleanup. */


### PR DESCRIPTION
## Summary

ModifySpecFile (M122 port + PS L1425 original) injects the changelog-entry line with a hardcoded \`First Last <firstname.lastname@broadcom.com>\` author. M125 makes the three components operator-overridable on both implementations, with the current strings as defaults so legacy invocations stay byte-identical.

## Touches

| Implementation | How |
|---|---|
| **PS** (photonos-package-report.ps1) | New top-level params \`-FirstName\` / \`-LastName\` / \`-EmailAddress\`. Propagated via \`\$global:firstName\` etc. so ModifySpecFile picks them up without changing its 11-arg signature or threading through CheckURLHealth. L1425 reads the globals with inline `if-empty-else-default`. |
| **C** (\`src/modify_spec.c\`) | Reads env \`PR_FIRST_NAME\` / \`PR_LAST_NAME\` / \`PR_EMAIL_ADDRESS\` inside the line1 construction. Defaults applied when env unset/empty. |
| **PS workflow** | New inputs \`first_name\` / \`last_name\` / \`email_address\` (each default \`''\`). \`EXTRA_ARGS\` only appends the corresponding PS param when its input is non-empty → unchanged legacy invocations. |
| **C workflow** | Same three inputs, propagated as \`PR_FIRST_NAME\` / \`PR_LAST_NAME\` / \`PR_EMAIL_ADDRESS\` env vars on the c_run step. |

## Tests

- \`tests/unit/test_phase6g.c\` extended:
  - \`test_changelog_author_default\` — env unset → expect legacy \`First Last <firstname.lastname@broadcom.com>\`
  - \`test_changelog_author_override\` — env set → expect \`Ada Lovelace <ada@example.com>\` and NO trace of the legacy string

All 6 test cases pass locally; ctest 14/14 green.

## Test plan

- [x] ctest 14/14 green
- [x] Build green
- [ ] Parity gate (legacy invocations should remain strict — no .prn delta because the changelog line is in SPECS_NEW_C, not .prn)
- [ ] Dispatch with \`first_name=Ada last_name=Lovelace email_address=ada@example.com modify_spec=true spec=libev.spec\` → confirm \`SPECS_NEW_C/libev/libev-4.33.spec\` shows \`Ada Lovelace <ada@example.com>\` in the new changelog line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)