### PR TITLE
phase-M task M144: compute col9 SHA in M57 hardcoded-override block

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -2998,8 +2998,16 @@ char *check_urlhealth(pr_task_t                       *task,
      * stray value) for the same net output. HealthUpdateURL is "200";
      * UpdateDownloadName derives from the URL via the standard L4810-4842
      * pipeline (download_name_post), so the leading-'v' strip etc. match PS.
-     * col9 (SHAValue) is left empty here — it is soft in the parity verdict
-     * and PS computes it from a network fetch we intentionally skip. */
+     *
+     * M144 (2026-06-05): col9 was previously left empty here under the
+     * (incorrect) assumption that col9 was soft in the parity verdict.
+     * col9 IS strict (ADR-0006), and PS DOES compute it for these specs
+     * via Get-FileHashWithRetry against the pinned UpdateDownloadFile.
+     * That left ~46-98 PS-only col9 rows (cdrkit, mpc, sendmail, runit,
+     * vsftpd, python-daemon, python-Js2Py, python-ruamel-yaml, etc.) in
+     * the residual gap. Below we compute SHA via the standard
+     * cache-aware pipeline used by the github-tag / scraper / PyPI paths,
+     * so PS-preserved cache bytes flow into col9 here too. */
     {
         static const struct { const char *spec, *url, *ver, *archdate; } k_hard[] = {
             {"cdrkit.spec",             "https://deb.debian.org/debian/pool/main/c/cdrkit/cdrkit_1.1.11.orig.tar.gz", "1.1.11", "2021-10-10"},
@@ -3028,6 +3036,26 @@ char *check_urlhealth(pr_task_t                       *task,
             if (state.UpdateDownloadName == NULL) state.UpdateDownloadName = dup_or_empty("");
             if (k_hard[i].archdate[0]) {
                 free(state.ArchivationDate); state.ArchivationDate = dup_or_empty(k_hard[i].archdate);
+            }
+            /* M144: compute col9 via the standard cache-aware pipeline so
+             * PS-preserved cache bytes flow into the hardcoded-override
+             * row too. Uses the same %define-sha1/256/512 detection
+             * pattern as the github-tag / scraper / PyPI paths. */
+            if (state.UpdateURL && state.UpdateURL[0]
+                && state.UpdateDownloadName && state.UpdateDownloadName[0]) {
+                pr_sha_alg_t alg = PR_SHA512;
+                for (size_t li = 0; li < task->content_lines; li++) {
+                    const char *line = task->content[li];
+                    if (line == NULL) continue;
+                    if (strstr(line, "%define sha1")   != NULL) { alg = PR_SHA1;   break; }
+                    if (strstr(line, "%define sha256") != NULL) { alg = PR_SHA256; break; }
+                    if (strstr(line, "%define sha512") != NULL) { alg = PR_SHA512; break; }
+                }
+                char *cache_file_hc = col9_cache_path(
+                    clone_root, state.UpdateDownloadName);
+                char *hex_hc = pr_sha_of_url_cached(alg, state.UpdateURL, cache_file_hc);
+                if (hex_hc) { free(state.SHAValue); state.SHAValue = hex_hc; }
+                free(cache_file_hc);
             }
             break;
         }


### PR DESCRIPTION
## Summary

The M57 hardcoded UpdateURL/UpdateAvailable override block (L2990-3034 of ``check_urlhealth.c``) explicitly left ``state.SHAValue`` empty for the 14 pinned specs (cdrkit, iptraf, json-spirit, libassuan, libtiff, mpc, python-daemon, python-enum, python-enum34, python-Js2Py, python-ruamel-yaml, runit, sendmail, vsftpd) under the comment *"col9 is soft in the parity verdict"*.

**col9 is strict, not soft** (ADR-0006). PS DOES compute col9 for these specs via ``Get-FileHashWithRetry`` against the pinned UpdateDownloadFile. Empirically on PS 27033250548 / C 27036499180: **~46-98 PS-only rows** across these specs × branches trace to this intentional skip.

## Fix

Add SHA computation via the same cache-aware pipeline used by the github-tag / scraper / PyPI paths — reads PS-preserved bytes from the M140 col9 cache when available, so PS and C produce byte-identical col9 for the pinned overrides too. Same ``%define sha1/256/512`` detection pattern as the other sites.

## Expected effect

Closes the M57-hardcoded sub-cluster (~46-98 of the 112 PS-only rows). col9 match rate predicted: **97.6 % → ~98.5-99.5 %**.

## Test plan

- [x] local build clean
- [x] local ctest: 14/14 pass
- [ ] parity-gate (PR) green
- [ ] post-merge: dispatch PS + auto-trigger C, measure new col9 match rate
- [ ] sanity-check: mpc.spec on 3.0 → C col9 should match cache SHA-1 ``BAC1C1FA79F5602DF1E29E4684E103AD55714E02``

## Notes

- FRD: FRD-011
- ADR: ADR-0006 (bit-identical priority)
- PS-source: photonos-package-report.ps1 L 2264-2363, 5210-5226
- Parity: strict
- Composes with: M141 (col9 = cache bytes), M142 (PS sha-alg typo), M143 (C python PyPI SHA recompute)

🤖 Generated with [Claude Code](https://claude.com/claude-code)