### PR TITLE
phase-M task M139: extend sha_cache=ON default to workflow_run auto-trigger

### DIFF
--- a/.github/workflows/package-report-C.yml
+++ b/.github/workflows/package-report-C.yml
@@ -278,14 +278,21 @@ jobs:
           # the network paths to run — without it, cols 4/5/6/7/10 are
           # all empty on the C side and every row diffs strict.
           PR_TEST_NETWORK: "1"
-          # M64 / ADR-0009 TODO-1: shared col9 tarball cache. Gated by the
-          # sha_cache dispatch input (default OFF) — see its description for
-          # the residual-col9-mismatch finding. When on, PR_SHA_CACHE makes C
-          # hash from the cache and PR_SHA_CACHE_BASE points at the SOURCES_NEW
-          # the PS job preserved, so C reuses PS's exact bytes. Off on auto
-          # (workflow_run) runs → col9 behaves exactly as before this change.
-          PR_SHA_CACHE: ${{ github.event.inputs.sha_cache == 'true' && '1' || '' }}
-          PR_SHA_CACHE_BASE: ${{ github.event.inputs.sha_cache == 'true' && '/root/.cache/photonos-shared/photon-upstreams' || '' }}
+          # M64 / M135 / M139: shared col9 tarball cache (PR_SHA_CACHE).
+          # M135 flipped the workflow_dispatch input default to 'true', but
+          # `github.event.inputs.*` is empty on `workflow_run` events
+          # (GitHub Actions does not propagate dispatch-input defaults into
+          # workflow_run-triggered runs). The fixed expression below treats
+          # "input is anything other than the literal string 'false'" as ON
+          # so that:
+          #   - workflow_dispatch with sha_cache=true (the M135 default) → ON
+          #   - workflow_dispatch with explicit sha_cache=false           → OFF
+          #   - workflow_run auto-trigger (empty inputs)                  → ON
+          # PR_SHA_CACHE makes C hash from the cache; PR_SHA_CACHE_BASE
+          # points at the SOURCES_NEW the PS job preserved, so C reuses
+          # PS's exact bytes and col9 matches PS row-for-row.
+          PR_SHA_CACHE: ${{ github.event.inputs.sha_cache != 'false' && '1' || '' }}
+          PR_SHA_CACHE_BASE: ${{ github.event.inputs.sha_cache != 'false' && '/root/.cache/photonos-shared/photon-upstreams' || '' }}
           # T1: single-spec investigation mode. When set, the C binary
           # compacts its task list to only that one spec basename (e.g.
           # "libev.spec"). Diagnostic-only — the resulting .prn has one


### PR DESCRIPTION
## Summary
- Change `PR_SHA_CACHE` / `PR_SHA_CACHE_BASE` evaluation in `package-report-C.yml` from `inputs.sha_cache == 'true'` to `inputs.sha_cache != 'false'`.
- Effect: auto-trigger (`workflow_run`) runs now see `PR_SHA_CACHE=1` instead of empty.

## Why
M135 flipped the workflow_dispatch input default to `'true'`, expecting auto-trigger runs to inherit it. They don't — GitHub Actions does NOT propagate `workflow_dispatch.inputs` defaults to `workflow_run`-triggered runs, so `github.event.inputs.sha_cache` is empty on auto-trigger and the existing `== 'true'` check evaluates falsy.

Confirmed empirically on the first post-M135 auto-trigger run [26878330214](https://github.com/dcasota/photonos-scripts/actions/runs/26878330214):
- `PR_SHA_CACHE:` printed empty in the "Run C binary" environment
- 0 / 4917 col9 SHAName matches across all 8 branches
- diff-report shape identical to pre-M135 era

| Trigger | input value | Before M139 | After M139 |
|---|---|---|---|
| `workflow_dispatch` (M135 default true) | `'true'` | ON ✓ | ON ✓ |
| `workflow_dispatch` explicit false | `'false'` | OFF ✓ | OFF ✓ |
| `workflow_run` auto-trigger | empty | **OFF ✗** | **ON ✓** |

## Safety
- col9 is still soft (`PR_STRICT_COL9 = OFF`); the only change is auto-trigger now emits col9 SHAs instead of empties.
- Other inputs (`strict_col9`, `modify_spec`, `single_spec`, author overrides) intentionally KEEP the empty-defaults-to-legacy behaviour and need no change.

## Test plan
- [x] YAML parses cleanly
- [ ] Gate + parity-gate pass (PR exercises the gates)
- [ ] After merge, next PS run + auto-trigger C will measure the real production col9 match-rate (expected ~95 %+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)