### PR TITLE
phase-M task M145: empty-string env var counts as unset (POSIX convention)

### DIFF
--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -550,7 +550,15 @@ static int pr_build_update_url(pr_task_t *task, const char *source0_save,
  * Returns NULL (→ legacy /tmp download) when caching is off or inputs missing. */
 static char *col9_cache_path(const char *clone_root, const char *download_name)
 {
-    if (getenv("PR_SHA_CACHE") == NULL) return NULL;
+    /* M145 (2026-06-06): treat empty-string env var the same as unset.
+     * GitHub Actions workflow YAML cannot conditionally omit an env: entry,
+     * so when sha_cache=false the workflow sets PR_SHA_CACHE="" -- but
+     * getenv() returns "" (not NULL) for an empty-string-set env var, so
+     * the old `getenv(...) == NULL` check let cache_file get computed and
+     * later returned NULL inside pr_sha_of_url_cached, breaking the
+     * live-download fallback. POSIX-conventional: empty == unset. */
+    const char *e = getenv("PR_SHA_CACHE");
+    if (e == NULL || e[0] == '\0') return NULL;
     if (clone_root == NULL || clone_root[0] == '\0') return NULL;
     if (download_name == NULL || download_name[0] == '\0') return NULL;
     const char *suffix = "/clones";

--- a/photonos-package-report/photonos-package-report/src/sha.c
+++ b/photonos-package-report/photonos-package-report/src/sha.c
@@ -150,8 +150,16 @@ char *pr_sha_of_url_cached(pr_sha_alg_t alg, const char *url,
      * SOURCES_NEW), a miss means PS did NOT preserve this tarball — i.e. PS
      * itself produced an empty col9. Mirror that (return NULL → empty) instead
      * of downloading C's own bytes, which would create a spurious col9 diff
-     * (C-has-SHA vs PS-empty, or auto-archive byte drift). */
-    if (getenv("PR_SHA_CACHE_BASE") != NULL)
+     * (C-has-SHA vs PS-empty, or auto-archive byte drift).
+     *
+     * M145 (2026-06-06): empty-string env var counts as unset (POSIX
+     * convention). GHA YAML cannot conditionally omit an env: entry, so
+     * the C workflow sets PR_SHA_CACHE_BASE="" when sha_cache=false; the
+     * old `getenv(...) != NULL` check wrongly entered shared-cache mode
+     * and returned NULL, breaking the legacy live-download fallback
+     * below. */
+    const char *cb = getenv("PR_SHA_CACHE_BASE");
+    if (cb != NULL && cb[0] != '\0')
         return NULL;
     /* Legacy (C-local cache): download into the cache path, persist, hash. */
     if (download_url_to_file(url, cache_file) != 0)
@@ -169,8 +177,10 @@ int pr_sha_of_url_multi_cached(const char *url,
     if (sha256_hex) *sha256_hex = NULL;
     if (sha512_hex) *sha512_hex = NULL;
     if (access(cache_file, R_OK) != 0) {
-        /* M64 shared-cache mode: miss → mirror PS's empty col9, don't fetch. */
-        if (getenv("PR_SHA_CACHE_BASE") != NULL) return -1;
+        /* M64 shared-cache mode: miss → mirror PS's empty col9, don't fetch.
+         * M145: empty-string env var counts as unset (POSIX convention). */
+        const char *cb_m = getenv("PR_SHA_CACHE_BASE");
+        if (cb_m != NULL && cb_m[0] != '\0') return -1;
         if (download_url_to_file(url, cache_file) != 0) return -1;
     }
     if (sha256_hex) {


### PR DESCRIPTION
## Summary

The C-side workflow YAML at ``.github/workflows/package-report-C.yml`` L294-295 sets ``PR_SHA_CACHE`` and ``PR_SHA_CACHE_BASE`` to **empty strings** when ``sha_cache=false``. GitHub Actions YAML cannot conditionally omit an ``env:`` entry. ``getenv()`` returns ``""`` (not ``NULL``) for empty-string-set vars, so the previous

```c
if (getenv("PR_SHA_CACHE") == NULL) return NULL;
if (getenv("PR_SHA_CACHE_BASE") != NULL) return NULL;
```

checks treated empty-string-set as "set", which:

1. Made ``col9_cache_path`` proceed when it should have returned NULL (no cache mode), producing a legacy-C cache path that doesn't exist.
2. Made ``pr_sha_of_url_cached`` enter shared-cache mode on the cache miss and return NULL instead of falling through to the legacy live-download path.

## Net effect

A ``sha_cache=false`` dispatch (C standalone, no PS-preserved cache) emitted **0 SHAs across all 4902 URL-having rows** — the live-download fallback was unreachable.

Verified on run 27049183025 (0/4902 col9 vs PS standalone 27050614603 emitting 4902 SHAs). 

## Fix

Replace ``getenv(...) == NULL`` and ``getenv(...) != NULL`` with empty-aware checks at three sites:
- ``check_urlhealth.c`` ``col9_cache_path`` (L553)
- ``sha.c`` ``pr_sha_of_url_cached`` (L154)
- ``sha.c`` ``pr_sha_of_url_multi_cached`` (L173)

POSIX convention: empty == unset.

## Why latent

PR_SHA_CACHE=true has been the production default since M135 (2026-06-03), so the live-download fallback was never exercised in CI. Surfaced when wiping the cache and dispatching C with ``sha_cache=false`` for a standalone validation.

## Test plan

- [x] local build clean
- [x] local ctest: 14/14 pass
- [ ] parity-gate (PR) green
- [ ] post-merge: re-run C standalone (cache empty, sha_cache=false), expect 4500+ SHA rows
- [ ] post-merge: comparison vs PS standalone 27050614603 (4902 SHA rows)

## Notes

- FRD: FRD-011
- ADR: ADR-0006 (bit-identical priority)
- Parity: strict
- Composes with: M141, M142, M143, M144 (the Option C col9 chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)