### PR TITLE
phase-M task M129: drop retention-days 95 → 90 to silence the every-run warning

### DIFF
--- a/.github/workflows/package-report.yml
+++ b/.github/workflows/package-report.yml
@@ -437,11 +437,14 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           # Name embeds the PS run id so the C workflow can find it via
-          # the workflow_run.id payload field. Retention matches the
-          # ADR-0009 90-day clock plus 5 days slack.
+          # the workflow_run.id payload field. Retention is set to the
+          # repository's hard ceiling (90 days) — the ADR-0009 30/60/90
+          # ladder reaches verdict by day 90, so a longer retention has
+          # no operational value, and asking for more (e.g. 95) just
+          # emits a "Using 90 instead" warning on every run.
           name: parity-snapshot-${{ github.run_id }}
           path: ${{ steps.parity_snapshot.outputs.tar }}
-          retention-days: 95
+          retention-days: 90
           if-no-files-found: warn
 
       - name: Upload report artifacts


### PR DESCRIPTION
## Summary

The "Upload parity snapshot artifact" step asked for 95-day retention to give ADR-0009's 30/60/90 ladder a 5-day slack, but the repo's artifact-retention ceiling is **90 days**. GitHub clamps and warns:

\`\`\`
::warning::Retention days cannot be greater than the maximum allowed retention
set within the repository. Using 90 instead.
\`\`\`

— **every** weekly run.

## Impact / options

| # | Approach | Verdict |
|---|---|---|
| **A** | Set to 90 (actual cap) | ← chosen; behaviour unchanged, noise eliminated |
| B | Raise the repo cap in Settings | not possible on a free public repo |
| C | Move snapshot off the artifact channel | overkill for 5 days |

The 5-day slack never existed; aligning code to reality is a one-line change with no behavioural delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)