### PR TITLE
phase-M task M130: step-summary PNG via raw.githubusercontent.com URL (M128 broken-icon fix)

### DIFF
--- a/.github/workflows/database-report.yml
+++ b/.github/workflows/database-report.yml
@@ -179,28 +179,35 @@ jobs:
         continue-on-error: true
         run: |
           DB="${{ steps.paths.outputs.db }}"
-          REPORT_DIR="${{ steps.paths.outputs.report }}"
-          mkdir -p "$REPORT_DIR"
-          PNG="$REPORT_DIR/timeline-chart.png"
+          # M130: write the PNG straight into the scans/ tree so the
+          # existing "Commit report to repository" step picks it up. A
+          # stable filename (no timestamp) means each weekly run
+          # OVERWRITES the previous PNG — git stores one delta per week,
+          # not a new file per week. Cheap (~150 KB) compared to the
+          # .docx already committed each weekly run.
+          SCANS_DIR="$GITHUB_WORKSPACE/repo/photonos-package-report/scans"
+          mkdir -p "$SCANS_DIR"
+          PNG="$SCANS_DIR/timeline-chart.png"
           python3 repo/.github/scripts/gen-timeline-chart.py --db "$DB" --out "$PNG"
           echo "png=$PNG" >> "$GITHUB_OUTPUT"
 
-          # M128: render the PNG INLINE in the job summary via a base64
-          # data: URI. The Step Summary markdown renderer cannot read
-          # arbitrary runner-local files, so a plain path produces text
-          # only. Inlining as data: makes the image actually show up on
-          # the workflow run page right where the operator is reading.
-          # Typical PNG (~150 KB) → ~200 KB base64; well under the 1 MB
-          # per-step summary cap. Guarded so a render failure doesn't
-          # break the summary.
+          # M130: GitHub's $GITHUB_STEP_SUMMARY markdown sanitiser STRIPS
+          # data: URIs from <img> tags as CSP hardening, so the M128
+          # base64 inlining showed a broken-icon glyph in run
+          # 26739028580. Only http(s) URLs are allowed. Reference the
+          # PNG via raw.githubusercontent.com pointing at master — the
+          # "Commit report to repository" step pushes the new PNG to
+          # master at the SAME path, so by the time the operator views
+          # the run summary the URL serves the just-rendered chart.
+          # A run-id query string defeats CDN caches between runs.
           if [ -f "$PNG" ]; then
-            B64=$(base64 -w0 "$PNG")
+            URL="https://raw.githubusercontent.com/${{ github.repository }}/master/photonos-package-report/scans/timeline-chart.png?run=${{ github.run_id }}"
             {
               echo "## Timeline chart"
               echo ""
-              echo "<img alt=\"Updates available per branch over time\" src=\"data:image/png;base64,${B64}\" />"
+              echo "![Updates available per branch over time]($URL)"
               echo ""
-              echo "_Rendered from photon-scans.db ($(stat -c%s "$PNG") bytes). Also embedded in Section 1 of the generated .docx._"
+              echo "_Rendered from photon-scans.db ($(stat -c%s "$PNG") bytes). Also embedded in Section 1 of the generated .docx and committed alongside it for raw-URL preview above._"
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 


### PR DESCRIPTION
## Root cause

The M128 base64 \`data:\` URI rendered as a broken-icon glyph on run **26739028580**. GitHub's \`\$GITHUB_STEP_SUMMARY\` markdown sanitiser strips \`data:\` URIs from \`<img>\` tags as a CSP-hardening measure — the element survives but its \`src\` is removed, so the browser shows the standard broken-image placeholder. The same restriction applies to \`![alt](data:...)\` markdown syntax. Only \`http(s)\` URLs survive.

## Options considered

| # | Approach | Inline? | Bloat | Complexity |
|---|---|---|---|---|
| **A** | Commit PNG to scans/ (stable filename), reference via \`raw.githubusercontent.com/.../master/.../timeline-chart.png\` | ✓ | ~150 KB/week delta | minimal — uses existing commit step |
| B | Orphan branch \`chart-snapshots\` force-pushed each run | ✓ | constant | new git plumbing |
| C | Push to a Gist / external CDN | ✓ | none in-repo | external infra |
| D | Artifact link only | ✗ click required | none | minimal |

**A chosen**: zero new infra, the existing weekly \`Commit report to repository\` step already runs \`git add photonos-package-report/scans/\` so it picks up the new PNG without any additional plumbing.

## Implementation

- Write the PNG straight into the scans/ tree at a **stable filename** (no timestamp): each weekly run **overwrites** the previous PNG, so git stores one delta per week (~150 KB) instead of accumulating files. Comparable to the .docx already committed each weekly run.
- Step summary now writes \`![alt](https://raw.githubusercontent.com/\${{ github.repository }}/master/photonos-package-report/scans/timeline-chart.png?run=\${{ github.run_id }})\`. The \`?run=\` query string defeats CDN caching between runs so the operator always sees the freshest chart.
- By the time the operator opens the workflow run page (post-job), the commit step has already pushed the PNG; the URL therefore resolves to the chart from this exact run.

## Test plan

- [ ] Dispatch \`Photon OS Database Report\`, confirm the **Timeline chart** section in the run summary renders the chart inline (no broken icon).
- [ ] \`?run=<id>\` defeats any browser/CDN cache between runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)