### PR TITLE
phase-M task M151: %{_jdk_update}+%{_jdk_build} nested macros (openjdk8_aarch64.spec)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -395,6 +395,15 @@ function ParseDirectory {
             if ($content -ilike '*%define upstream_version*') { $upstreamversion = (($content | Select-String -Pattern '%define upstream_version')[0].ToString() -ireplace '%define upstream_version', "").Trim() }
             if ($content -ilike '*%global upstream_version*') { $upstreamversion = (($content | Select-String -Pattern '%global upstream_version')[0].ToString() -ireplace '%global upstream_version', "").Trim() }
 
+            # M151 (2026-06-06): _jdk_update / _jdk_build — openjdk8_aarch64.spec
+            # on 3.0. _repo_ver expands to a string still containing these two
+            # macros; substitution order in Source0 resolves _repo_ver first,
+            # then these two cover the second pass.
+            $_jdk_update=""
+            if ($content -ilike '*%define _jdk_update*') { $_jdk_update = (($content | Select-String -Pattern '%define _jdk_update')[0].ToString() -ireplace '%define _jdk_update', "").Trim() }
+            $_jdk_build=""
+            if ($content -ilike '*%define _jdk_build*') { $_jdk_build = (($content | Select-String -Pattern '%define _jdk_build')[0].ToString() -ireplace '%define _jdk_build', "").Trim() }
+
             $null = $Packages.Add([PSCustomObject]@{
                 content = $content
                 Spec = $currentFile.Name
@@ -425,6 +434,8 @@ function ParseDirectory {
                 rel_tag = $rel_tag
                 full_name = $full_name
                 upstream_name = $upstream_name
+                _jdk_update = $_jdk_update
+                _jdk_build = $_jdk_build
             })
         }
         catch {
@@ -2346,6 +2357,11 @@ function CheckURLHealth {
         # M150: %{upstream_name} + %{upstream_version} — squid.spec on 5.0+main.
         if ($Source0 -ilike '*%{upstream_name}*')    { $Source0 = $Source0 -ireplace '%{upstream_name}',$currentTask.upstream_name }
         if ($Source0 -ilike '*%{upstream_version}*') { $Source0 = $Source0 -ireplace '%{upstream_version}',$currentTask.upstreamversion }
+        # M151: %{_jdk_update} + %{_jdk_build} — openjdk8_aarch64.spec on 3.0.
+        # Must come after %{_repo_ver} (handled by existing code earlier in
+        # this block at PS L 2304-2305) so the inner macros get a second pass.
+        if ($Source0 -ilike '*%{_jdk_update}*') { $Source0 = $Source0 -ireplace '%{_jdk_update}',$currentTask._jdk_update }
+        if ($Source0 -ilike '*%{_jdk_build}*')  { $Source0 = $Source0 -ireplace '%{_jdk_build}',$currentTask._jdk_build }
     }
 
 

--- a/photonos-package-report/photonos-package-report/include/pr_types.h
+++ b/photonos-package-report/photonos-package-report/include/pr_types.h
@@ -100,6 +100,8 @@ typedef struct {
     char  *rel_tag;                /* M148 (nss.spec dev+master): %define rel_tag */
     char  *full_name;              /* M149 (python3-msal.spec 5.0+main): %global full_name */
     char  *upstream_name;          /* M150 (squid.spec 5.0+main): %define upstream_name */
+    char  *_jdk_update;            /* M151 (openjdk8_aarch64.spec 3.0): %define _jdk_update */
+    char  *_jdk_build;             /* M151 (openjdk8_aarch64.spec 3.0): %define _jdk_build */
 } pr_task_t;
 
 /* A growable list of pr_task_t. ParseDirectory returns one of these

--- a/photonos-package-report/photonos-package-report/src/parse_directory.c
+++ b/photonos-package-report/photonos-package-report/src/parse_directory.c
@@ -521,6 +521,22 @@ static int parse_one_spec(const char *specs_path,
         upstream_name = first_value(content, n_lines, "%global upstream_name", "%global upstream_name");
     }
 
+    /* M151 (2026-06-06): _jdk_update / _jdk_build — openjdk8_aarch64.spec
+     * on 3.0 uses `%define _jdk_update 181`, `%define _jdk_build 13`, and
+     * `%{_repo_ver}` which itself expands to `aarch64-jdk8u%{_jdk_update}-b%{_jdk_build}`.
+     * The substitution order in source0_substitute.c expands _repo_ver
+     * first; these two cover the second pass. */
+    char *_jdk_update = empty_dup();
+    if (lines_ilike_contains(content, n_lines, "%define _jdk_update")) {
+        free(_jdk_update);
+        _jdk_update = first_value(content, n_lines, "%define _jdk_update", "%define _jdk_update");
+    }
+    char *_jdk_build = empty_dup();
+    if (lines_ilike_contains(content, n_lines, "%define _jdk_build")) {
+        free(_jdk_build);
+        _jdk_build = first_value(content, n_lines, "%define _jdk_build", "%define _jdk_build");
+    }
+
     /* PS L 345-372: $Packages.Add([PSCustomObject]@{ ... }) */
     pr_task_t t;
     memset(&t, 0, sizeof t);
@@ -555,6 +571,8 @@ static int parse_one_spec(const char *specs_path,
     t.rel_tag           = rel_tag;  /* M148 */
     t.full_name         = full_name;  /* M149 */
     t.upstream_name     = upstream_name;  /* M150 */
+    t._jdk_update       = _jdk_update;  /* M151 */
+    t._jdk_build        = _jdk_build;  /* M151 */
 
     if (pr_task_list_add(out, &t) != 0) {
         pr_task_free(&t);

--- a/photonos-package-report/photonos-package-report/src/source0_substitute.c
+++ b/photonos-package-report/photonos-package-report/src/source0_substitute.c
@@ -266,6 +266,17 @@ int pr_source0_substitute(pr_task_t *task, char **source0, const char *version)
             *source0 = istr_replace_all(*source0, "%{_repo_ver}", task->_repo_ver ? task->_repo_ver : "");
             if (*source0 == NULL) return -1;
         }
+        /* M151 (2026-06-06): _jdk_update / _jdk_build — openjdk8_aarch64.spec
+         * 3.0. _repo_ver expands to a string still containing these two
+         * macros, so we substitute them in the same pass (AFTER _repo_ver). */
+        if (icontains(*source0, "%{_jdk_update}")) {
+            *source0 = istr_replace_all(*source0, "%{_jdk_update}", task->_jdk_update ? task->_jdk_update : "");
+            if (*source0 == NULL) return -1;
+        }
+        if (icontains(*source0, "%{_jdk_build}")) {
+            *source0 = istr_replace_all(*source0, "%{_jdk_build}", task->_jdk_build ? task->_jdk_build : "");
+            if (*source0 == NULL) return -1;
+        }
         /* PS L 2202: %{commit_id} */
         if (icontains(*source0, "%{commit_id}")) {
             *source0 = istr_replace_all(*source0, "%{commit_id}", task->commit_id ? task->commit_id : "");

--- a/photonos-package-report/photonos-package-report/src/task.c
+++ b/photonos-package-report/photonos-package-report/src/task.c
@@ -48,6 +48,8 @@ void pr_task_free(pr_task_t *t)
     free(t->rel_tag);  /* M148 (nss.spec dev+master) */
     free(t->full_name);  /* M149 (python3-msal.spec 5.0+main) */
     free(t->upstream_name);  /* M150 (squid.spec 5.0+main) */
+    free(t->_jdk_update);  /* M151 (openjdk8_aarch64.spec 3.0) */
+    free(t->_jdk_build);  /* M151 (openjdk8_aarch64.spec 3.0) */
     memset(t, 0, sizeof *t);
 }
 


### PR DESCRIPTION
Adds _jdk_update + _jdk_build to PS+C with order-aware substitution AFTER %{_repo_ver}. Closes 1 PS-only Cat-2 row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)