### PR TITLE
phase-M task M135: default sha_cache=ON in package-report-C workflow

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -27,8 +27,8 @@ on:
         description: 'Concurrency for CheckURLHealth (sequential clones on-demand at -ThrottleLimit 1 take many hours for full multi-branch snapshots). Drop to 1 when chasing a strict-diff that needs byte-stable stderr ordering.'
         default: '8'
       sha_cache:
-        description: 'M64 TODO-1: activate the shared col9 SHA cache (PR_SHA_CACHE). Default false: validation (run 26357010174) showed 122 residual col9 mismatches because col9 has several computation paths + download-name vs preserved-filename gaps the simple cache does not yet close. Keep off until the col9-path completion follow-on lands; the preserve/mechanism is dormant infra meanwhile.'
-        default: 'false'
+        description: 'M64/M135 TODO-1: read PS-preserved tarballs from the shared col9 SHA cache (PR_SHA_CACHE). Default true. Direct cache vs .prn analysis on the 2026-06-01 PS+C pair (M135) measured 4833/4913 cache HITs across all 8 branches (98.4% of PS-has-SHA rows) -- the original M64 122-row finding has collapsed as sha.c hardened the cache-only path. Set false only to reproduce a pre-cache C result for debugging.'
+        default: 'true'
       strict_col9:
         description: 'M64 TODO-3: count col9 (SHA) toward the strict verdict (PR_STRICT_COL9). Leave false until the shared col9 cache (TODO-1) has been confirmed to hold col9 byte-stable across a PS→C cycle — enabling early spikes strict and resets the 90-day clock.'
         default: 'false'

--- a/photonos-package-report/photonos-package-report/docs/maintainer-runbook.md
+++ b/photonos-package-report/photonos-package-report/docs/maintainer-runbook.md
@@ -536,6 +536,60 @@ only when:
 In both cases open a separate PR that resets the journal explicitly
 with a justification linked to the ADR or PRD change.
 
+### col9 SHA cache (`sha_cache` workflow input, default ON since M135)
+
+The C workflow reads PS's preserved `SOURCES_NEW/*.tar.{gz,xz,bz2}`
+from a shared cache so PS and C hash byte-identical bytes. Net effect:
+~70-100 % of `SHAName` (col 9) emits match PS row-for-row, depending
+on how close in time the two runs are.
+
+Where the cache lives on the self-hosted runner:
+
+```
+${PR_SHA_CACHE_BASE:-$HOME/.cache/photonos-shared/photon-upstreams}
+└── photon-<branch>/SOURCES_NEW/<UpdateDownloadName>
+```
+
+The PS workflow's "Preserve SOURCES_NEW to shared col9 cache" step
+writes here on every PS run; the C workflow reads through
+`col9_cache_path()` when `PR_SHA_CACHE=1`. A 50 GB LRU prune kicks in
+when the cache exceeds the cap (tarballs older than 21 days dropped).
+
+#### When you'd flip `sha_cache=false`
+
+* Reproducing a pre-cache C result for a regression bisection.
+* Investigating col9 byte-drift suspected to come from the cache
+  itself (rare — the cache is just a filesystem copy of what PS
+  downloaded, so unless the cache file is *corrupted* you'd see
+  identical bytes).
+
+#### Why a manual replay shows lower col9 match-rate than production
+
+In a `workflow_run` auto-trigger run, PS preserves the tarballs and
+the C run starts within seconds — the cache state on disk and PS's
+own `.prn`-frozen SHAs are guaranteed to be the same bytes.
+
+In a `workflow_dispatch -f snapshot_run_id=<old-id>` manual replay,
+PS preserved its tarballs into the cache *at the time the snapshot
+was taken*; later PS runs have since OVERWRITTEN those entries with
+newer bytes. Github (and GitLab) auto-regenerate archive tarballs
+non-deterministically — different compression timing → different
+hash. So in manual replays the cache hashes drift from the snapshot's
+frozen col9 values, and a fraction of rows show `both-differ`.
+
+If you want a manual replay that matches the snapshot's col9 hashes
+exactly, you'd have to snapshot the cache itself alongside
+`parity-snapshot-<id>.tar.gz` (deferred — production auto-trigger
+makes this unnecessary).
+
+#### Strict / soft
+
+col9 mismatches are **soft** by default — they do not fail the
+strict gate. `strict_col9` (workflow input → `PR_STRICT_COL9`) is the
+companion switch to promote col9 to strict; keep it OFF until the
+auto-trigger flow has been measured to hold col9 byte-stable across
+several cycles.
+
 ---
 
 ## 10. On-demand VPN for blocked upstream hosts (Stage 6)


### PR DESCRIPTION
## Summary
- Flip `sha_cache` workflow input default from `'false'` to `'true'`.
- Updated description from the stale M64-122-mismatch finding to the M135 cache-vs-prn measurement (4833/4913 cache hits = 98.4 %).

## Why
M64 (2026-05-24) measured 122 residual col9 mismatches with `sha_cache=ON` and defaulted OFF until col9-path completion landed. Since then `sha.c` hardened the `PR_SHA_CACHE_BASE`-set miss-returns-NULL path on all col9 emit sites.

Direct cache-vs-`.prn` analysis on the 2026-06-01 PS+C pair (PS run [26627758650](https://github.com/dcasota/photonos-scripts/actions/runs/26627758650) / C run [26740005888](https://github.com/dcasota/photonos-scripts/actions/runs/26740005888)) measured across all 8 branches:

| | rows | share |
|---|---:|---:|
| Cache HITs with `sha_cache=ON` | 4833 | **98.4 %** |
| Version-drift (PS snapshot 3 days older than C run; auto-trigger eliminates) | 15 specs | manual-dispatch artefact |
| Real C-side bugs (different upstream URL than PS) | 2 specs | M136 newt + M137 psmisc |

## Safety
- col9 is still soft (`PR_STRICT_COL9` = OFF, TODO-3) -- flipping `sha_cache` cannot regress the strict verdict.
- The only behavioural change is converting `PS-has-SHA / C-empty` diff-report rows into matched rows (or, in the cache-miss tail, into nothing -- same as today).
- A miss in cache-only mode returns NULL → empty col9, same as today's behaviour with the flag OFF.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] Operator: dispatch a full validation run on master with all-defaults; expect strict-rows unchanged (col9 is soft) and diff-report col9 row count to drop ~98 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)