### PR TITLE
phase-M task M146: handle %define src_name + %{src_name} (alternatives.spec)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -314,6 +314,13 @@ function ParseDirectory {
             $srcname=""
             if ($content -ilike '*%define srcname*') { $srcname = (($content | Select-String -Pattern '%define srcname')[0].ToString() -ireplace '%define srcname', "").Trim() }
             if ($content -ilike '*%global srcname*') { $srcname = (($content | Select-String -Pattern '%global srcname')[0].ToString() -ireplace '%global srcname', "").Trim() }
+            # M146 (2026-06-06): some specs (e.g. alternatives.spec on
+            # 5.0 + main) use `%define src_name` (with underscore) and
+            # `%{src_name}` in Source0. Mirror to the same $srcname
+            # variable -- empirically no spec declares both srcname
+            # and src_name, so there is no conflict.
+            if ($content -ilike '*%define src_name*') { $srcname = (($content | Select-String -Pattern '%define src_name')[0].ToString() -ireplace '%define src_name', "").Trim() }
+            if ($content -ilike '*%global src_name*') { $srcname = (($content | Select-String -Pattern '%global src_name')[0].ToString() -ireplace '%global src_name', "").Trim() }
 
             $gem_name=""
             if ($content -ilike '*%define gem_name*') { $gem_name = (($content | Select-String -Pattern '%define gem_name')[0].ToString() -ireplace '%define gem_name', "").Trim() }
@@ -2278,6 +2285,8 @@ function CheckURLHealth {
     if ($Source0 -like '*{*')
     {
         if ($Source0 -ilike '*%{srcname}*') { $Source0 = $Source0 -ireplace '%{srcname}',$currentTask.srcname }
+        # M146: mirror srcname to also resolve %{src_name} (alternatives.spec).
+        if ($Source0 -ilike '*%{src_name}*') { $Source0 = $Source0 -ireplace '%{src_name}',$currentTask.srcname }
         if ($Source0 -ilike '*%{gem_name}*') { $Source0 = $Source0 -ireplace '%{gem_name}',$currentTask.gem_name }
         if ($Source0 -ilike '*%{extra_version}*') { $Source0 = $Source0 -ireplace '%{extra_version}',$currentTask.extra_version }
         if ($Source0 -ilike '*%{main_version}*') { $Source0 = $Source0 -ireplace '%{main_version}',$currentTask.main_version }

--- a/photonos-package-report/photonos-package-report/src/parse_directory.c
+++ b/photonos-package-report/photonos-package-report/src/parse_directory.c
@@ -336,6 +336,18 @@ static int parse_one_spec(const char *specs_path,
         free(srcname);
         srcname = first_value(content, n_lines, "%global srcname", "%global srcname");
     }
+    /* M146 (2026-06-06): alternatives.spec (5.0 + main) uses
+     * `%define src_name` (with underscore) and `%{src_name}` in
+     * Source0. Mirror to the same srcname field -- no spec declares
+     * both srcname and src_name simultaneously, so no conflict. */
+    if (lines_ilike_contains(content, n_lines, "%define src_name")) {
+        free(srcname);
+        srcname = first_value(content, n_lines, "%define src_name", "%define src_name");
+    }
+    if (lines_ilike_contains(content, n_lines, "%global src_name")) {
+        free(srcname);
+        srcname = first_value(content, n_lines, "%global src_name", "%global src_name");
+    }
 
     /* PS L 295-297: gem_name (define, then global overrides) */
     char *gem_name = empty_dup();

--- a/photonos-package-report/photonos-package-report/src/source0_substitute.c
+++ b/photonos-package-report/photonos-package-report/src/source0_substitute.c
@@ -172,6 +172,12 @@ int pr_source0_substitute(pr_task_t *task, char **source0, const char *version)
             *source0 = istr_replace_all(*source0, "%{srcname}", task->srcname ? task->srcname : "");
             if (*source0 == NULL) return -1;
         }
+        /* M146: %{src_name} (underscore variant) — alternatives.spec
+         * on 5.0 and main. Same value source as %{srcname}. */
+        if (icontains(*source0, "%{src_name}")) {
+            *source0 = istr_replace_all(*source0, "%{src_name}", task->srcname ? task->srcname : "");
+            if (*source0 == NULL) return -1;
+        }
         /* PS L 2188: %{gem_name} */
         if (icontains(*source0, "%{gem_name}")) {
             *source0 = istr_replace_all(*source0, "%{gem_name}", task->gem_name ? task->gem_name : "");


### PR DESCRIPTION
## Summary

``alternatives.spec`` (5.0 + main) uses ``%define src_name chkconfig`` and ``%{src_name}`` in Source0:

```
https://github.com/fedora-sysv/chkconfig/archive/refs/tags/%{src_name}-%{version}.tar.gz
```

Both PS and C only recognise ``%define srcname`` (no underscore), so the ``%{src_name}`` macro never resolves. Result: col3 retains the literal ``%{src_name}`` substring, col4=``substitution_unfinished``, col6/9/10 empty, col11 "packaging format" warning. **Empirically 2 PS-only rows** (5.0 and main).

Empirical check confirms no other spec uses both ``srcname`` and ``src_name`` simultaneously, so reusing the existing ``\$srcname`` / ``task->srcname`` field is safe and minimum-impact.

## Fix

**PS** (``photonos-package-report.ps1``):
- L314 area: read ``%define src_name`` and ``%global src_name`` into ``\$srcname`` (same variable as ``srcname``)
- L2280 area: substitute ``%{src_name}`` → ``\$currentTask.srcname``

**C** (``src/parse_directory.c``, ``src/source0_substitute.c``):
- parse_directory: ``%define`` / ``%global src_name`` → ``srcname`` field
- source0_substitute: ``%{src_name}`` substitution mirroring ``%{srcname}``

## Expected effect

Closes the 2 PS-only Category-2 ("URL substitution unfinished") rows for ``alternatives.spec`` on 5.0 and main. Other Category-2 specs (``dhcp``, ``nss``, ``openjdk8_aarch64``, ``python3-msal``, ``squid``) use different macros and need separate per-spec analysis.

## Test plan

- [x] local build clean
- [x] local ctest: 14/14 pass
- [ ] parity-gate (PR) green
- [ ] post-merge: dispatch chain, confirm alternatives.spec on 5.0/main: col4=200, col6 = github URL with chkconfig substituted

## Notes

- FRD: FRD-011
- ADR: ADR-0006 (bit-identical priority)
- PS-source: photonos-package-report.ps1 L 314-322, 2280-2282
- Parity: strict
- Composes with: M141-M145

🤖 Generated with [Claude Code](https://claude.com/claude-code)