### PR TITLE
phase-M task M140: drop cp -a in PS preserve step so cache mtimes match preserve-time

### DIFF
--- a/.github/workflows/package-report.yml
+++ b/.github/workflows/package-report.yml
@@ -421,9 +421,23 @@ jobs:
             [ -d "$d" ] || continue
             br=$(basename "$(dirname "$d")")
             mkdir -p "$SHARED/$br/SOURCES_NEW"
-            cp -a "$d/." "$SHARED/$br/SOURCES_NEW/" 2>/dev/null && n=$((n+1)) || true
+            # M140: NO `-a` here. `cp -a` would preserve the workspace's
+            # mtime on the cached copy, but PS only re-downloads a tarball
+            # when its detected version changes. Most tarballs in workspace
+            # carry mtimes from the run that first downloaded them (weeks
+            # or months ago). With `cp -a`, those ancient mtimes propagate
+            # to the cache, and the 21-day LRU prune below then deletes
+            # tarballs we just re-preserved -- the cache visibly halved
+            # between PS runs 26874878793 (65 GB, ~1100 files/branch) and
+            # 26883987022 (34 GB, ~500 files/branch). Plain `cp -rfL`
+            # stamps cached copies with the current preserve-time, so the
+            # 21-day prune only kills tarballs PS hasn't re-touched in 21d.
+            cp -rfL "$d/." "$SHARED/$br/SOURCES_NEW/" 2>/dev/null && n=$((n+1)) || true
           done
           # Disk cap (LRU by mtime): keep the shared tarball cache bounded.
+          # Now safe to be aggressive -- the only mtime "old" files are ones
+          # PS legitimately stopped downloading (spec dropped from photon,
+          # spec no longer targeted, etc).
           CAP_MB=50000
           cur=$(du -sm "$SHARED" 2>/dev/null | cut -f1)
           if [ "${cur:-0}" -gt "$CAP_MB" ]; then


### PR DESCRIPTION
## Summary
- Replace `cp -a "$d/." "$SHARED/$br/SOURCES_NEW/"` with `cp -rfL ...` in the PS workflow's "Preserve SOURCES_NEW to shared col9 cache" step.
- Result: cached tarballs get the **current** mtime when preserved, not the workspace's stale download mtime.

## Why
The post-M139 auto-trigger validation run [26888581942](https://github.com/dcasota/photonos-scripts/actions/runs/26888581942) confirmed `PR_SHA_CACHE=1` was set in env (the M139 wiring works) but only hit **30.1 % col9 match** across all branches — way below the projected ~95 %.

Investigation: PS workspace has `acl-2.3.2.tar.gz` dated 2026-05-12, but the cache doesn't have it. Reason — `cp -a` preserves the source mtime, so the cached copy inherits the workspace's ancient mtime. The 21-day LRU prune that fires when cache exceeds 50 GB then deletes tarballs we just re-preserved.

Empirical evidence: cache size halved between PS runs 26874878793 (65 GB, ~1100 files/branch) and 26883987022 (34 GB, ~500 files/branch). main branch is the exception (75.8 % match) because main is a newer branch and most of its tarballs were downloaded after May 12 → fresh mtimes survive the prune.

| Run | cache size | files/branch (avg) | col9 match |
|---|---:|---:|---:|
| 26874878793 (pre-prune) | 65 GB | ~1100 | n/a (M139 not yet) |
| 26883987022 (post-prune) | 34 GB | ~500 | 30.1 % |
| Expected after M140 | ~30 GB | converges to workspace size | ~95 %+ |

## Safety
- Plain `cp` (no `-a`, no `-p`) is GNU coreutils default; cached files get current mtime.
- No data loss: the next PS run touches every preserved tarball, bringing all into the "21-day-fresh" window in one step.
- Worst case: cache might temporarily exceed 50 GB after the first post-M140 PS run; the prune correctly handles that on the run after.

## Test plan
- [x] YAML parses cleanly
- [x] Local demo: `cp -a /tmp/src/file /tmp/dst/file` carries May-12 mtime; `cp -rfL` stamps Jun-3 mtime
- [ ] Gate + parity-gate pass (PR exercises gates)
- [ ] After merge, dispatch PS+C auto-trigger cycle; expect col9 match ≥ 90 %

🤖 Generated with [Claude Code](https://claude.com/claude-code)