### PR TITLE
habv4: docs — v1.9.38 through v1.9.56 catchup (README + VERSION_TABLE + TROUBLESHOOTING)

### DIFF
--- a/HABv4SimulationEnvironment/README.md
+++ b/HABv4SimulationEnvironment/README.md
@@ -399,6 +399,176 @@ On first boot, the **blue MokManager screen** appears:
 
 ## Version History
 
+- **v1.9.56** - UI bug fixes from operator VM test feedback (2026-06-06):
+  - **Bug A fix**: install crash `Unknown install_config keys: mok_quickstart`.
+    The v1.9.43 anchor-based regex (`'manifest_file',`) for whitelisting
+    `mok_quickstart` in `Installer.known_keys` doesn't exist in older Photon
+    installer 2.2 (base ISO swapped from `effac38a0` 2.8 → `dde71ec57` 2.2
+    mid-session). **Fix**: replace surgical regex insert with a module-level
+    monkey-patch appended at end of installer.py that supports any known_keys
+    container type (set/list/tuple/frozenset). Version-resilient, idempotent.
+  - **Bug B fix**: "Photon MOK Secure Boot" dead entry in PackageSelector
+    after MokQuickstart "No" path. The v1.6.0 add_mok_option patch is now
+    obsolete (MOK is exclusively via MokQuickstart Yes paths). Skipped via
+    `#if 0` block in source.
+  - **Bug C deferred**: back-navigation broken on MokQuickstart Yes path —
+    needs `iso_config.py` extraction to diagnose `inactive_screen`
+    ActionResult direction handling.
+
+- **v1.9.55** - Disable Linux floppy driver (`CONFIG_BLK_DEV_FD=n`):
+  - After v1.9.54 fixed the FIPS rollback, operator VM made it past dracut
+    FIPS init but hung at ~28s into initramfs with
+    `floppy0: floppy timeout called` + `I/O error, dev fd0, sector 0`.
+  - **Root cause**: the 128 MB `efuse-secureboot.img` (from `-I PATH:128`)
+    attached as virtual floppy. Linux `floppy.c` auto-probes /dev/fd0 with
+    standard geometries (max 2.88 MB), times out on 128 MB, dracut emergency.
+    GRUB's EFUSE_SIM label check still works (BIOS/UEFI reads).
+  - **Fix**: `scripts/config --disable CONFIG_BLK_DEV_FD` in kernel build.
+  - **VM-side workaround**: attach the .img as virtual SATA disk instead
+    of floppy.
+
+- **v1.9.54** - Explicit `--disable` for FIPS configs (sibling kbuild trap):
+  - v1.9.53 attempted to roll back v1.9.49's `CONFIG_CRYPTO_FIPS=y` by
+    DELETING the `scripts/config --enable` calls. Insufficient —
+    removing `--enable` doesn't undo a prior enable. olddefconfig retains
+    the cached `=y`. Verified post-v1.9.53 rebuild: `CONFIG_CRYPTO_FIPS=y`
+    persisted.
+  - **Fix**: explicit `scripts/config --disable` for `CONFIG_CRYPTO_FIPS`,
+    `CONFIG_CRYPTO_FIPS_NAME`, `CONFIG_FIPS_SIGNATURE_CHECK`.
+  - **Sibling trap to v1.9.46/47** (`--module` vs `--enable` on FUSION).
+    Two canonical kbuild gotchas now documented:
+    - `--module` gets dropped by olddefconfig on tristate symbols whose
+      parent isn't `=m` → use `--enable` for parents.
+    - Removing `--enable` doesn't undo it — explicit `--disable` required
+      to flip back.
+
+- **v1.9.53** - M27 FIPS deferred to v1.10b:
+  - v1.9.49 enabled `CONFIG_CRYPTO_FIPS=y` + built-in `CONFIG_CMDLINE="fips=1"`
+    per operator request. Installed VM booted into emergency mode.
+  - **Root cause** (VMDK analysis 2026-06-06): Photon's installer template
+    hardcodes `audit=1 fips=1 ima_hash=sha256` in installed-system grub.cfg
+    cmdline. Was a silent no-op when kernel had CRYPTO_FIPS=n. With v1.9.49's
+    CRYPTO_FIPS=y, fips=1 engaged real FIPS mode — but the FIPS userland
+    (`/etc/system-fips` marker, openssl-fips, dracut fips module) was never
+    staged → first boot failed before journald could log anything.
+  - **Fingerprint of "first boot never completed"**: `/.selinux-relabel`
+    still at /, `/var/log/installer.log` absent, `/var/log/journal/` empty.
+  - **Fix (this release)**: roll back the kernel-side runtime activation
+    (incomplete — see v1.9.54). M27 deferred to v1.10b with full stack
+    recipe: separate `linux-mok-fips` flavor + `/etc/system-fips` via
+    spec `%post` + dracut `fips` module + openssl-fips package + operator
+    runbook.
+
+- **v1.9.52** - M25 `/ostree-repo.tar.gz` placeholder fix:
+  - GNU tar refuses to create archives from empty input
+    (`tar czf foo --files-from /dev/null` → `Cowardly refusing to create
+    an empty archive`). v1.9.51's M25 placeholder fallback hit this when
+    `ostree` CLI was absent on the build host.
+  - **Fix**: tar a single tiny `M25-NOTE.txt` placeholder instead.
+    Real-ostree-CLI branch unchanged.
+
+- **v1.9.51** - M25 OSTree skeleton `/ostree-repo.tar.gz`:
+  - FEB-2026 PHOTON_SB_6.0 build shipped `/ostree-repo.tar.gz` (261 MB)
+    with an atomic A/B-update OSTree repository. v1.9.51 ships a SKELETON
+    empty ostree-archive repo as the FEB-pattern marker. Full atomic-update
+    functionality (system snapshot + installer wiring) filed for v1.9.52
+    follow-up (M25b).
+
+- **v1.9.50** - M24 `/RPMS_MOK/` parallel audit tree:
+  - FEB-2026 PHOTON_SB_6.0 build shipped a separate `/RPMS_MOK/` directory
+    carrying the MOK-installable package set. Intent: chain-of-trust audit
+    boundary — `/RPMS/` is the original VMware-signed Photon repo;
+    `/RPMS_MOK/` is the HABv4-blessed subset for the MOK install path.
+  - **Minimum-viable**: mirror the 4 MOK-flavored RPMs + mokutil into
+    `/RPMS_MOK/x86_64/` + createrepo. Full 2,150-package dependency-closure
+    mirror filed as v1.9.51 follow-up (M24b).
+
+- **v1.9.49** - M27 FIPS 140-3 (CONFIG_CRYPTO_FIPS=y + built-in `fips=1`):
+  - **INITIAL ATTEMPT — broke first boot.** Rolled back in v1.9.53.
+  - Per operator: "FIPS canister kernels = 140-3; CONFIG_CRYPTO_FIPS=y.
+    FIPS_ENABLED is default."
+  - Configs landed: CRYPTO_FIPS=y, CRYPTO_FIPS_NAME=y, FIPS_SIGNATURE_CHECK=y,
+    CMDLINE_BOOL=y, CMDLINE="fips=1", CMDLINE_OVERRIDE=n.
+  - See v1.9.53 for the post-mortem on why this needed rollback.
+
+- **v1.9.48** - M32 verbose `loglevel=7` in MOK grub.cfg install entry:
+  - Matches FEB-2026 PHOTON_SB_6.0 build pattern. Effect is short-lived
+    (installer boot only) but buys full kernel-side diagnostics during
+    boot — would have shortened the v1.9.43→47 cascade significantly.
+
+- **v1.9.47** - Full hypervisor storage/network coverage:
+  - v1.9.46 enabled CONFIG_VMWARE_PVSCSI/NVME/VIRTIO* but FUSION_*/HYPERV_*/
+    ATA_PIIX were silently dropped by `make olddefconfig`.
+  - **Root cause**: `scripts/config --module CONFIG_FUSION` is dropped by
+    olddefconfig — only `--enable` (=y) survives for tristate symbols whose
+    parent isn't `=m`.
+  - **Fix**: `--enable` for parents (FUSION, FUSION_SPI, FUSION_SAS, ATA_SFF,
+    HYPERV). Added CONFIG_HYPERV_NET. Extended dracut pre-filter with
+    hv_vmbus/hv_storvsc/hv_netvsc/virtio_net. **Also**: fixed shadow
+    `#define VERSION` in `PhotonOS-HABv4Emulation-ISOCreator.c:40` that
+    masked the canonical one in `habv4_common.h:32` — every header-only
+    version bump was a runtime no-op.
+
+- **v1.9.46** - Enable VMware/SATA/NVMe/VirtIO storage drivers:
+  - Photon's `config-esx_x86_64` only ships `mpt3sas` in SCSI driver set;
+    no vmw_pvscsi/mptspi/ahci/nvme/virtio_*. linux-(esx-)mok ISOs only
+    boot VMs with LSI Logic SAS. v1.9.46 added `scripts/config` block.
+    **Partial fix** — FUSION/HYPERV/ATA_PIIX silently dropped (see v1.9.47).
+
+- **v1.9.45** - Pre-filter dracut drivers + fail-fast on MOK build failure:
+  - bash pre-filter loop in linux-(esx-)mok.spec %build that only includes
+    drivers whose .ko exists in `./lib/modules/$KVER`. Missing drivers
+    silently skipped, present ones force-included.
+  - **PLUS** cadastre Rec #1 finally landed: `ISOCreator.c:3979`
+    `log_warn` → `log_error` + `return 1` on MOK RPM build failure.
+    Tool now aborts instead of shipping rc=0 with broken contents.
+
+- **v1.9.44** - Initial expanded dracut --add-drivers (broken — squashed
+  into v1.9.45 narrative): dracut `--add-drivers` is fail-fast on missing
+  modules; `ata_piix` doesn't exist in ESX kernel build → dracut aborted
+  → linux-mok.spec %build failed → tool reported rc=0 anyway → ISO
+  shipped with NO MOK RPMs. v1.9.45 fixes both the pre-filter + the
+  fail-fast.
+
+- **v1.9.43** - Whitelist `mok_quickstart` in `Installer.known_keys`:
+  - `_check_install_config` at installer.py:558-560 raised
+    `InstallerConfigError: Unknown install_config keys: mok_quickstart`
+    on install path. Fix 8: regex insert `'mok_quickstart',` into known_keys
+    set after `'manifest_file',`. **NOTE**: this anchor-based regex broke
+    against older Photon installer 2.2 in v1.9.56 cycle — see v1.9.56
+    for the robust monkey-patch replacement.
+
+- **v1.9.42** - PackageSelector display() guard + ostree pop:
+  - The v1.9.41 `__init__`-time guard was DEAD CODE — `iso_config.add_ui_pages()`
+    instantiates ALL screens at app startup, BEFORE
+    `MokQuickstartSelector.display()` runs. Move guard to `display()`;
+    keep `__init__` belt-and-suspenders for kickstart pre-seed.
+    `_apply_yes()` now pops `install_config['ostree']` (audit Q2).
+
+- **v1.9.41** - "Apply MOK Secure Boot" pre-question UI cascade:
+  - New `MokQuickstartSelector` screen + `mok_quickstart.py` embedded in
+    tool + 4 new installer patches (iso_config / packageselector /
+    linuxselector FIX 4 / stigenable). Implements operator's
+    `No / Yes-Generic / Yes-ESX` flow per ADR-0027 autonomous Q1-Q5.
+
+- **v1.9.40** - Complete linuxselector guard + `exit_gracefully(cause=inst)`:
+  - v1.9.39 patch was incomplete (terminated collector at blank line
+    between Menu and Window). v1.9.40 completes the menu/window/
+    set_action_panel guard.
+  - **Exception cause-chaining**: `exit_gracefully(cause=inst)` +
+    `raise InstallerError(f"... {cause!r}") from cause` — un-masks the
+    real exception text on installer crashes.
+
+- **v1.9.39** - Real `linux-esx-mok.spec` generator + installer hardening.
+
+- **v1.9.38** - Fix python3.11 hardcoded paths + plug 3 missing patches:
+  - Photon 5.0 installer ships python3.14 (was 3.11 in earlier Photon
+    versions). All three hardcoded `usr/lib/python3.11/...` paths silently
+    skipped.
+  - **Fix**: `find_photon_installer_file()` globs `python3.*`. Regex-tolerant
+    patches. Plus 3 missing patch implementations (all_linux_flavors,
+    linuxselector dict, exit_gracefully cause-chain).
+
 - **v1.9.37** - Virtual eFuse USB image (`-I, --create-efuse-img=PATH[:SIZE]`):
   - **New CLI option**: `--create-efuse-img=PATH[:SIZE]` writes the eFuse
     dongle payload to a regular file instead of a physical block device.

--- a/HABv4SimulationEnvironment/docs/TROUBLESHOOTING.md
+++ b/HABv4SimulationEnvironment/docs/TROUBLESHOOTING.md
@@ -11,7 +11,87 @@ This document covers common issues and their solutions.
 5. [Module Loading Issues](#module-loading-issues)
 6. [ISO Creation Issues](#iso-creation-issues)
 7. [USB Boot Issues](#usb-boot-issues)
-8. [Diagnostic Commands](#diagnostic-commands)
+8. [Build Host Issues (Photon WSL2)](#build-host-issues-photon-wsl2)
+9. [Installer Patch Failures](#installer-patch-failures)
+10. [Diagnostic Commands](#diagnostic-commands)
+
+---
+
+## Build Host Issues (Photon WSL2)
+
+### Build fails with `cp: No space left on device` mid-rpmbuild %install
+
+**Cause** (v1.9.49+ FIPS-build cycle): On a typical Photon WSL2 instance, `/tmp` is mounted as a 12 GB tmpfs (RAM-backed). rpmbuild's BUILDROOT for the two MOK kernel flavors (linux-mok + linux-esx-mok) plus the expanded FIPS-config `.ko` set together exceed 12 GB.
+
+**Symptom**: cp errors flood the log mid-rpmbuild `%install`:
+```
+cp: error copying './lib/modules/6.12.87-esx/.../foo.ko' to
+'/tmp/rpm_mok_build/rpmbuild/BUILD/linux-mok-...-build/BUILDROOT/...':
+No space left on device
+```
+v1.9.45 fail-fast triggers correctly with the cadastre-Rec-1 message.
+
+**Fix**: symlink `/tmp/rpm_mok_build` to a disk-backed path:
+```bash
+rm -rf /tmp/rpm_mok_build /root/rpm_mok_build_backing
+mkdir -p /root/rpm_mok_build_backing
+ln -snf /root/rpm_mok_build_backing /tmp/rpm_mok_build
+```
+
+After applying, rpmbuild writes to `/root/rpm_mok_build_backing/` via the symlink. Keep this symlink in place across all future builds.
+
+### Build "succeeds" but no ISO is at `/root/5.0/stage/`
+
+**Cause**: The Photon image-build pipeline (`staging/runPh5_*` scripts) regenerates `/root/5.0/stage/` periodically. Our build output gets wiped between sessions.
+
+**Fix**: archive the built ISO to a location the pipeline doesn't touch:
+```bash
+ISO=$(ls -t /root/5.0/stage/photon-5.0-*-secureboot.iso 2>/dev/null | head -1)
+[ -n "$ISO" ] && cp "$ISO" /root/iso-archive/$(basename "$ISO" .iso)-$(date -u +%Y%m%dT%H%M%S).iso
+```
+
+### Base ISO snapshot drifts between builds (e.g. `effac38a0` → `dde71ec57`)
+
+**Cause**: same as above — the parallel image-build pipeline can drop a different Photon snapshot in `/root/5.0/stage/`. Different snapshots ship different `photon-installer` versions (2.2 vs 2.8) with different `installer.py` shapes. Anchor-based patches that worked against one version may fail silently against another.
+
+**Detection**: a build log line like
+```
+FATAL: manifest_file anchor not found - mok_quickstart NOT whitelisted
+```
+means the v1.9.43 patcher anchor wasn't in this installer.py — the patch silently degrades and the install will crash later with `Unknown install_config keys: mok_quickstart`.
+
+**Fix**: v1.9.56 replaced the fragile anchor regex with a module-level monkey-patch — works across installer versions. Rebuild with v1.9.56+ to pick up the robust patch.
+
+---
+
+## Installer Patch Failures
+
+### Install crashes: `Unknown install_config keys: mok_quickstart`
+
+**Symptom** at end of installer flow when user clicks "Start Installation":
+```
+Traceback (most recent call last):
+  ...
+Exception: Failed with error: Unknown install_config keys: mok_quickstart
+```
+
+**Cause**: the v1.9.43 patch to whitelist `mok_quickstart` in `Installer.known_keys` used regex `'manifest_file',` as anchor. That token exists in photon-installer 2.8 but not in 2.2. Tool emitted `FATAL: manifest_file anchor not found - mok_quickstart NOT whitelisted` at build time but the build continued.
+
+**Fix**: rebuild with v1.9.56+ which uses a robust module-level monkey-patch instead of anchor regex.
+
+### "Photon MOK Secure Boot" entry appears in PackageSelector when user picked "No" in MokQuickstart
+
+**Cause** (pre-v1.9.56): v1.6.0 added a "1. Photon MOK Secure Boot" entry to `build_install_options_all.json` as the primary MOK install path. v1.9.41's MokQuickstart pre-question made this redundant — MOK is now exclusively via Yes paths. The dead entry confused users on the No path.
+
+**Fix**: v1.9.56 skipped the `add_mok_option` patch step via `#if 0`. PackageSelector now shows Photon's default Minimal / Developer / etc options on the No path.
+
+### Back-navigation from Network/Hostname/Password doesn't return to MokQuickstart screen on Yes path
+
+**Cause**: After MokQuickstart Yes, the display() guards on PackageSelector / LinuxSelector / StigEnable cause them to return `ActionResult(None, {"inactive_screen": True})` — Photon's `iso_config` likely doesn't propagate back-direction through inactive screens correctly.
+
+**Status**: deferred to v1.9.57+ — needs `iso_config.py` extraction to diagnose direction handling of the `inactive_screen` ActionResult.
+
+---
 
 ---
 

--- a/HABv4SimulationEnvironment/docs/VERSION_TABLE.md
+++ b/HABv4SimulationEnvironment/docs/VERSION_TABLE.md
@@ -1,11 +1,29 @@
-# Version Table: v1.9.0 to v1.9.37
+# Version Table: v1.9.0 to v1.9.56
 
 > Latest summarised in detail: see Version History in `README.md`. The table
-> below is a snapshot of the v1.9.0 → v1.9.32 series; later entries
-> (v1.9.33–v1.9.37) are summarised inline here for continuity.
+> below is a quick reference; the README has the full narrative.
 
 | Version | MOK Option | Summary |
 |---------|------------|---------|
+| v1.9.56 | ✅ YES | **Bug A** mok_quickstart whitelist robust monkey-patch (replaces fragile `'manifest_file',` anchor that broke against installer 2.2); **Bug B** drop dead "Photon MOK Secure Boot" PackageSelector entry (made obsolete by v1.9.41 MokQuickstart); **Bug C** back-navigation deferred to v1.9.57 |
+| v1.9.55 | ✅ YES | Disable Linux floppy driver (`CONFIG_BLK_DEV_FD=n`) — 128MB efuse-img attached as virtual floppy caused 28s timeout + dracut emergency on first boot of installed system |
+| v1.9.54 | ✅ YES | Explicit `scripts/config --disable` for FIPS configs (v1.9.53 was no-op against kbuild cache — removing `--enable` doesn't undo prior enable; olddefconfig retains the cached =y) |
+| v1.9.53 | ✅ YES | M27 FIPS rolled back to deferred-v1.10b: Photon installer template hardcodes `fips=1 ima_hash=sha256` in installed grub.cfg cmdline; with v1.9.49's CRYPTO_FIPS=y, fips=1 engaged real FIPS mode without userland → first boot emergency |
+| v1.9.52 | ✅ YES | M25 placeholder fix: GNU tar refuses empty archives (`--files-from /dev/null`). Tar a tiny placeholder file instead |
+| v1.9.51 | ✅ YES | M25 `/ostree-repo.tar.gz` skeleton OSTree repo — FEB-2026 PHOTON_SB_6.0 audit marker. Graceful degradation if ostree CLI absent |
+| v1.9.50 | ✅ YES | M24 `/RPMS_MOK/` parallel audit tree — mirror MOK RPMs + mokutil into separate repo (chain-of-trust audit boundary) |
+| v1.9.49 | ❌ ROLLED BACK | M27 FIPS 140-3 (CONFIG_CRYPTO_FIPS=y + built-in `fips=1`) — broke first boot, rolled back in v1.9.53 |
+| v1.9.48 | ✅ YES | M32 verbose `loglevel=7` in MOK grub.cfg install entry (matches FEB-2026 PHOTON_SB_6.0 build) |
+| v1.9.47 | ✅ YES | Full hypervisor coverage: `--enable` (not `--module`) for FUSION_*/HYPERV/ATA_SFF parents; add CONFIG_HYPERV_NET; extend dracut pre-filter with hv_vmbus/hv_storvsc/hv_netvsc/virtio_net. Also: fixed shadow `#define VERSION` in PhotonOS-HABv4Emulation-ISOCreator.c:40 |
+| v1.9.46 | ✅ YES | Enable VMware/SATA/NVMe/VirtIO storage drivers in MOK kernel build (partial — see v1.9.47 for FUSION/HYPERV/ATA_PIIX fix) |
+| v1.9.45 | ✅ YES | Pre-filter dracut `--add-drivers` to only include drivers whose .ko exists; **cadastre Rec #1 LANDED** — fail-fast on MOK RPM build failure (was log_warn → log_error + return 1) |
+| v1.9.44 | ⚠️ BROKEN | Initial expanded dracut --add-drivers; squashed into v1.9.45 narrative (dracut bailed on missing ata_piix; tool reported rc=0 anyway) |
+| v1.9.43 | ✅ YES | Whitelist `mok_quickstart` in `Installer.known_keys` (anchor: `'manifest_file',` — see v1.9.56 for robust replacement) |
+| v1.9.42 | ✅ YES | PackageSelector display() guard + `_apply_yes` ostree pop (the v1.9.41 `__init__` guard was DEAD CODE — all screens instantiated upfront at startup) |
+| v1.9.41 | ✅ YES | "Apply MOK Secure Boot" pre-question UI cascade (`No / Yes-Generic / Yes-ESX`); embedded `mok_quickstart.py` + 4 installer patches per ADR-0027 |
+| v1.9.40 | ✅ YES | Complete linuxselector menu/window/set_action_panel guard; `exit_gracefully(cause=inst)` exception cause-chaining (`raise InstallerError(f"...{cause!r}") from cause`) |
+| v1.9.39 | ✅ YES | Real `linux-esx-mok.spec` generator + installer hardening |
+| v1.9.38 | ✅ YES | Fix python3.11 hardcoded paths (Photon 5.0 ships python3.14); regex-tolerant patches; plug 3 missing patch implementations (all_linux_flavors, linuxselector dict, exit_gracefully cause-chain) |
 | v1.9.37 | ✅ YES | `--create-efuse-img=PATH[:SIZE]` — eFuse USB as `.img` file (loop-backed); byte-equivalent to `--create-efuse-usb`; QEMU-attachable, CI-friendly |
 | v1.9.36 | ✅ YES | Remove conflicting packages from ISO to unblock MOK installation (Error 1525) |
 | v1.9.35 | ✅ YES | Chainloader path, repodata full rebuild, kernel-dependent package removal, RPM macro fix, GPG key path fix, header struct fix, dynamic meta-package expansion |


### PR DESCRIPTION
Catches up the docs in `HABv4SimulationEnvironment/` to reflect the full v1.9.38-v1.9.56 narrative.

Three files updated:
- `README.md` — Version History section gains 19 new entries (newest first)
- `docs/VERSION_TABLE.md` — quick-reference table now covers v1.9.0 → v1.9.56
- `docs/TROUBLESHOOTING.md` — two new sections:
  - **Build Host Issues (Photon WSL2)** — /tmp 12G tmpfs ENOSPC, /root/5.0/stage/ regenerated by parallel session, base ISO snapshot drift between sessions
  - **Installer Patch Failures** — `Unknown install_config keys: mok_quickstart`, dead "Photon MOK Secure Boot" entry, back-navigation broken on MokQuickstart Yes path

🤖 Generated with [Claude Code](https://claude.com/claude-code)