### PR TITLE
phase-M task M142: fix PS sha-alg fallback typo ($object → $currentTask.content)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -5223,7 +5223,20 @@ function CheckURLHealth {
                 if ($currentTask.content -ilike '*%define sha256*') { $SHAValue = (Get-FileHashWithRetry $ShaSourceFile -Algorithm SHA256).Hash;$SHALine = [system.string]::concat('%define sha256 ',$currentTask.Name,'=',$SHAValue) }
                 if ($currentTask.content -ilike '*%define sha512*') { $SHAValue = (Get-FileHashWithRetry $ShaSourceFile -Algorithm SHA512).Hash;$SHALine = [system.string]::concat('%define sha512 ',$currentTask.Name,'=',$SHAValue) }
                     # if the spec file does not contain any sha value, add sha512
-                if ((!($currentTask.content -ilike '*%define sha512*')) -and (!($object -ilike '*%define sha256*')) -and (!($object -ilike '*%define sha1*'))) { $SHAValue = (Get-FileHashWithRetry $ShaSourceFile -Algorithm SHA512).Hash; $SHALine = [system.string]::concat('%define sha512 ',$currentTask.Name,'=',$SHAValue) }
+                # M142 (2026-06-05): the sha256/sha1 negation checks
+                # referenced $object instead of $currentTask.content -- a
+                # typo that left $object undefined in this scope, so the
+                # `!($object -ilike ...)` terms always evaluated true and
+                # the SHA-512 fallback fired for every spec missing
+                # %define sha512, OVERWRITING the algorithm correctly
+                # picked by the prior three checks above. Empirically
+                # this caused 554 algo-divergence rows on the
+                # 27017982736/27021237366 parity pair (PS emitted
+                # SHA-512 for specs the spec file declared as sha1 or
+                # sha256). All three negations now key off
+                # $currentTask.content so the fallback only fires when
+                # the spec genuinely declares no algorithm.
+                if ((!($currentTask.content -ilike '*%define sha512*')) -and (!($currentTask.content -ilike '*%define sha256*')) -and (!($currentTask.content -ilike '*%define sha1*'))) { $SHAValue = (Get-FileHashWithRetry $ShaSourceFile -Algorithm SHA512).Hash; $SHALine = [system.string]::concat('%define sha512 ',$currentTask.Name,'=',$SHAValue) }
                 # ADR-0014: always compute SHA-256 and SHA-512 alongside
                 # the spec's preferred algorithm. Get-FileHashWithRetry
                 # streams from local file so two extra calls are cheap.


### PR DESCRIPTION
## Summary

Line 5226 of ``photonos-package-report.ps1`` had a typo in the sha-alg fallback check: the sha256 and sha1 negation terms referenced ``\$object`` instead of ``\$currentTask.content``. With ``\$object`` undefined in this scope, ``!(\$object -ilike ...)`` always evaluated true, and the SHA-512 fallback fired for every spec missing ``%define sha512`` — which **overwrote** the correct algorithm picked by the three positive checks immediately above (lines 5222-5224).

## Effect on the .prn

PS col9 emitted SHA-512 for every spec whose spec file declared ``%define sha1`` or ``%define sha256``, ignoring the declared algorithm. Empirically observed on PS run 27017982736 / C run 27021237366: **554 col9 rows differ** between PS (SHA-512, 128 chars) and C (correctly-selected sha1, 40 chars). The bytes hashed were identical (cache match); only the algorithm choice diverged.

## Fix

Route all three negations through ``\$currentTask.content``. The fallback now fires only when the spec genuinely declares no algorithm, in which case both PS and C default to SHA-512.

## Expected effect

Closes the 554-row algo-divergence sub-cluster of the M141 residual gap. col9 match rate predicted: **71.1 % → ~82-83 %**. Remaining ~570 same-algo divergence (python-* concentration) is a separate investigation tracked as M143.

## Test plan

- [ ] parity-gate (PR) green
- [ ] post-merge: dispatch PS + auto-trigger C, measure new col9 match rate
- [ ] sanity-check acl.spec on 3.0 (was SHA-512 vs SHA-1 mismatch): PS should now emit SHA-1 matching C

## Notes

- FRD: FRD-011
- ADR: ADR-0006 (bit-identical priority)
- PS-source: photonos-package-report.ps1 L 5226
- Parity: strict
- Composes with: M141 (col9 = cache bytes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)