### PR TITLE
phase-M task M141: PS col9 hashes cache bytes (composes ADR-0015 + M140)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -5182,25 +5182,36 @@ function CheckURLHealth {
         [system.string]$SHALine=""
         [system.string]$SHAValue=""
 
-        # ADR-0015 (Accepted Option A): for github auto-archive URLs,
-        # the SHA against the auto-archive drifts (GitHub regenerates
-        # the tarball on demand). Probe the corresponding
-        # releases/download/<tag>/<asset> URL and, if available, hash
-        # against the stable asset. The auto-archive remains
-        # downloaded for ModifySpecFile / UpdateDownloadFile uses;
-        # only the col-9 .prn value is sourced from the stable URL.
+        # M141 (composes ADR-0015 + M140, 2026-06-05): col9 always
+        # hashes $UpdateDownloadFile, i.e. the bytes preserved to the
+        # M140 col9 cache. The original ADR-0015 design (Option A)
+        # silently swapped col9 to the stable-asset SHA whenever a
+        # release-asset URL was found, which made col6 (download URL)
+        # and col9 (its SHA) semantically inconsistent and produced
+        # a 1242-row C↔PS col9 gap once M140 shipped (cache holds the
+        # auto-archive bytes; PS was hashing a different artefact).
+        #
+        # ADR-0015 stays: the stable-asset URL is still resolved and
+        # the file still downloaded, but its SHA now flows into the
+        # ADR-0014 cols 13/14 (gated by PR_EMIT_MULTI_SHA) where it
+        # serves as a canonical-attestation anchor independent of
+        # col9's operational-integrity role.
         [system.string]$ShaSourceFile = $UpdateDownloadFile
+        [system.string]$StableShaSourceFile = ""
         $stableSourceURL = Resolve-StableSourceURL -SpecName $currentTask.spec -LatestTag $UpdateAvailable -CurrentURL $UpdateURL
         if (-not [string]::IsNullOrEmpty($stableSourceURL)) {
             $stableFile = [system.string](Join-Path -Path (Split-Path $UpdateDownloadFile -Parent) -ChildPath ([System.Guid]::NewGuid().ToString() + ".stable")).Trim()
             try {
                 Invoke-WebRequest -Uri $stableSourceURL -UseBasicParsing -OutFile $stableFile -TimeoutSec 60 -ErrorAction Stop
-                if (Test-Path $stableFile) { $ShaSourceFile = $stableFile }
+                if (Test-Path $stableFile) { $StableShaSourceFile = $stableFile }
             } catch {}
         }
 
-        # ADR-0014 (Accepted Option B): cols 13 (SHA256Name) + 14
-        # (SHA512Name) computed against the same stable source URL.
+        # ADR-0014 (Accepted Option B) composed with M141: cols 13
+        # (SHA256Name) + 14 (SHA512Name) carry the stable-asset SHA
+        # when ADR-0015 found a release-asset URL; otherwise they fall
+        # back to hashing the same bytes col9 hashed. Either way these
+        # are vendor-info-quality hashes independent of col9.
         # Emission of the new cols gated by env var PR_EMIT_MULTI_SHA.
         [system.string]$SHA256Name = ""
         [system.string]$SHA512Name = ""
@@ -5216,16 +5227,21 @@ function CheckURLHealth {
                 # ADR-0014: always compute SHA-256 and SHA-512 alongside
                 # the spec's preferred algorithm. Get-FileHashWithRetry
                 # streams from local file so two extra calls are cheap.
+                # M141: prefer the stable-asset file when ADR-0015 found
+                # one; otherwise hash the same bytes col9 hashed.
                 if (-not [string]::IsNullOrEmpty($env:PR_EMIT_MULTI_SHA)) {
-                    $SHA256Name = (Get-FileHashWithRetry $ShaSourceFile -Algorithm SHA256).Hash
-                    $SHA512Name = (Get-FileHashWithRetry $ShaSourceFile -Algorithm SHA512).Hash
+                    $multiShaFile = if ((-not [string]::IsNullOrEmpty($StableShaSourceFile)) -and (Test-Path $StableShaSourceFile)) { $StableShaSourceFile } else { $ShaSourceFile }
+                    $SHA256Name = (Get-FileHashWithRetry $multiShaFile -Algorithm SHA256).Hash
+                    $SHA512Name = (Get-FileHashWithRetry $multiShaFile -Algorithm SHA512).Hash
                 }
             }
         }
 
         # Clean up the temporary stable-asset file if we created one.
-        if (-not [string]::IsNullOrEmpty($stableSourceURL) -and $ShaSourceFile -ne $UpdateDownloadFile) {
-            Remove-Item -Path $ShaSourceFile -Force -ErrorAction SilentlyContinue
+        # M141: now keyed off $StableShaSourceFile (separate variable
+        # from $ShaSourceFile, which now stays = $UpdateDownloadFile).
+        if ((-not [string]::IsNullOrEmpty($StableShaSourceFile)) -and (Test-Path $StableShaSourceFile)) {
+            Remove-Item -Path $StableShaSourceFile -Force -ErrorAction SilentlyContinue
         }
         # Add a space to signalitze that something went wrong when extracting SHAvalue but do not stop modifying the spec file.
         if ([string]::IsNullOrEmpty($SHALine)) { $SHALine=" " }

--- a/photonos-package-report/photonos-package-report/specs/adr/0015-stable-source-sha.md
+++ b/photonos-package-report/photonos-package-report/specs/adr/0015-stable-source-sha.md
@@ -188,3 +188,80 @@ redundancy — both axes addressed.
 - FRD-007 (GitHub tag detection)
 - The col-9-only bucket (~75 specs/branch in the post-M21-wired
   journal) is the direct target.
+
+## Amendment (M141, 2026-06-05) — composition with M140
+
+**Status**: Accepted (dcasota, 2026-06-05). Supersedes the col-9
+override behaviour of Option A above; ADR-0015's resolver itself is
+retained.
+
+### Why the original col-9 override no longer fits
+
+Option A was decided 2026-05-18 against a parity baseline where PS
+and C each downloaded their own copy of the tarball — the byte-drift
+risk was real because PS-time and C-time were ~hours apart. M140
+(2026-06-03) eliminated that gap by having PS preserve `SOURCES_NEW`
+to a shared col-9 cache that C then reads. With M140 in place, PS and
+C see byte-identical tarballs regardless of GitHub's behaviour, so
+the parity-side justification for swapping col-9 to the stable URL
+no longer holds.
+
+The override also has a cost the original ADR didn't book: col-6
+(the URL the spec downloads from) and col-9 (the SHA emitted)
+become semantically inconsistent. A downstream consumer fetching
+col-6 and verifying against col-9 gets a mismatch — col-9 was
+computed against a different URL. With the M140 cache holding the
+auto-archive bytes, this manifests as 1242 both-differ col-9 rows
+between PS and C, all on the same root cause.
+
+### Revised composition
+
+- **col-9** always hashes `$UpdateDownloadFile` — i.e. the bytes
+  preserved to the M140 col-9 cache, which is also what col-6
+  points at. Col-6 and col-9 are now semantically consistent again
+  (operational-integrity anchor: "the bytes you fetched from the
+  URL you were told to fetch them from").
+
+- **ADR-0015's `Resolve-StableSourceURL`** still fires and still
+  downloads the stable-asset file, but its SHA now flows into
+  **ADR-0014 cols 13 / 14** (`SHA256Name` / `SHA512Name`,
+  gated by `PR_EMIT_MULTI_SHA`) as a canonical-attestation anchor:
+  "the SHA of the maintainer-uploaded release artefact for this
+  tag, stable across time and indexable by SBOM / supply-chain
+  tooling". The two anchors serve different verification questions
+  and degrade independently.
+
+### Why this is more robust than either Option A or "delete ADR-0015"
+
+- Multiple independent verification anchors per artefact (col-9 for
+  what-you-fetched; cols 13/14 for canonical-stable) — the
+  structural property SLSA / in-toto attestation pipelines expect.
+- Defence in depth across hash algorithms: col-9's SHA-512 + cols
+  13/14's SHA-256 + SHA-512 guards against single-algorithm break.
+- Graceful degradation: when `Resolve-StableSourceURL` returns
+  null (no release asset, host outside allowlist), cols 13/14 fall
+  back to hashing the same bytes col-9 hashed — non-empty rather
+  than half-broken.
+
+### Implementation (M141 = PS-side; M142+ = C-side)
+
+- **M141 (PS)**: `photonos-package-report.ps1` ~L 5192-5232:
+  introduce `$StableShaSourceFile` separate from `$ShaSourceFile`;
+  stop assigning `$ShaSourceFile = $stableFile`; cols 13/14
+  resolution prefers `$StableShaSourceFile` when set, falls back
+  to `$ShaSourceFile` otherwise; cleanup keys off
+  `$StableShaSourceFile`. **Effect**: col-9 immediately aligns
+  with cache bytes → 1242-row gap closes.
+- **M142 (C)**: port `Resolve-StableSourceURL` + multi-SHA
+  emission. Until then C continues to emit 12-col rows; cols
+  13/14 are PS-only (the parity-diff treats absent cols as
+  trivially-matched for now). Strict comparison on 13/14 enables
+  once both sides emit.
+- **M143 (gate + parity-diff)**: 14-col schema rolled into
+  parity-diff comparison + journal verdict logic.
+
+### Open questions deferred from original ADR
+
+- HEAD probe failure modes, asset-name variability, resolved-URL
+  caching — all still apply to the ADR-0015 resolver itself, just
+  no longer affect col-9 verdict stability.


### PR DESCRIPTION
## Summary

ADR-0015's Option A (Accepted 2026-05-18) swapped col9's SHA computation to the GitHub release-asset URL whenever one was found, under the premise that PS and C would otherwise hash drifted bytes. **M140 (2026-06-03) made that premise moot**: PS now preserves SOURCES_NEW to a shared col9 cache that C reads, so both sides see byte-identical inputs regardless of GitHub's behaviour.

With the override still in place, PS hashes stable-asset bytes and C (reading the cache) hashes auto-archive bytes. Empirically on PS 26988245462 / C 26990730946 this produced **1242 both-differ col9 rows on identical UpdateDownloadName** — the full residual gap that survived M135/M139/M140.

This PR aligns col9 with the cache bytes:

- ``$ShaSourceFile`` stays = ``$UpdateDownloadFile`` unconditionally
- New ``$StableShaSourceFile`` tracks the resolved release-asset file
- Cleanup keys off ``$StableShaSourceFile``
- ADR-0014 cols 13/14 (``PR_EMIT_MULTI_SHA``-gated) prefer ``$StableShaSourceFile`` when set, fall back to ``$ShaSourceFile``

ADR-0015's resolver is retained — the stable-asset SHA moves from col9 to cols 13/14 as a canonical-attestation anchor independent of col9's operational-integrity role. **Col6 (download URL) and col9 (its SHA) become semantically consistent again.**

## Expected effect on parity verdict

The 1242 both-differ rows close; col9 match rate climbs from **68.2 % → ~93-94 %**. Residual gap (~300 PS-only, ~60 C-only, plus the non-github acl-style C cache-lookup sub-bucket) carries into M142+ work.

## Test plan

- [ ] parity-gate (PR) green on this branch
- [ ] post-merge: dispatch PS workflow, watch auto-trigger C, measure new col9 match rate
- [ ] confirm cols 13/14 still empty by default (``PR_EMIT_MULTI_SHA`` unset) — schema unchanged for current consumers
- [ ] confirm M141 commit-block comments preserved in the patched ps1

## Notes

- FRD: FRD-007
- ADR: ADR-0014 (compose), ADR-0015 (amended — col9 override removed; resolver retained)
- PS-source: photonos-package-report.ps1 L 5184-5237
- Parity: strict (this PR is the col9 alignment, not a verdict downgrade)
- ADR-0015 doc updated with "Amendment (M141, 2026-06-05) — composition with M140" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)