### PR TITLE
phase-M task M149: handle %{full_name} (python3-msal.spec)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -378,6 +378,13 @@ function ParseDirectory {
             if ($content -ilike '*%define rel_tag*') { $rel_tag = (($content | Select-String -Pattern '%define rel_tag')[0].ToString() -ireplace '%define rel_tag', "").Trim() }
             if ($content -ilike '*%global rel_tag*') { $rel_tag = (($content | Select-String -Pattern '%global rel_tag')[0].ToString() -ireplace '%global rel_tag', "").Trim() }
 
+            # M149 (2026-06-06): full_name — python3-msal.spec on 5.0+main
+            # uses `%global full_name microsoft-authentication-library-for-python`
+            # and `%{full_name}` in Source0.
+            $full_name=""
+            if ($content -ilike '*%define full_name*') { $full_name = (($content | Select-String -Pattern '%define full_name')[0].ToString() -ireplace '%define full_name', "").Trim() }
+            if ($content -ilike '*%global full_name*') { $full_name = (($content | Select-String -Pattern '%global full_name')[0].ToString() -ireplace '%global full_name', "").Trim() }
+
             $null = $Packages.Add([PSCustomObject]@{
                 content = $content
                 Spec = $currentFile.Name
@@ -406,6 +413,7 @@ function ParseDirectory {
                 _repo_ver = $_repo_ver
                 commit_id = $commit_id
                 rel_tag = $rel_tag
+                full_name = $full_name
             })
         }
         catch {
@@ -2322,6 +2330,8 @@ function CheckURLHealth {
         if ($Source0 -ilike '*%{commit_id}*') { $Source0 = $Source0 -ireplace '%{commit_id}',$currentTask.commit_id }
         # M148: %{rel_tag} — nss.spec on dev + master.
         if ($Source0 -ilike '*%{rel_tag}*') { $Source0 = $Source0 -ireplace '%{rel_tag}',$currentTask.rel_tag }
+        # M149: %{full_name} — python3-msal.spec on 5.0+main.
+        if ($Source0 -ilike '*%{full_name}*') { $Source0 = $Source0 -ireplace '%{full_name}',$currentTask.full_name }
     }
 
 

--- a/photonos-package-report/photonos-package-report/include/pr_types.h
+++ b/photonos-package-report/photonos-package-report/include/pr_types.h
@@ -98,6 +98,7 @@ typedef struct {
     char  *_repo_ver;              /* PS L 370 */
     char  *commit_id;              /* PS L 371 */
     char  *rel_tag;                /* M148 (nss.spec dev+master): %define rel_tag */
+    char  *full_name;              /* M149 (python3-msal.spec 5.0+main): %global full_name */
 } pr_task_t;
 
 /* A growable list of pr_task_t. ParseDirectory returns one of these

--- a/photonos-package-report/photonos-package-report/src/parse_directory.c
+++ b/photonos-package-report/photonos-package-report/src/parse_directory.c
@@ -482,6 +482,19 @@ static int parse_one_spec(const char *specs_path,
         rel_tag = first_value(content, n_lines, "%global rel_tag", "%global rel_tag");
     }
 
+    /* M149 (2026-06-06): full_name — python3-msal.spec on 5.0 + main
+     * uses `%global full_name microsoft-authentication-library-for-python`
+     * and `%{full_name}` in Source0. */
+    char *full_name = empty_dup();
+    if (lines_ilike_contains(content, n_lines, "%define full_name")) {
+        free(full_name);
+        full_name = first_value(content, n_lines, "%define full_name", "%define full_name");
+    }
+    if (lines_ilike_contains(content, n_lines, "%global full_name")) {
+        free(full_name);
+        full_name = first_value(content, n_lines, "%global full_name", "%global full_name");
+    }
+
     /* PS L 345-372: $Packages.Add([PSCustomObject]@{ ... }) */
     pr_task_t t;
     memset(&t, 0, sizeof t);
@@ -514,6 +527,7 @@ static int parse_one_spec(const char *specs_path,
     t._repo_ver         = _repo_ver;
     t.commit_id         = commit_id;
     t.rel_tag           = rel_tag;  /* M148 */
+    t.full_name         = full_name;  /* M149 */
 
     if (pr_task_list_add(out, &t) != 0) {
         pr_task_free(&t);

--- a/photonos-package-report/photonos-package-report/src/source0_substitute.c
+++ b/photonos-package-report/photonos-package-report/src/source0_substitute.c
@@ -276,6 +276,11 @@ int pr_source0_substitute(pr_task_t *task, char **source0, const char *version)
             *source0 = istr_replace_all(*source0, "%{rel_tag}", task->rel_tag ? task->rel_tag : "");
             if (*source0 == NULL) return -1;
         }
+        /* M149 (2026-06-06): %{full_name} — python3-msal.spec on 5.0 + main. */
+        if (icontains(*source0, "%{full_name}")) {
+            *source0 = istr_replace_all(*source0, "%{full_name}", task->full_name ? task->full_name : "");
+            if (*source0 == NULL) return -1;
+        }
     }
 
     return 0;

--- a/photonos-package-report/photonos-package-report/src/task.c
+++ b/photonos-package-report/photonos-package-report/src/task.c
@@ -46,6 +46,7 @@ void pr_task_free(pr_task_t *t)
     free(t->_repo_ver);
     free(t->commit_id);
     free(t->rel_tag);  /* M148 (nss.spec dev+master) */
+    free(t->full_name);  /* M149 (python3-msal.spec 5.0+main) */
     memset(t, 0, sizeof *t);
 }
 


### PR DESCRIPTION
Adds full_name macro parsing+substitution to PS and C for python3-msal.spec 5.0+main. Closes 2 PS-only Cat-2 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)