### PR TITLE
phase-M task M153: extract HTTP status from urlhealth exception message

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -1571,6 +1571,15 @@ function urlhealth {
     catch
     {
         $urlhealthrc = [int]$_.Exception.Response.StatusCode.value__
+        # M153: pwsh 7's HttpWebRequest sets $_.Exception.Response = $null for many HTTP
+        # error responses (4xx/5xx and 308 alike), so the line above yields 0 even when
+        # the server returned a real status code. C/libcurl reports the actual numeric
+        # status, producing PS-col4=0 vs C-col4=4xx single-column strict diffs across
+        # ~16 specs per branch. Recover the status code from the exception message
+        # (".NET formats as '(NNN) <reason>'") when the Response object is null.
+        if (($urlhealthrc -eq 0) -and ($_.Exception.Message -match '\((\d{3})\)')) {
+            $urlhealthrc = [int]$matches[1]
+        }
         if (($checkurl -ilike '*netfilter.org*') -or ($checkurl -ilike 'https://ftp.*'))
         {
             $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession


### PR DESCRIPTION
## Summary

- PS-side urlhealth catch fallback for the pwsh 7 quirk where `Exception.Response = $null` makes `[int]$null.StatusCode.value__` evaluate to 0 even when the server returned a real 4xx/5xx. C/libcurl reports actual numeric status; the asymmetry produces PS-col4=0 vs C-col4=404 single-column strict diffs across 16 specs per branch on 5.0 (and similar elsewhere).
- Fix: regex-extract status from exception message `(NNN) <reason>` format when Response is null.
- Predicted impact: 16/branch × 7 branches = ~110 strict rows closed. Combined with M152 (-104), total Cat-3 closure since this morning ≈ -210 rows.

## Test plan

- [x] Six sanity cases pass (M152 x.org good/bad, M153 github 404 x2, github 200 control, DNS-fail control).
- [ ] gate + parity-gate green.
- [ ] Dispatched validation chain confirms -16ish on 5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)