### PR TITLE
phase-M task M148: handle %define rel_tag + %{rel_tag} (nss.spec)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -372,6 +372,12 @@ function ParseDirectory {
             if ($content -ilike '*%global commit_id*') { $commit_id = (($content | Select-String -Pattern '%global commit_id')[0].ToString() -ireplace '%global commit_id', "").Trim() }
             if ($content -ilike '*%define commit_id*') { $commit_id = (($content | Select-String -Pattern '%define commit_id')[0].ToString() -ireplace '%define commit_id', "").Trim() }
 
+            # M148 (2026-06-06): rel_tag — nss.spec on dev + master uses
+            # `%define rel_tag 3_98` and `%{rel_tag}` in Source0.
+            $rel_tag=""
+            if ($content -ilike '*%define rel_tag*') { $rel_tag = (($content | Select-String -Pattern '%define rel_tag')[0].ToString() -ireplace '%define rel_tag', "").Trim() }
+            if ($content -ilike '*%global rel_tag*') { $rel_tag = (($content | Select-String -Pattern '%global rel_tag')[0].ToString() -ireplace '%global rel_tag', "").Trim() }
+
             $null = $Packages.Add([PSCustomObject]@{
                 content = $content
                 Spec = $currentFile.Name
@@ -399,6 +405,7 @@ function ParseDirectory {
                 _url_src = $_url_src
                 _repo_ver = $_repo_ver
                 commit_id = $commit_id
+                rel_tag = $rel_tag
             })
         }
         catch {
@@ -2313,6 +2320,8 @@ function CheckURLHealth {
         if ($Source0 -ilike '*%{_url_src}*') { $Source0 = $Source0 -ireplace '%{_url_src}',$currentTask._url_src }
         if ($Source0 -ilike '*%{_repo_ver}*') { $Source0 = $Source0 -ireplace '%{_repo_ver}',$currentTask._repo_ver}
         if ($Source0 -ilike '*%{commit_id}*') { $Source0 = $Source0 -ireplace '%{commit_id}',$currentTask.commit_id }
+        # M148: %{rel_tag} — nss.spec on dev + master.
+        if ($Source0 -ilike '*%{rel_tag}*') { $Source0 = $Source0 -ireplace '%{rel_tag}',$currentTask.rel_tag }
     }
 
 

--- a/photonos-package-report/photonos-package-report/include/pr_types.h
+++ b/photonos-package-report/photonos-package-report/include/pr_types.h
@@ -97,6 +97,7 @@ typedef struct {
     char  *_url_src;               /* PS L 369 */
     char  *_repo_ver;              /* PS L 370 */
     char  *commit_id;              /* PS L 371 */
+    char  *rel_tag;                /* M148 (nss.spec dev+master): %define rel_tag */
 } pr_task_t;
 
 /* A growable list of pr_task_t. ParseDirectory returns one of these

--- a/photonos-package-report/photonos-package-report/src/parse_directory.c
+++ b/photonos-package-report/photonos-package-report/src/parse_directory.c
@@ -469,6 +469,19 @@ static int parse_one_spec(const char *specs_path,
         commit_id = first_value(content, n_lines, "%define commit_id", "%define commit_id");
     }
 
+    /* M148 (2026-06-06): rel_tag — nss.spec on dev + master uses
+     * `%define rel_tag 3_98` and `%{rel_tag}` in Source0. Define-
+     * then-global override semantics mirror srcname/gem_name. */
+    char *rel_tag = empty_dup();
+    if (lines_ilike_contains(content, n_lines, "%define rel_tag")) {
+        free(rel_tag);
+        rel_tag = first_value(content, n_lines, "%define rel_tag", "%define rel_tag");
+    }
+    if (lines_ilike_contains(content, n_lines, "%global rel_tag")) {
+        free(rel_tag);
+        rel_tag = first_value(content, n_lines, "%global rel_tag", "%global rel_tag");
+    }
+
     /* PS L 345-372: $Packages.Add([PSCustomObject]@{ ... }) */
     pr_task_t t;
     memset(&t, 0, sizeof t);
@@ -500,6 +513,7 @@ static int parse_one_spec(const char *specs_path,
     t._url_src          = _url_src;
     t._repo_ver         = _repo_ver;
     t.commit_id         = commit_id;
+    t.rel_tag           = rel_tag;  /* M148 */
 
     if (pr_task_list_add(out, &t) != 0) {
         pr_task_free(&t);

--- a/photonos-package-report/photonos-package-report/src/source0_substitute.c
+++ b/photonos-package-report/photonos-package-report/src/source0_substitute.c
@@ -271,6 +271,11 @@ int pr_source0_substitute(pr_task_t *task, char **source0, const char *version)
             *source0 = istr_replace_all(*source0, "%{commit_id}", task->commit_id ? task->commit_id : "");
             if (*source0 == NULL) return -1;
         }
+        /* M148 (2026-06-06): %{rel_tag} — nss.spec on dev + master. */
+        if (icontains(*source0, "%{rel_tag}")) {
+            *source0 = istr_replace_all(*source0, "%{rel_tag}", task->rel_tag ? task->rel_tag : "");
+            if (*source0 == NULL) return -1;
+        }
     }
 
     return 0;

--- a/photonos-package-report/photonos-package-report/src/task.c
+++ b/photonos-package-report/photonos-package-report/src/task.c
@@ -45,6 +45,7 @@ void pr_task_free(pr_task_t *t)
     free(t->_url_src);
     free(t->_repo_ver);
     free(t->commit_id);
+    free(t->rel_tag);  /* M148 (nss.spec dev+master) */
     memset(t, 0, sizeof *t);
 }
 


### PR DESCRIPTION
Adds rel_tag macro parsing+substitution to PS and C for nss.spec dev+master. Closes 2 PS-only Cat-2 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)