### PR TITLE
phase-M task M127: dynamic per-branch timeline PNG embedded in database-report .docx

### DIFF
--- a/.github/scripts/gen-timeline-chart.py
+++ b/.github/scripts/gen-timeline-chart.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""gen-timeline-chart.py — M127.
+
+Render the per-branch updates-available timeline as a high-quality PNG
+from photon-scans.db. The workflow's database-report job calls this
+right after the import step and passes the resulting path to
+`photon-report-db --chart-png ...` so Section 1 of the dynamic .docx
+embeds this image instead of the static OOXML chart1.xml.
+
+Usage:
+    gen-timeline-chart.py --db <path.db> --out <path.png>
+"""
+import argparse, os, sqlite3, sys
+from collections import defaultdict
+from datetime import datetime
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mtick
+
+SQL = """
+SELECT sf.branch, sf.scan_datetime, COUNT(*) AS n
+FROM scan_files sf JOIN packages p ON p.scan_file_id = sf.id
+WHERE p.update_available IS NOT NULL
+  AND p.update_available <> ''
+  AND p.update_available NOT LIKE 'Warning:%'
+  AND p.update_available NOT LIKE 'Info:%'
+  AND p.update_available <> '(same version)'
+GROUP BY sf.branch, sf.scan_datetime
+ORDER BY sf.scan_datetime ASC
+"""
+
+# Stable colour assignment so the same branch reads as the same line
+# across every weekly run.
+BRANCH_COLORS = {
+    "3.0":    "#7F7F7F",   # legacy — grey
+    "4.0":    "#B22222",
+    "5.0":    "#0F4C81",   # photon-blue (current focus)
+    "6.0":    "#3FA34D",
+    "common": "#E1A300",
+    "dev":    "#9B59B6",
+    "master": "#1B9E9E",
+    "main":   "#FF7F0E",
+}
+BRANCH_ORDER = ["3.0", "4.0", "5.0", "6.0", "common", "dev", "master", "main"]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--db", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    if not os.path.exists(args.db):
+        print(f"::error::DB not found: {args.db}", file=sys.stderr)
+        return 1
+
+    data = defaultdict(list)  # branch -> [(dt, n), ...]
+    con = sqlite3.connect(args.db)
+    for branch, ts_str, n in con.execute(SQL):
+        try:
+            dt = datetime.strptime(ts_str, "%Y%m%d%H%M")
+        except ValueError:
+            continue
+        data[branch].append((dt, n))
+    con.close()
+
+    for b in data:
+        data[b].sort(key=lambda p: p[0])
+
+    if not any(data.values()):
+        print("::warning::no timeline points — DB has no real-update rows", file=sys.stderr)
+        return 1
+
+    plt.rcParams.update({
+        "font.family": "DejaVu Sans",
+        "font.size": 10,
+        "axes.titlesize": 13,
+        "axes.titleweight": "bold",
+        "axes.labelsize": 10,
+        "axes.spines.top":   False,
+        "axes.spines.right": False,
+        "axes.grid": True,
+        "grid.linestyle": ":",
+        "grid.alpha": 0.4,
+        "figure.dpi": 160,
+    })
+
+    fig, ax = plt.subplots(figsize=(11, 5))
+    for b in BRANCH_ORDER:
+        if b not in data:
+            continue
+        xs = [p[0] for p in data[b]]
+        ys = [p[1] for p in data[b]]
+        ax.plot(xs, ys, "-o", lw=2, ms=4, label=f"photon-{b}",
+                color=BRANCH_COLORS[b], alpha=0.95)
+
+    ax.set_title("Photon OS package-report — Updates available per branch over time", pad=12)
+    ax.set_xlabel("Scan date (UTC)")
+    ax.set_ylabel("Packages with a real upstream update")
+    ax.legend(loc="upper left", frameon=False, ncols=4, fontsize=9,
+              bbox_to_anchor=(0, -0.13))
+    ax.xaxis.set_major_locator(mdates.AutoDateLocator(minticks=6, maxticks=12))
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m"))
+    ax.yaxis.set_major_formatter(mtick.FuncFormatter(lambda v, _: f"{int(v):,}"))
+    fig.autofmt_xdate(rotation=30, ha="right")
+
+    all_dt = [d for v in data.values() for d, _ in v]
+    if all_dt:
+        rng = f"{min(all_dt):%Y-%m-%d}  →  {max(all_dt):%Y-%m-%d}"
+        ax.text(0.99, -0.32,
+                f"Source: photon-scans.db  ({sum(len(v) for v in data.values())} scans, span: {rng})",
+                transform=ax.transAxes, ha="right",
+                fontsize=8.5, color="#555", style="italic")
+
+    plt.tight_layout()
+    plt.savefig(args.out, bbox_inches="tight")
+    plt.close()
+
+    sz = os.path.getsize(args.out)
+    print(f"timeline chart written: {args.out}  ({sz/1024:.0f} KB, "
+          f"{sum(len(v) for v in data.values())} points, {len(data)} branches)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/database-report.yml
+++ b/.github/workflows/database-report.yml
@@ -169,6 +169,22 @@ jobs:
             echo '```' >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Generate timeline chart (M127)
+        # Render the per-branch UpdateAvailable timeline as a high-quality PNG
+        # from the just-imported DB. The C report writer embeds this image
+        # in Section 1 of the .docx via the `--chart-png` flag below; if this
+        # step is skipped or fails, the writer silently falls back to the
+        # legacy hand-built OOXML c:chart so the report still renders.
+        id: chart
+        continue-on-error: true
+        run: |
+          DB="${{ steps.paths.outputs.db }}"
+          REPORT_DIR="${{ steps.paths.outputs.report }}"
+          mkdir -p "$REPORT_DIR"
+          PNG="$REPORT_DIR/timeline-chart.png"
+          python3 repo/.github/scripts/gen-timeline-chart.py --db "$DB" --out "$PNG"
+          echo "png=$PNG" >> "$GITHUB_OUTPUT"
+
       - name: Generate report
         working-directory: repo/${{ env.TOOL_DIR }}
         run: |
@@ -181,7 +197,18 @@ jobs:
             exit 1
           fi
 
-          ./photon-report-db --db "$DB" --report "$REPORT" 2>&1 | tee /tmp/report.log
+          # M127: pass --chart-png when the prior step produced one; the
+          # writer treats it as optional and falls back on its own otherwise.
+          CHART_ARGS=()
+          PNG="${{ steps.chart.outputs.png }}"
+          if [ -n "$PNG" ] && [ -f "$PNG" ]; then
+            CHART_ARGS=(--chart-png "$PNG")
+            echo "Embedding dynamic timeline PNG: $PNG" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Using legacy OOXML c:chart for timeline (no PNG)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          ./photon-report-db --db "$DB" --report "$REPORT" "${CHART_ARGS[@]}" 2>&1 | tee /tmp/report.log
 
           # The tool auto-generates report-<datetime>.docx inside the directory
           DOCX_FILE=$(find "$REPORT" -maxdepth 1 -name 'report-*.docx' -type f -printf '%T@ %p\n' 2>/dev/null | sort -rn | head -1 | cut -d' ' -f2-)

--- a/photonos-package-report/package-report-database-tool/src/docx_writer.c
+++ b/photonos-package-report/package-report-database-tool/src/docx_writer.c
@@ -169,23 +169,38 @@ static int zip_close(zipwriter_t *z)
     return 0;
 }
 
-/* Generate OOXML content type XML */
-static char *gen_content_types(void)
+/* Generate OOXML content type XML.
+ * M127: when use_png_timeline=1, declare png as a Default extension AND drop
+ * the chart1 override (Section 1's chart1.xml is replaced by the embedded
+ * PNG). chart2 + chart3 (pie + drift) stay untouched. */
+static char *gen_content_types(int use_png_timeline)
 {
-    return strdup(
+    strbuf_t sb; strbuf_init(&sb);
+    strbuf_append(&sb,
         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\r\n"
         "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">"
         "<Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>"
-        "<Default Extension=\"xml\" ContentType=\"application/xml\"/>"
+        "<Default Extension=\"xml\" ContentType=\"application/xml\"/>");
+    if (use_png_timeline) {
+        strbuf_append(&sb,
+            "<Default Extension=\"png\" ContentType=\"image/png\"/>");
+    }
+    strbuf_append(&sb,
         "<Override PartName=\"/word/document.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml\"/>"
         "<Override PartName=\"/word/styles.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml\"/>"
         "<Override PartName=\"/word/settings.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml\"/>"
         "<Override PartName=\"/word/webSettings.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.webSettings+xml\"/>"
-        "<Override PartName=\"/word/fontTable.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.fontTable+xml\"/>"
-        "<Override PartName=\"/word/charts/chart1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.drawingml.chart+xml\"/>"
+        "<Override PartName=\"/word/fontTable.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.fontTable+xml\"/>");
+    if (!use_png_timeline) {
+        strbuf_append(&sb,
+            "<Override PartName=\"/word/charts/chart1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.drawingml.chart+xml\"/>");
+    }
+    strbuf_append(&sb,
         "<Override PartName=\"/word/charts/chart2.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.drawingml.chart+xml\"/>"
         "<Override PartName=\"/word/charts/chart3.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.drawingml.chart+xml\"/>"
         "</Types>");
+    char *out = sb.data; sb.data = NULL; strbuf_free(&sb);
+    return out;
 }
 
 static char *gen_rels(void)
@@ -197,19 +212,31 @@ static char *gen_rels(void)
         "</Relationships>");
 }
 
-static char *gen_doc_rels(void)
+/* M127: when use_png_timeline=1, rId2 points at the embedded PNG
+ * (media/timeline.png) instead of charts/chart1.xml. */
+static char *gen_doc_rels(int use_png_timeline)
 {
-    return strdup(
+    strbuf_t sb; strbuf_init(&sb);
+    strbuf_append(&sb,
         "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\r\n"
         "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">"
-        "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\" Target=\"styles.xml\"/>"
-        "<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart\" Target=\"charts/chart1.xml\"/>"
+        "<Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles\" Target=\"styles.xml\"/>");
+    if (use_png_timeline) {
+        strbuf_append(&sb,
+            "<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/image\" Target=\"media/timeline.png\"/>");
+    } else {
+        strbuf_append(&sb,
+            "<Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart\" Target=\"charts/chart1.xml\"/>");
+    }
+    strbuf_append(&sb,
         "<Relationship Id=\"rId3\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart\" Target=\"charts/chart2.xml\"/>"
         "<Relationship Id=\"rId4\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart\" Target=\"charts/chart3.xml\"/>"
         "<Relationship Id=\"rId5\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/settings\" Target=\"settings.xml\"/>"
         "<Relationship Id=\"rId6\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/webSettings\" Target=\"webSettings.xml\"/>"
         "<Relationship Id=\"rId7\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable\" Target=\"fontTable.xml\"/>"
         "</Relationships>");
+    char *out = sb.data; sb.data = NULL; strbuf_free(&sb);
+    return out;
 }
 
 static char *gen_styles(void)
@@ -308,6 +335,47 @@ static void doc_add_cell(strbuf_t *sb, const char *text)
     free(esc);
 }
 
+/* M127 helpers: PNG embed -------------------------------------------- */
+
+/* Slurp a file into a heap buffer. Returns malloc'd bytes (caller frees)
+ * and writes *out_len. Returns NULL on any error. */
+static unsigned char *read_file_bytes(const char *path, size_t *out_len)
+{
+    if (!path || !out_len) return NULL;
+    FILE *fp = fopen(path, "rb");
+    if (!fp) return NULL;
+    if (fseek(fp, 0, SEEK_END) != 0) { fclose(fp); return NULL; }
+    long n = ftell(fp);
+    if (n < 0) { fclose(fp); return NULL; }
+    if (fseek(fp, 0, SEEK_SET) != 0) { fclose(fp); return NULL; }
+    unsigned char *buf = malloc((size_t)n);
+    if (!buf) { fclose(fp); return NULL; }
+    if (fread(buf, 1, (size_t)n, fp) != (size_t)n) { fclose(fp); free(buf); return NULL; }
+    fclose(fp);
+    *out_len = (size_t)n;
+    return buf;
+}
+
+/* Parse PNG IHDR to get width/height in pixels. PNG layout:
+ *   bytes 0-7   signature 89 50 4E 47 0D 0A 1A 0A
+ *   bytes 8-11  chunk length (4 bytes, big-endian)
+ *   bytes 12-15 chunk type "IHDR"
+ *   bytes 16-19 width  (big-endian uint32)
+ *   bytes 20-23 height (big-endian uint32)
+ * Returns 0 on success. */
+static int parse_png_dims(const unsigned char *b, size_t n,
+                          unsigned *out_w, unsigned *out_h)
+{
+    static const unsigned char sig[8] = {0x89,0x50,0x4E,0x47,0x0D,0x0A,0x1A,0x0A};
+    if (!b || n < 24 || memcmp(b, sig, 8) != 0) return -1;
+    if (memcmp(b + 12, "IHDR", 4) != 0) return -1;
+    *out_w = (unsigned)b[16] << 24 | (unsigned)b[17] << 16 |
+             (unsigned)b[18] <<  8 | (unsigned)b[19];
+    *out_h = (unsigned)b[20] << 24 | (unsigned)b[21] << 16 |
+             (unsigned)b[22] <<  8 | (unsigned)b[23];
+    return 0;
+}
+
 /* Helper: inline chart reference (docPr id must be unique per document) */
 static int s_next_docpr_id = 1;
 
@@ -330,8 +398,56 @@ static void doc_add_chart_ref(strbuf_t *sb, const char *rid)
         dpid, dpid, rid);
 }
 
+/* M127: inline picture (PNG) reference. Uses the same wp:inline frame as
+ * doc_add_chart_ref but swaps a:graphicData → DrawingML picture (pic:pic
+ * with a:blip r:embed). EMU sizing keeps the rendered image at the same
+ * 5486400 × ((cy × h)/w) box width so the layout matches the legacy chart.
+ * 914400 EMU = 1 inch; 9525 EMU = 1 px at 96 DPI. */
+static void doc_add_picture(strbuf_t *sb, const char *rid,
+                            unsigned px_w, unsigned px_h)
+{
+    int dpid = s_next_docpr_id++;
+    /* Hold display width at 6 inches (5,486,400 EMU); scale height to preserve aspect. */
+    long long cx = 5486400LL;
+    long long cy = (px_w > 0) ? (cx * (long long)px_h) / (long long)px_w : 3200400LL;
+    if (cy <= 0) cy = 3200400LL;
+    strbuf_printf(sb,
+        "<w:p><w:r>"
+        "<w:drawing>"
+        "<wp:inline xmlns:wp=\"http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing\" "
+        "distT=\"0\" distB=\"0\" distL=\"0\" distR=\"0\">"
+        "<wp:extent cx=\"%lld\" cy=\"%lld\"/>"
+        "<wp:docPr id=\"%d\" name=\"Timeline %d\"/>"
+        "<wp:cNvGraphicFramePr>"
+        "<a:graphicFrameLocks xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\" noChangeAspect=\"1\"/>"
+        "</wp:cNvGraphicFramePr>"
+        "<a:graphic xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\">"
+        "<a:graphicData uri=\"http://schemas.openxmlformats.org/drawingml/2006/picture\">"
+        "<pic:pic xmlns:pic=\"http://schemas.openxmlformats.org/drawingml/2006/picture\">"
+        "<pic:nvPicPr>"
+        "<pic:cNvPr id=\"%d\" name=\"timeline.png\"/>"
+        "<pic:cNvPicPr/>"
+        "</pic:nvPicPr>"
+        "<pic:blipFill>"
+        "<a:blip xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" r:embed=\"%s\"/>"
+        "<a:stretch><a:fillRect/></a:stretch>"
+        "</pic:blipFill>"
+        "<pic:spPr>"
+        "<a:xfrm><a:off x=\"0\" y=\"0\"/><a:ext cx=\"%lld\" cy=\"%lld\"/></a:xfrm>"
+        "<a:prstGeom prst=\"rect\"><a:avLst/></a:prstGeom>"
+        "</pic:spPr>"
+        "</pic:pic>"
+        "</a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>\r\n",
+        cx, cy, dpid, dpid, dpid, rid, cx, cy);
+}
+
+/* M127: when timeline_png_w/h > 0, Section 1 embeds a PNG via doc_add_picture
+ * (rId2 now resolves to media/timeline.png). When both are 0, the legacy
+ * c:chart reference path is used. */
 static char *gen_document(const top_changed_data_t *top_changed,
-                          const least_changed_data_t *least_changed)
+                          const least_changed_data_t *least_changed,
+                          unsigned timeline_png_w,
+                          unsigned timeline_png_h)
 {
     s_next_docpr_id = 1;
     strbuf_t sb;
@@ -359,7 +475,12 @@ static char *gen_document(const top_changed_data_t *top_changed,
     doc_add_heading(&sb, "1. Package Health Timeline", "Heading2");
     doc_add_para(&sb, "Packages matching UrlHealth=200, UpdateAvailable with version, "
                       "and correct UpdateDownloadName (name-version.tar.*), per branch over time.");
-    doc_add_chart_ref(&sb, "rId2");
+    if (timeline_png_w > 0 && timeline_png_h > 0) {
+        /* M127: dynamic per-run PNG generated by the workflow's Python step. */
+        doc_add_picture(&sb, "rId2", timeline_png_w, timeline_png_h);
+    } else {
+        doc_add_chart_ref(&sb, "rId2");
+    }
 
     /* Section 2: Top 10 Most-Changed Packages (all branches) */
     doc_add_heading(&sb, "2. Top 10 Most-Changed Packages (all branches, 2023-current)", "Heading2");
@@ -453,27 +574,52 @@ int docx_write_report(const char *output_path,
                       const top_changed_data_t *top_changed,
                       const least_changed_data_t *least_changed,
                       const category_data_t *categories,
-                      const category_drift_data_t *drift)
+                      const category_drift_data_t *drift,
+                      const char *timeline_chart_png)
 {
     if (!output_path)
         return -1;
 
+    /* M127: optional PNG embed. When the file is given AND readable AND
+     * its IHDR parses cleanly, the workflow's pre-rendered chart wins
+     * Section 1. Otherwise we silently fall back to the OOXML c:chart. */
+    unsigned char *png_bytes = NULL;
+    size_t         png_len   = 0;
+    unsigned       png_w = 0, png_h = 0;
+    int            use_png  = 0;
+    if (timeline_chart_png && timeline_chart_png[0]) {
+        png_bytes = read_file_bytes(timeline_chart_png, &png_len);
+        if (png_bytes && parse_png_dims(png_bytes, png_len, &png_w, &png_h) == 0) {
+            use_png = 1;
+        } else {
+            fprintf(stderr,
+                "::warning::timeline_chart_png='%s' unreadable or not a valid PNG — "
+                "falling back to OOXML c:chart\n", timeline_chart_png);
+            free(png_bytes);
+            png_bytes = NULL;
+            png_len = 0;
+        }
+    }
+
     zipwriter_t z;
     if (zip_open(&z, output_path) != 0) {
         fprintf(stderr, "Cannot create output file: %s\n", output_path);
+        free(png_bytes);
         return -1;
     }
 
     /* Generate all XML content */
-    char *content_types = gen_content_types();
+    char *content_types = gen_content_types(use_png);
     char *rels = gen_rels();
-    char *doc_rels = gen_doc_rels();
+    char *doc_rels = gen_doc_rels(use_png);
     char *styles = gen_styles();
     char *settings = gen_settings();
     char *web_settings = gen_web_settings();
     char *font_table = gen_font_table();
-    char *document = gen_document(top_changed, least_changed);
-    char *chart1 = chart_xml_timeline(timeline);
+    char *document = gen_document(top_changed, least_changed,
+                                  use_png ? png_w : 0,
+                                  use_png ? png_h : 0);
+    char *chart1 = use_png ? NULL : chart_xml_timeline(timeline);
     char *chart2 = chart_xml_pie(categories);
     char *chart3 = chart_xml_bar_stacked_branch(drift, "5.0");
 
@@ -497,8 +643,12 @@ int docx_write_report(const char *output_path,
         goto cleanup;
     }
 
-    if (chart1 && zip_add_file(&z, "word/charts/chart1.xml", chart1, strlen(chart1)) != 0)
+    if (use_png) {
+        if (zip_add_file(&z, "word/media/timeline.png", png_bytes, png_len) != 0)
+            rc = -1;
+    } else if (chart1 && zip_add_file(&z, "word/charts/chart1.xml", chart1, strlen(chart1)) != 0) {
         rc = -1;
+    }
     if (chart2 && zip_add_file(&z, "word/charts/chart2.xml", chart2, strlen(chart2)) != 0)
         rc = -1;
     if (chart3 && zip_add_file(&z, "word/charts/chart3.xml", chart3, strlen(chart3)) != 0)
@@ -516,6 +666,7 @@ cleanup:
     free(chart1);
     free(chart2);
     free(chart3);
+    free(png_bytes);
 
     if (zip_close(&z) != 0)
         rc = -1;

--- a/photonos-package-report/package-report-database-tool/src/docx_writer.h
+++ b/photonos-package-report/package-report-database-tool/src/docx_writer.h
@@ -3,12 +3,21 @@
 
 #include "db.h"
 
-/* Write a complete .docx report file. Returns 0 on success. */
+/* Write a complete .docx report file. Returns 0 on success.
+ *
+ * M127: `timeline_chart_png` is an OPTIONAL path to a PNG file. When non-NULL
+ * and readable, Section 1's "Package Health Timeline" embeds that PNG image
+ * instead of the hand-built OOXML c:chart (chart1.xml is then omitted). The
+ * caller is expected to pre-render the PNG (the workflow does this via
+ * .github/scripts/gen-timeline-chart.py before invoking photon-report-db).
+ * When NULL or unreadable, the legacy chart1.xml c:chart path is preserved
+ * byte-identically. */
 int docx_write_report(const char *output_path,
                       const timeline_data_t *timeline,
                       const top_changed_data_t *top_changed,
                       const least_changed_data_t *least_changed,
                       const category_data_t *categories,
-                      const category_drift_data_t *drift);
+                      const category_drift_data_t *drift,
+                      const char *timeline_chart_png);
 
 #endif

--- a/photonos-package-report/package-report-database-tool/src/main.c
+++ b/photonos-package-report/package-report-database-tool/src/main.c
@@ -9,12 +9,16 @@
 
 static void print_usage(const char *prog)
 {
-    fprintf(stderr, "Usage: %s --db <path.db> [--import <scans-dir>] [--report <output.docx>]\n\n", prog);
+    fprintf(stderr, "Usage: %s --db <path.db> [--import <scans-dir>] [--report <output.docx>] [--chart-png <path>]\n\n", prog);
     fprintf(stderr, "Options:\n");
-    fprintf(stderr, "  --db <path>       SQLite database file (created if absent)\n");
-    fprintf(stderr, "  --import <dir>    Import photonos-urlhealth-*.prn files from directory\n");
-    fprintf(stderr, "  --report <path>   Generate .docx report\n");
-    fprintf(stderr, "  --help            Show this help message\n");
+    fprintf(stderr, "  --db <path>         SQLite database file (created if absent)\n");
+    fprintf(stderr, "  --import <dir>      Import photonos-urlhealth-*.prn files from directory\n");
+    fprintf(stderr, "  --report <path>     Generate .docx report\n");
+    fprintf(stderr, "  --chart-png <path>  M127: embed this PNG as Section 1's timeline\n");
+    fprintf(stderr, "                      (typically pre-rendered by the workflow's\n");
+    fprintf(stderr, "                      gen-timeline-chart.py step). When unset or\n");
+    fprintf(stderr, "                      unreadable, falls back to the OOXML c:chart.\n");
+    fprintf(stderr, "  --help              Show this help message\n");
 }
 
 int main(int argc, char **argv)
@@ -22,6 +26,7 @@ int main(int argc, char **argv)
     const char *db_path = NULL;
     const char *import_dir = NULL;
     const char *report_path = NULL;
+    const char *chart_png = NULL;
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--db") == 0 && i + 1 < argc) {
@@ -30,6 +35,8 @@ int main(int argc, char **argv)
             import_dir = argv[++i];
         } else if (strcmp(argv[i], "--report") == 0 && i + 1 < argc) {
             report_path = argv[++i];
+        } else if (strcmp(argv[i], "--chart-png") == 0 && i + 1 < argc) {
+            chart_png = argv[++i];
         } else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
             print_usage(argv[0]);
             return 0;
@@ -148,7 +155,8 @@ int main(int argc, char **argv)
         }
 
         if (docx_write_report(final_report, &timeline, &top_changed,
-                              &least_changed, &categories, &drift) != 0) {
+                              &least_changed, &categories, &drift,
+                              chart_png) != 0) {
             fprintf(stderr, "Failed to write report\n");
             exit_code = 1;
         } else {

--- a/photonos-package-report/package-report-database-tool/test/test_db.c
+++ b/photonos-package-report/package-report-database-tool/test/test_db.c
@@ -203,7 +203,7 @@ static void test_docx_generation(void)
     category_drift_data_t drift;
     memset(&drift, 0, sizeof(drift));
 
-    int rc = docx_write_report(docxpath, &tl, &tc, &lc, &cat, &drift);
+    int rc = docx_write_report(docxpath, &tl, &tc, &lc, &cat, &drift, NULL);
     if (rc != 0) {
         FAIL("docx_write_report failed");
     } else {


### PR DESCRIPTION
## Summary

The dynamic report section emitted by every database-report run was indistinguishable from a static placeholder: same OOXML \`c:chart\` wired to the same \`chart1.xml\` every week. M127 swaps Section 1 ("Package Health Timeline") to embed a **freshly-rendered per-branch PNG** produced from the actual scan history in \`photon-scans.db\` — one connected line per branch, all 8 branches, from the first scan onward.

## Pieces

### 1. \`.github/scripts/gen-timeline-chart.py\`

matplotlib (Agg backend) renders the chart from the verified SQL:

\`\`\`sql
SELECT sf.branch, sf.scan_datetime, COUNT(*)
FROM scan_files sf JOIN packages p ON p.scan_file_id = sf.id
WHERE p.update_available <> '' AND ...
GROUP BY sf.branch, sf.scan_datetime
ORDER BY sf.scan_datetime ASC;
\`\`\`

Stable per-branch palette (5.0 = photon-blue, etc.) so the same line keeps the same colour across weekly runs.

### 2. \`.github/workflows/database-report.yml\`

New "Generate timeline chart" step between import and report. \`continue-on-error: true\` — if matplotlib fails, the C writer falls back to the legacy c:chart, the .docx still renders.

### 3. C side — \`src/docx_writer.{c,h}\` + \`src/main.c\`

New \`--chart-png <path>\` flag. When given AND readable AND the PNG IHDR parses, the writer:
- emits \`word/media/timeline.png\` with the file's raw bytes
- rewrites \`rId2\` in document.xml.rels from chart → image
- declares \`<Default Extension="png" ...>\` in \`[Content_Types].xml\`
- drops the chart1 override
- swaps \`<a:graphicData uri=".../chart">\` for \`<a:graphicData uri=".../picture"><pic:pic>...<a:blip r:embed="rId2">\`

IHDR is parsed in C from the first 24 bytes (no Pillow dep). zlib is already linked.

When the flag is unset, the legacy c:chart path is byte-identical to pre-M127.

## Verification

| Check | Result |
|---|---|
| \`make test\` | 5/5 PASS (extended test_db.c for new sig) |
| Legacy invocation (no flag) | byte-identical structure: 11 files, chart1+chart2+chart3 |
| --chart-png on live photon-scans.db | 1 pic:pic + 2 c:chart, word/media/timeline.png embedded, [Content_Types].xml correctly omits chart1 override |
| Word renders correctly | confirmed locally |

## Risk

- Chart generation failure → \`continue-on-error\` keeps the pipeline alive; writer silently falls back.
- C writer reads PNG → bad-magic / unreadable file → \`::warning::\` + fallback; no abort.
- DB query is read-only → no DB mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)