### PR TITLE
phase-M task M147: substitute shell-style ${name} / ${version} (dhcp.spec typo)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -2274,6 +2274,17 @@ function CheckURLHealth {
     # replace variables
     $Source0 = $Source0 -ireplace '%{name}',$currentTask.Name
     $Source0 = $Source0 -ireplace '%{version}',$version
+    # M147 (2026-06-06): also resolve shell-style ${name} / ${version}.
+    # dhcp.spec on 3.0/4.0/6.0 carries an upstream typo using
+    # `${version}` instead of `%{version}` in Source0, which leaves
+    # col3 unresolved and emits Category-2 (substitution_unfinished).
+    # Empirical scan confirms dhcp.spec is the only spec across all
+    # 8 branches with `${...}` in Source0, so this lenient substitution
+    # has zero regression risk on other specs. Case-sensitive .Replace
+    # (not -ireplace) avoids regex interpretation of `${...}` as a
+    # backreference.
+    if ($Source0.Contains('${name}'))    { $Source0 = $Source0.Replace('${name}',    $currentTask.Name) }
+    if ($Source0.Contains('${version}')) { $Source0 = $Source0.Replace('${version}', $version) }
 
     if ($Source0 -like '*{*')
     {

--- a/photonos-package-report/photonos-package-report/src/source0_substitute.c
+++ b/photonos-package-report/photonos-package-report/src/source0_substitute.c
@@ -163,6 +163,24 @@ int pr_source0_substitute(pr_task_t *task, char **source0, const char *version)
     *source0 = istr_replace_all(*source0, "%{version}", version ? version : "");
     if (*source0 == NULL) return -1;
 
+    /* M147 (2026-06-06): mirror PS L 2277-2284 -- also resolve the
+     * shell-style ${name} / ${version}. dhcp.spec on 3.0/4.0/6.0
+     * carries an upstream typo using `${version}` instead of
+     * `%{version}` in Source0; empirical scan across all 8 branches
+     * confirms dhcp.spec is the ONLY spec with ${...} in Source0,
+     * so the lenient substitution has zero regression risk on other
+     * specs. Case-insensitive via istr_replace_all (matches the PS
+     * .Replace() being applied to a single token whose case is
+     * uniform across the corpus). */
+    if (icontains(*source0, "${name}")) {
+        *source0 = istr_replace_all(*source0, "${name}", task->Name ? task->Name : "");
+        if (*source0 == NULL) return -1;
+    }
+    if (icontains(*source0, "${version}")) {
+        *source0 = istr_replace_all(*source0, "${version}", version ? version : "");
+        if (*source0 == NULL) return -1;
+    }
+
     /* PS L 2185-2202: gated by `*{*` (case-SENSITIVE -like, since `{` is
      * the only meta we care about and it has no case). */
     if (contains(*source0, "{")) {


### PR DESCRIPTION
## Summary

``dhcp.spec`` on photon-3.0 / 4.0 / 6.0 carries an upstream Source0 typo:

```
ftp://ftp.isc.org/isc/dhcp/${version}/%{name}-%{version}.tar.gz
```

``${version}`` is shell variable syntax, not RPM macro syntax. PS+C substitute only ``%{version}`` / ``%{name}``, so col3 retains the literal ``${version}`` and col4 reports ``substitution_unfinished``. Net: **3 PS-only Category-2 rows on 3.0/4.0/6.0**.

Empirical scan confirms ``dhcp.spec`` is the **only** spec across all 8 branches with ``${...}`` in Source0. So lenient substitution of ``${name}`` and ``${version}`` has zero regression risk on other specs.

## Fix

**PS** — after the standard ``%{name}/%{version}`` ``-ireplace`` calls, add ``.Replace('${name}', ...)`` and ``.Replace('${version}', ...)``. Case-sensitive ``.Replace()`` avoids regex interpretation of ``${...}`` as a backreference.

**C** — after the ``%{name}/%{version}`` ``istr_replace_all`` calls, add guarded ``istr_replace_all`` calls for ``${name}`` and ``${version}``.

## Expected effect

Closes the 3 PS-only Category-2 rows for ``dhcp.spec`` on 3.0/4.0/6.0. Other Category-2 specs (``nss``, ``openjdk8_aarch64``, ``python3-msal``, ``squid``) use different macros — separate per-spec analysis in M148+.

## Test plan

- [x] local build clean
- [x] local ctest: 14/14 pass
- [ ] parity-gate (PR) green
- [ ] post-merge: dispatch chain, confirm dhcp.spec on 3.0/4.0/6.0: col4=200 (or repo-deprecated category), col6 = resolved ftp.isc.org URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)