### PR TITLE
phase-M task M150: handle %{upstream_name}+%{upstream_version} (squid.spec)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -385,6 +385,16 @@ function ParseDirectory {
             if ($content -ilike '*%define full_name*') { $full_name = (($content | Select-String -Pattern '%define full_name')[0].ToString() -ireplace '%define full_name', "").Trim() }
             if ($content -ilike '*%global full_name*') { $full_name = (($content | Select-String -Pattern '%global full_name')[0].ToString() -ireplace '%global full_name', "").Trim() }
 
+            # M150 (2026-06-06): squid.spec on 5.0+main uses
+            # `%define upstream_name SQUID` and `%define upstream_version 7_4`.
+            # upstream_version reuses $upstreamversion (no spec uses both forms);
+            # upstream_name gets its own field.
+            $upstream_name=""
+            if ($content -ilike '*%define upstream_name*') { $upstream_name = (($content | Select-String -Pattern '%define upstream_name')[0].ToString() -ireplace '%define upstream_name', "").Trim() }
+            if ($content -ilike '*%global upstream_name*') { $upstream_name = (($content | Select-String -Pattern '%global upstream_name')[0].ToString() -ireplace '%global upstream_name', "").Trim() }
+            if ($content -ilike '*%define upstream_version*') { $upstreamversion = (($content | Select-String -Pattern '%define upstream_version')[0].ToString() -ireplace '%define upstream_version', "").Trim() }
+            if ($content -ilike '*%global upstream_version*') { $upstreamversion = (($content | Select-String -Pattern '%global upstream_version')[0].ToString() -ireplace '%global upstream_version', "").Trim() }
+
             $null = $Packages.Add([PSCustomObject]@{
                 content = $content
                 Spec = $currentFile.Name
@@ -414,6 +424,7 @@ function ParseDirectory {
                 commit_id = $commit_id
                 rel_tag = $rel_tag
                 full_name = $full_name
+                upstream_name = $upstream_name
             })
         }
         catch {
@@ -2332,6 +2343,9 @@ function CheckURLHealth {
         if ($Source0 -ilike '*%{rel_tag}*') { $Source0 = $Source0 -ireplace '%{rel_tag}',$currentTask.rel_tag }
         # M149: %{full_name} — python3-msal.spec on 5.0+main.
         if ($Source0 -ilike '*%{full_name}*') { $Source0 = $Source0 -ireplace '%{full_name}',$currentTask.full_name }
+        # M150: %{upstream_name} + %{upstream_version} — squid.spec on 5.0+main.
+        if ($Source0 -ilike '*%{upstream_name}*')    { $Source0 = $Source0 -ireplace '%{upstream_name}',$currentTask.upstream_name }
+        if ($Source0 -ilike '*%{upstream_version}*') { $Source0 = $Source0 -ireplace '%{upstream_version}',$currentTask.upstreamversion }
     }
 
 

--- a/photonos-package-report/photonos-package-report/include/pr_types.h
+++ b/photonos-package-report/photonos-package-report/include/pr_types.h
@@ -99,6 +99,7 @@ typedef struct {
     char  *commit_id;              /* PS L 371 */
     char  *rel_tag;                /* M148 (nss.spec dev+master): %define rel_tag */
     char  *full_name;              /* M149 (python3-msal.spec 5.0+main): %global full_name */
+    char  *upstream_name;          /* M150 (squid.spec 5.0+main): %define upstream_name */
 } pr_task_t;
 
 /* A growable list of pr_task_t. ParseDirectory returns one of these

--- a/photonos-package-report/photonos-package-report/src/parse_directory.c
+++ b/photonos-package-report/photonos-package-report/src/parse_directory.c
@@ -387,6 +387,19 @@ static int parse_one_spec(const char *specs_path,
         free(upstreamversion);
         upstreamversion = first_value(content, n_lines, "%define upstreamversion", "%define upstreamversion");
     }
+    /* M150 (2026-06-06): squid.spec on 5.0 + main uses
+     * `%define upstream_version 7_4` (with underscore) and
+     * `%{upstream_version}` in Source0. Empirically no spec uses
+     * both upstreamversion and upstream_version simultaneously,
+     * so reusing the upstreamversion field is safe. */
+    if (lines_ilike_contains(content, n_lines, "%define upstream_version")) {
+        free(upstreamversion);
+        upstreamversion = first_value(content, n_lines, "%define upstream_version", "%define upstream_version");
+    }
+    if (lines_ilike_contains(content, n_lines, "%global upstream_version")) {
+        free(upstreamversion);
+        upstreamversion = first_value(content, n_lines, "%global upstream_version", "%global upstream_version");
+    }
 
     /* PS L 311-312: subversion */
     char *subversion = empty_dup();
@@ -495,6 +508,19 @@ static int parse_one_spec(const char *specs_path,
         full_name = first_value(content, n_lines, "%global full_name", "%global full_name");
     }
 
+    /* M150 (2026-06-06): upstream_name — squid.spec on 5.0 + main
+     * uses `%define upstream_name SQUID` and `%{upstream_name}` in
+     * Source0. New dedicated field. */
+    char *upstream_name = empty_dup();
+    if (lines_ilike_contains(content, n_lines, "%define upstream_name")) {
+        free(upstream_name);
+        upstream_name = first_value(content, n_lines, "%define upstream_name", "%define upstream_name");
+    }
+    if (lines_ilike_contains(content, n_lines, "%global upstream_name")) {
+        free(upstream_name);
+        upstream_name = first_value(content, n_lines, "%global upstream_name", "%global upstream_name");
+    }
+
     /* PS L 345-372: $Packages.Add([PSCustomObject]@{ ... }) */
     pr_task_t t;
     memset(&t, 0, sizeof t);
@@ -528,6 +554,7 @@ static int parse_one_spec(const char *specs_path,
     t.commit_id         = commit_id;
     t.rel_tag           = rel_tag;  /* M148 */
     t.full_name         = full_name;  /* M149 */
+    t.upstream_name     = upstream_name;  /* M150 */
 
     if (pr_task_list_add(out, &t) != 0) {
         pr_task_free(&t);

--- a/photonos-package-report/photonos-package-report/src/source0_substitute.c
+++ b/photonos-package-report/photonos-package-report/src/source0_substitute.c
@@ -281,6 +281,18 @@ int pr_source0_substitute(pr_task_t *task, char **source0, const char *version)
             *source0 = istr_replace_all(*source0, "%{full_name}", task->full_name ? task->full_name : "");
             if (*source0 == NULL) return -1;
         }
+        /* M150 (2026-06-06): %{upstream_name} — squid.spec on 5.0 + main. */
+        if (icontains(*source0, "%{upstream_name}")) {
+            *source0 = istr_replace_all(*source0, "%{upstream_name}", task->upstream_name ? task->upstream_name : "");
+            if (*source0 == NULL) return -1;
+        }
+        /* M150: %{upstream_version} — squid.spec on 5.0 + main. Reuses the
+         * upstreamversion field (no spec uses both upstreamversion and
+         * upstream_version simultaneously). */
+        if (icontains(*source0, "%{upstream_version}")) {
+            *source0 = istr_replace_all(*source0, "%{upstream_version}", task->upstreamversion ? task->upstreamversion : "");
+            if (*source0 == NULL) return -1;
+        }
     }
 
     return 0;

--- a/photonos-package-report/photonos-package-report/src/task.c
+++ b/photonos-package-report/photonos-package-report/src/task.c
@@ -47,6 +47,7 @@ void pr_task_free(pr_task_t *t)
     free(t->commit_id);
     free(t->rel_tag);  /* M148 (nss.spec dev+master) */
     free(t->full_name);  /* M149 (python3-msal.spec 5.0+main) */
+    free(t->upstream_name);  /* M150 (squid.spec 5.0+main) */
     memset(t, 0, sizeof *t);
 }
 


### PR DESCRIPTION
Adds upstream_name + upstream_version macros to PS+C for squid.spec 5.0+main. Closes 2 PS-only Cat-2 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)