### PR TITLE
phase-M task M157: ext-fallback iterates on clean Source0+UpdateAvailable form

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -5036,20 +5036,24 @@ function CheckURLHealth {
                                             #
                                             # M155: when an alternate succeeds, emit an INFORMATIONAL
                                             # warning ("Info: Packaging format <old> has changed to
-                                            # <new>") instead of leaving col11 empty. This signals
-                                            # downstream consumers (operator review, automated SPECS_NEW
-                                            # adoption pipelines) that the new tarball + SHA in col6/9/10
-                                            # require a Source0-extension edit in the spec file before
-                                            # they can be consumed. col6/col7/col9/col10 are populated
-                                            # by the existing code path (no behaviour change for the
-                                            # download/hash flow); only col11 changes from "" → "Info:…".
-                                            # Preserve the existing "Warning: Manufacturer may changed
-                                            # version packaging format." for the truly-not-found case.
+                                            # <new>") instead of leaving col11 empty.
+                                            #
+                                            # M157: build candidates from the CLEAN Source0 + UpdateAvailable
+                                            # form, not from $UpdateURL. The prior version-format retries
+                                            # at L5001-5028 mutate $UpdateURL through .Replace(".","_") /
+                                            # .Replace(".","-") variants that don't match real upstream
+                                            # tarballs (e.g. libXau-1_0_12.tar.xz doesn't exist; only
+                                            # libXau-1.0.12.tar.xz does). So $UpdateURL by the time we
+                                            # reach this block is a polluted form, and ext-swapping its
+                                            # tail produces unreachable candidates regardless of the
+                                            # extension chosen. Rebuild from Source0Save + the dotted
+                                            # UpdateAvailable so each ext-swap is on a clean URL.
+                                            $cleanUpdateURL = $Source0Save -ireplace $version, $UpdateAvailable
                                             $source0OldExt = ""
-                                            if ($UpdateURL -match '(\.tar\.(xz|gz|bz2)|\.tgz|\.zip)$') { $source0OldExt = $matches[1] }
+                                            if ($cleanUpdateURL -match '(\.tar\.(xz|gz|bz2)|\.tgz|\.zip)$') { $source0OldExt = $matches[1] }
                                             foreach ($ext in @('.tar.xz','.tar.gz','.tar.bz2','.tgz','.zip')) {
-                                                $cand = $UpdateURL -replace '(\.tar\.(xz|gz|bz2)|\.tgz|\.zip)$', $ext
-                                                if ($cand -ne $UpdateURL) {
+                                                $cand = $cleanUpdateURL -replace '(\.tar\.(xz|gz|bz2)|\.tgz|\.zip)$', $ext
+                                                if ($cand -ne $cleanUpdateURL) {
                                                     if ((urlhealth($cand)) -eq "200") {
                                                         $UpdateURL=$cand; $HealthUpdateURL="200"
                                                         if (-not [string]::IsNullOrEmpty($source0OldExt)) {

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -538,8 +538,24 @@ static int pr_build_update_url(pr_task_t *task, const char *source0_save,
         url = t3; h = urlhealth(url);
     }
     /* M81 archive-extension fallback (L4914-4924); M155 surfaces the
-     * old+new ext for the caller's "Info: Packaging format ..." warning. */
-    if (h != 200 && try_url_ext_fallback(&url, out_old_ext, out_new_ext) == 200) h = 200;
+     * old+new ext for the caller's "Info: Packaging format ..." warning.
+     *
+     * M157: ext-fallback operates on a CLEAN copy of attempt-A's url
+     * (s0 with dotted ua). The intermediate attempts B-G mutate url
+     * with .Replace(".","_") / .Replace(".","-") variants that don't
+     * match real upstream tarballs (e.g. libXau-1_0_12.tar.xz doesn't
+     * exist; only libXau-1.0.12.tar.xz does). Probing ext-swaps of
+     * those polluted forms returns 404 for every extension. By rebuilding
+     * the clean form before the swap loop, the ext-fallback finds the
+     * real upstream tarball (mirrors PS M157 at L 5051). */
+    if (h != 200) {
+        char *url_clean = strdup(url_A);
+        if (try_url_ext_fallback(&url_clean, out_old_ext, out_new_ext) == 200) {
+            free(url); url = url_clean; h = 200;
+        } else {
+            free(url_clean);
+        }
+    }
 
     free(ver); free(ua); free(s0);
     free(vshort); free(uashort); free(ua_us); free(ua_dash); free(uashort_us);


### PR DESCRIPTION
## Summary

Iteration #2 of the X.org Cat-7 cluster fix. M155+M156 (PR #300) shipped the Info col11 emission but only closed 5/22 X.org specs (23%) on 5.0. Diagnosis: the M81 archive-extension fallback was iterating ext-swaps on the **polluted** `$UpdateURL` after attempts B-G had munged the version through `.Replace(".","_")` / `.Replace(".","-")` — producing URLs like `libXau-1_0_12.tar.xz` that don't exist upstream regardless of extension.

Fix: build the ext-fallback's base from `Source0Save + UpdateAvailable` directly (clean dotted form), iterate ext-swaps on that.

## Empirical verification

Probing `libXau-1_0_12.{tar.bz2,tar.xz,tar.gz,tgz,zip}` → 404 on all 5 (the polluted form pre-M157).
Probing `libXau-1.0.12.{tar.bz2,tar.xz,tar.gz}` → 404, 200, 200 (the clean form post-M157).

## Changes

- **PS L5036-5055**: insert `$cleanUpdateURL = $Source0Save -ireplace $version, $UpdateAvailable` before the foreach loop; iterate on `$cleanUpdateURL`.
- **C check_urlhealth.c L522**: pass `strdup(url_A)` (the saved attempt-A clean url) to `try_url_ext_fallback` instead of the polluted `url`. On success replace url; on failure free the clone.

## Predicted impact

~17 X.org specs/branch × 7 branches ≈ ~120 col6/7/9/10/11 strict touches; X.org cluster coverage target ≥99% (from current 23%).

## Test plan

- [x] cmake build clean
- [x] ctest 14/14 passes
- [x] Local PS+C trace: clean base form → libXau-1.0.12.tar.xz 200 → Info col11
- [ ] gate + parity-gate green
- [ ] Dispatched validation: confirm ≥99% X.org cluster coverage; if <99%, iteration #3 (extend ext list with .tar.lz/.lzma/.zst)

🤖 Generated with [Claude Code](https://claude.com/claude-code)