### PR TITLE
phase-M task M133: add main to snyk-analysis default branches list

### DIFF
--- a/.github/workflows/snyk-analysis.yml
+++ b/.github/workflows/snyk-analysis.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       branches:
         description: 'Photon branches to scan (comma-separated)'
-        default: '3.0,4.0,5.0,6.0,common,dev,master'
+        default: '3.0,4.0,5.0,6.0,common,dev,master,main'
       workingDir:
         description: 'Working directory containing photon-upstreams/ (default: $GITHUB_WORKSPACE/reports — matches package-report)'
         default: ''


### PR DESCRIPTION
## Summary

\`workflow_dispatch.inputs.branches.default\` was \`3.0,4.0,5.0,6.0,common,dev,master\` (7 branches, no \`main\`). The snyk-analysis tooling has no per-branch allowlist (grep confirms zero hardcoded branch routing in \`SnykAnalysis/\`), so \`main\` is functionally identical to \`master\` / \`dev\` from the scanner's perspective. The omission was historical; \`package-report-C.yml\` already includes \`main\` on equal footing since M66.

After: \`3.0,4.0,5.0,6.0,common,dev,master,main\` — 8 branches, matching the package-report defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)