### PR TITLE
phase-M task M152: rewrite ftp.x.org probe target to xorg.freedesktop.org

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -1535,16 +1535,31 @@ function ModifySpecFile {
     }
 }
 
+function Resolve-ProbeURL {
+    # M152: ftp.x.org issues a 308 Permanent Redirect to xorg.freedesktop.org/archive/,
+    # which neither HttpWebRequest::GetResponse nor Invoke-WebRequest/Invoke-RestMethod
+    # follow in pwsh 7. Probe the redirect target directly. Caller's URL stays unchanged;
+    # only the local probe URL is rewritten. C/libcurl already handles the 308 via
+    # CURLOPT_FOLLOWLOCATION, so col3/col6 byte-match between PS and C after this fix.
+    param([string]$url)
+    if ([string]::IsNullOrEmpty($url)) { return $url }
+    if ($url -match '^https?://ftp\.x\.org/(pub|archive)/+individual/') {
+        return ($url -replace '^https?://ftp\.x\.org/(pub|archive)/+individual/', 'https://xorg.freedesktop.org/archive/individual/')
+    }
+    return $url
+}
+
 function urlhealth {
     param (
         [parameter(Mandatory = $true)]
         $checkurl
     )
     $urlhealthrc=""
+    $probeurl = Resolve-ProbeURL $checkurl
     try
     {
         # Create a web request with HEAD method
-        $request = [System.Net.HttpWebRequest]::Create($checkurl)
+        $request = [System.Net.HttpWebRequest]::Create($probeurl)
         $request.Method = "HEAD"
         $request.Timeout = 120000
 
@@ -3434,7 +3449,8 @@ function CheckURLHealth {
 
 
         try{
-            $Names = ((((invoke-restmethod -uri $SourceTagURL -TimeoutSec 10 -usebasicparsing -ErrorAction Stop) -split "<tr><td") -split 'a href=') -split '>') -split "title="
+            # M152: rewrite ftp.x.org probe target — see Resolve-ProbeURL.
+            $Names = ((((invoke-restmethod -uri (Resolve-ProbeURL $SourceTagURL) -TimeoutSec 10 -usebasicparsing -ErrorAction Stop) -split "<tr><td") -split 'a href=') -split '>') -split "title="
             if ($Names) {
                 $Names = @($Names | foreach-object { if ($_ | select-string -pattern '.tar.' -simplematch) {$_}})
                 $Names = @(($Names | foreach-object { if (!($_ | select-string -pattern '</a' -simplematch)) {$_}})) -ireplace '"',""
@@ -5190,8 +5206,9 @@ function CheckURLHealth {
             else
             {
                 try {
+                    # M152: rewrite ftp.x.org probe target for SHA download — see Resolve-ProbeURL.
                     # Invoke-WebRequest -Uri $UpdateURL -UseBasicParsing -Verbose:$false -OutFile $UpdateDownloadFile -TimeoutSec 10
-                    Invoke-WebRequest -Uri $UpdateURL -UseBasicParsing -OutFile $UpdateDownloadFile -TimeoutSec 120 -ErrorAction Stop
+                    Invoke-WebRequest -Uri (Resolve-ProbeURL $UpdateURL) -UseBasicParsing -OutFile $UpdateDownloadFile -TimeoutSec 120 -ErrorAction Stop
                 }
                 catch
                 {
@@ -5442,6 +5459,9 @@ function GenerateUrlHealthReports {
                 # not recognized" and the SHA computation falls back to
                 # the auto-archive — defeating the ADR.
                 'Resolve-StableSourceURL' = (Get-Command 'Resolve-StableSourceURL' -ErrorAction SilentlyContinue).Definition
+                # M152: ftp.x.org probe-target rewriter; same parallel-runspace propagation
+                # requirement as Resolve-StableSourceURL.
+                'Resolve-ProbeURL' = (Get-Command 'Resolve-ProbeURL' -ErrorAction SilentlyContinue).Definition
                 HeapSortClass = $HeapSortClassDef
             }
             $initParts = @()


### PR DESCRIPTION
## Summary

- PS-side fix for 22 X.org-family Cat-3 rows per branch. PS HttpWebRequest / Invoke-WebRequest / Invoke-RestMethod all fail to follow `ftp.x.org` → `xorg.freedesktop.org` 308 Permanent Redirect; C via libcurl FOLLOWLOCATION handles it transparently. The asymmetry produces strict parity diffs on cols 3/4/5/6/7/9/10/11 for each X.org spec.
- New helper `Resolve-ProbeURL` rewrites the probe target (not the displayed Source0/UpdateURL — visible columns still byte-match C). Applied at 3 call sites + parallel-runspace function table.
- Predicted impact: -22 × 7 branches = ~150 strict rows closed, plus PS-side info-quality (col5/6/9/10 now populated for libICE/libSM/libXau/libXi/libXrandr/libXrender/libXt/libXtst/libXfont2/libxshmfence/libpciaccess/libfontenc/libXdamage/libXdmcp/libXext/libXfixes/libXcomposite/libXScrnSaver/libXcursor/font-util/util-macros/xtrans).

## Test plan

- [x] Sanity-tested `Resolve-ProbeURL` on 4 X.org URLs + 1 github control (rewriter + urlhealth probe).
- [ ] gate + parity-gate green.
- [ ] Dispatched PS+C validation chain measures strict-row delta on at least 5.0; expect ≈ -22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)