### PR TITLE
phase-M task M131: opt into Node.js 24 for package-report-C.yml JS actions

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -52,6 +52,19 @@ permissions:
   contents: write   # commit the journal back to master
   actions:  read    # download artifact from the triggering workflow
 
+# M131: opt into Node.js 24 for all JavaScript actions in this workflow,
+# silencing the deprecation warning surfaced on run 26703036870:
+#   "Node.js 20 actions are deprecated. The following actions are
+#    running on Node.js 20 and may not work as expected:
+#    actions/download-artifact@v5, actions/upload-artifact@v4."
+# This sets the documented opt-in BEFORE the 2026-06-16 hard switch.
+# When validated as working with the existing @v5/@v4 pins, the workflow
+# stays on the same action major versions (no behavioural change), just
+# on the newer JS runtime. To temporarily roll back, swap to
+# ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 # Serialise C-side runs: they share a persistent clone cache on the
 # self-hosted runner (see "Reconstruct" step). Two concurrent runs would
 # race the same clone dirs / branch checkouts. Queue rather than cancel so


### PR DESCRIPTION
## Warning

Run 26703036870 surfaced:
\`\`\`
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected:
actions/download-artifact@v5, actions/upload-artifact@v4.
Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.
\`\`\`

## Approach

Per [GitHub's deprecation guide](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), set \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true\` at workflow level. This runs the **same** pinned actions on the Node.js 24 runtime — no upgrade to v6/v7/v8 of download-artifact required, no behavioural change to the actions themselves.

## Why this over bumping versions

| Approach | Change | Risk |
|---|---|---|
| **Env-var opt-in** ← chosen | Runtime only | tiny — same action code, newer JS engine |
| Upgrade to download-artifact@v8 | Major-version step | v7→v8 changed defaults around merge-multiple and name resolution — needs its own compat audit |

## Validation plan

Dispatch this workflow on master post-merge, verify:
- [x] gate / parity-gate green on PR
- [ ] No "Node.js 20 actions are deprecated" annotation on the test run
- [ ] Artifact download + uploads succeed end-to-end (PS-snapshot download, c-side-prn upload, c-side-specs-new upload when modify_spec=true)

## Rollback

Drop the \`env\` block; or set \`ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true\` after the 2026-06-16 default flip if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)