### PR TITLE
phase-M task M158: ModifySpecFile rewrites Source0 ext on M157 ext-fallback adoption

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -1463,7 +1463,9 @@ function ModifySpecFile {
         [parameter(Mandatory = $true)]
         [string]$SHALine,
         [parameter(Mandatory = $false)]
-        [string]$CommitId = ""
+        [string]$CommitId = "",
+        [parameter(Mandatory = $false)]
+        [string]$Source0NewExt = ""
     )
     $SpecFile = join-path -path (join-path -path (join-path -path (join-path -path "$WorkingDir" -childpath "$photonDir") -childpath "SPECS") -childpath "$Name") -childpath "$SpecFileName"
     if (!(Test-Path $SpecFile)) {
@@ -1495,6 +1497,14 @@ function ModifySpecFile {
             elseif ($line -ilike '*Release:*') {$line = $line -replace 'Release:.+$', 'Release:        1%{?dist}'; $FileModified += $line}
             elseif ($line -ilike '*Source0:*')
             {
+                # M158: when M155's ext-fallback adopted a new packaging format,
+                # rewrite the Source0 line's literal extension so the spec
+                # written to SPECS_NEW points at the format the SHA was computed
+                # against. Otherwise rpmbuild looks for the old extension in
+                # SOURCES while the downloaded tarball uses the new extension.
+                if (-not [string]::IsNullOrEmpty($Source0NewExt)) {
+                    $line = $line -replace '(\.tar\.(xz|gz|bz2)|\.tgz|\.zip)([^/]*)$', ($Source0NewExt + '$3')
+                }
                 $FileModified += $line
                 $FileModified += $SHALine
                 $skip=$true
@@ -5059,6 +5069,9 @@ function CheckURLHealth {
                                                         if (-not [string]::IsNullOrEmpty($source0OldExt)) {
                                                             $warningText = [System.String]::Concat('Info: Packaging format ', $source0OldExt, ' has changed to ', $ext)
                                                             $warning = $warningText
+                                                            # M158: record the new extension so ModifySpecFile
+                                                            # can rewrite the spec's Source0 line accordingly.
+                                                            $source0NewExt = $ext
                                                         }
                                                         break
                                                     }
@@ -5379,9 +5392,15 @@ function CheckURLHealth {
         # Add a space to signalitze that something went wrong when extracting SHAvalue but do not stop modifying the spec file.
         if ([string]::IsNullOrEmpty($SHALine)) { $SHALine=" " }
 
-        if ($currentTask.Spec -ilike 'openjdk8.spec') {ModifySpecFile -SpecFileName $currentTask.spec -WorkingDir $WorkingDir -PhotonDir $photonDir -UpstreamsDir $UpstreamsDir -Name $currentTask.name -Update $UpdateAvailable -UpdateDownloadFile $UpdateDownloadFile -OpenJDK8 $true -SHALine $SHALine}
-        elseif ($currentTask.Spec -ilike 'netcat.spec') {ModifySpecFile -SpecFileName $currentTask.spec -WorkingDir $WorkingDir -PhotonDir $photonDir -UpstreamsDir $UpstreamsDir -Name $currentTask.name -Update $UpdateAvailable -UpdateDownloadFile $UpdateDownloadFile -OpenJDK8 $false -SHALine $SHALine -CommitId $Script:netcatCommitId}
-        else {ModifySpecFile -SpecFileName $currentTask.spec -WorkingDir $WorkingDir -PhotonDir $photonDir -UpstreamsDir $UpstreamsDir -Name $currentTask.name -Update $UpdateAvailable -UpdateDownloadFile $UpdateDownloadFile -OpenJDK8 $false -SHALine $SHALine}
+        # M158: pass $source0NewExt (set by M155+M157 ext-fallback when a new
+        # packaging format was adopted) so ModifySpecFile rewrites the spec's
+        # Source0 line to use the new ext. Default to empty when the variable
+        # was never assigned in this scope (ext-fallback didn't fire). Same
+        # default-via-coalesce pattern as other optional parameters.
+        $s0NewExt = if ($null -ne $source0NewExt) { $source0NewExt } else { "" }
+        if ($currentTask.Spec -ilike 'openjdk8.spec') {ModifySpecFile -SpecFileName $currentTask.spec -WorkingDir $WorkingDir -PhotonDir $photonDir -UpstreamsDir $UpstreamsDir -Name $currentTask.name -Update $UpdateAvailable -UpdateDownloadFile $UpdateDownloadFile -OpenJDK8 $true -SHALine $SHALine -Source0NewExt $s0NewExt}
+        elseif ($currentTask.Spec -ilike 'netcat.spec') {ModifySpecFile -SpecFileName $currentTask.spec -WorkingDir $WorkingDir -PhotonDir $photonDir -UpstreamsDir $UpstreamsDir -Name $currentTask.name -Update $UpdateAvailable -UpdateDownloadFile $UpdateDownloadFile -OpenJDK8 $false -SHALine $SHALine -CommitId $Script:netcatCommitId -Source0NewExt $s0NewExt}
+        else {ModifySpecFile -SpecFileName $currentTask.spec -WorkingDir $WorkingDir -PhotonDir $photonDir -UpstreamsDir $UpstreamsDir -Name $currentTask.name -Update $UpdateAvailable -UpdateDownloadFile $UpdateDownloadFile -OpenJDK8 $false -SHALine $SHALine -Source0NewExt $s0NewExt}
     }
 
     # ADR-0014 (Option B) row assembly: when PR_EMIT_MULTI_SHA is set,

--- a/photonos-package-report/photonos-package-report/include/pr_modify_spec.h
+++ b/photonos-package-report/photonos-package-report/include/pr_modify_spec.h
@@ -26,6 +26,10 @@
 
 #include "pr_types.h"
 
+/* M158: source0_new_ext (e.g. ".tar.gz", ".tar.xz") rewrites the Source0
+ * line's literal extension when the M81/M157 ext-fallback adopted a new
+ * packaging format. NULL or empty means "leave Source0 untouched"
+ * (default behaviour). Mirrors PS L1496-1505 + L5392-5394. */
 int pr_modify_spec_file(const pr_task_t *task,
                         const char      *working_dir,
                         const char      *upstreams_dir,
@@ -34,6 +38,7 @@ int pr_modify_spec_file(const pr_task_t *task,
                         const char      *sha_line,
                         int              openjdk8,
                         const char      *commit_id,
+                        const char      *source0_new_ext,
                         const char      *out_subdir);
 
 #endif /* PR_MODIFY_SPEC_H */

--- a/photonos-package-report/photonos-package-report/include/pr_state.h
+++ b/photonos-package-report/photonos-package-report/include/pr_state.h
@@ -44,6 +44,13 @@ struct pr_state {
      * cached PS snapshot). */
     char *SHA256Name;
     char *SHA512Name;
+    /* M158: the new packaging-format extension chosen by the M81/M157
+     * ext-fallback (e.g. ".tar.gz"). NULL when no ext swap happened.
+     * pr_modify_spec_file uses it to rewrite the spec's Source0 line so
+     * SPECS_NEW outputs are buildable against the downloaded tarball.
+     * Borrowed pointer into try_url_ext_fallback's static exts[]; not
+     * freed by pr_state_free. */
+    const char *Source0NewExt;
 };
 
 typedef struct pr_state pr_state_t;

--- a/photonos-package-report/photonos-package-report/src/check_urlhealth.c
+++ b/photonos-package-report/photonos-package-report/src/check_urlhealth.c
@@ -2122,6 +2122,9 @@ char *check_urlhealth(pr_task_t                       *task,
                                             free(state.Warning);
                                             state.Warning = info;
                                         }
+                                        /* M158: pass the new ext to pr_modify_spec_file
+                                         * so SPECS_NEW writes the correct Source0 line. */
+                                        state.Source0NewExt = fmt_new;
                                     }
                                 } else if (h == 0) {
                                     /* Transient network error (not a 404): keep
@@ -2958,6 +2961,9 @@ char *check_urlhealth(pr_task_t                       *task,
                                 free(state.Warning);
                                 state.Warning = info;
                             }
+                            /* M158: pass the new ext to pr_modify_spec_file
+                             * so SPECS_NEW writes the correct Source0 line. */
+                            state.Source0NewExt = fmt_new;
                         }
                         if (state.UpdateURL && state.UpdateURL[0]) {
                             char *dl_name = pr_basename_from_url(state.UpdateURL);
@@ -3234,7 +3240,9 @@ char *check_urlhealth(pr_task_t                       *task,
                                     working_dir,   /* output: SPECS_NEW_C alongside SPECS */
                                     photon_dir,
                                     state.UpdateAvailable, sha_line,
-                                    is_openjdk8, NULL, "SPECS_NEW_C");
+                                    is_openjdk8, NULL,
+                                    state.Source0NewExt, /* M158 */
+                                    "SPECS_NEW_C");
                 free(sha_line);
             }
         }

--- a/photonos-package-report/photonos-package-report/src/modify_spec.c
+++ b/photonos-package-report/photonos-package-report/src/modify_spec.c
@@ -125,6 +125,7 @@ int pr_modify_spec_file(const pr_task_t *task,
                         const char      *sha_line,
                         int              openjdk8,
                         const char      *commit_id,
+                        const char      *source0_new_ext,
                         const char      *out_subdir)
 {
     if (task == NULL || task->Spec == NULL || task->Name == NULL) return -1;
@@ -210,7 +211,48 @@ int pr_modify_spec_file(const pr_task_t *task,
             char *r = replace_after_colon("Release:", "1%{?dist}");
             if (r) { EMIT(r); free(r); } else { EMIT(line); }
         } else if (ilike_contains(line, "Source0:")) {
-            EMIT(line);
+            /* M158: when the M81/M157 ext-fallback adopted a new packaging
+             * format, rewrite the Source0 line's literal extension so the
+             * spec written to SPECS_NEW points at the format the SHA was
+             * computed against. Mirrors PS L 1496-1505. The trailing
+             * captured group (`%3` in PS) preserves any post-ext suffix
+             * like "  # comment". */
+            const char *src0_line = line;
+            char *swapped = NULL;
+            if (source0_new_ext && source0_new_ext[0]) {
+                static const char *const exts[] = {
+                    ".tar.xz", ".tar.gz", ".tar.bz2", ".tgz", ".zip", NULL
+                };
+                /* Find the rightmost recognised ext in the line. */
+                const char *found = NULL; size_t found_pos = 0; size_t found_len = 0;
+                for (int e = 0; exts[e]; e++) {
+                    const char *p = strstr(src0_line, exts[e]);
+                    while (p) {
+                        const char *next = strstr(p + 1, exts[e]);
+                        if (next == NULL) break;
+                        p = next;
+                    }
+                    if (p && (found == NULL || (size_t)(p - src0_line) > found_pos)) {
+                        found = p;
+                        found_pos = (size_t)(p - src0_line);
+                        found_len = strlen(exts[e]);
+                    }
+                }
+                if (found && strcmp(found, source0_new_ext) != 0) {
+                    size_t new_len = strlen(source0_new_ext);
+                    size_t tail_len = strlen(found + found_len);
+                    swapped = (char *)malloc(found_pos + new_len + tail_len + 1);
+                    if (swapped) {
+                        memcpy(swapped, src0_line, found_pos);
+                        memcpy(swapped + found_pos, source0_new_ext, new_len);
+                        memcpy(swapped + found_pos + new_len,
+                               found + found_len, tail_len + 1);
+                        src0_line = swapped;
+                    }
+                }
+            }
+            EMIT(src0_line);
+            free(swapped);
             if (sha_line && sha_line[0]) EMIT(sha_line);
             skip_next = 1;
         } else if (ilike_prefix(line, "%changelog")) {

--- a/photonos-package-report/photonos-package-report/src/state.c
+++ b/photonos-package-report/photonos-package-report/src/state.c
@@ -25,6 +25,7 @@ void pr_state_init(pr_state_t *s)
     s->ArchivationDate    = new_empty();
     s->SHA256Name         = new_empty();
     s->SHA512Name         = new_empty();
+    s->Source0NewExt      = NULL;          /* M158: borrowed pointer, NULL = no swap */
 }
 
 void pr_state_free(pr_state_t *s)

--- a/photonos-package-report/photonos-package-report/tests/unit/test_phase6g.c
+++ b/photonos-package-report/photonos-package-report/tests/unit/test_phase6g.c
@@ -107,7 +107,7 @@ static void test_default_spec(const char *tmp)
 
     int rc = pr_modify_spec_file(t, tmp, tmp, "photon-5.0",
                                  "1.2.5", "%define sha512 foo=NEWHASH",
-                                 0, NULL, "SPECS_NEW_C");
+                                 0, NULL, NULL, "SPECS_NEW_C");
     EXPECT(rc == 0);
 
     char out_path[1024];
@@ -154,7 +154,7 @@ static void test_openjdk8_version(const char *tmp)
                              lines, sizeof lines / sizeof lines[0]);
     int rc = pr_modify_spec_file(t, tmp, tmp, "photon-3.0",
                                  "402b05", "%define sha512 openjdk=NEW",
-                                 1 /* openjdk8 */, NULL, "SPECS_NEW_C");
+                                 1 /* openjdk8 */, NULL, NULL, "SPECS_NEW_C");
     EXPECT(rc == 0);
 
     char out_path[1024];
@@ -187,7 +187,7 @@ static void test_subversion_and_commit_id(const char *tmp)
                              lines, sizeof lines / sizeof lines[0]);
     int rc = pr_modify_spec_file(t, tmp, tmp, "photon-6.0",
                                  "1.1", "%define sha512 netcat=NEW",
-                                 0, "deadbeef", "SPECS_NEW_C");
+                                 0, "deadbeef", NULL, "SPECS_NEW_C");
     EXPECT(rc == 0);
     char out_path[1024];
     snprintf(out_path, sizeof out_path,
@@ -225,7 +225,7 @@ static void test_changelog_author_default(const char *tmp)
                              lines, sizeof lines / sizeof lines[0]);
     int rc = pr_modify_spec_file(t, tmp, tmp, "photon-master",
                                  "2.0", "%define sha512 foo=NEW",
-                                 0, NULL, "SPECS_NEW_C");
+                                 0, NULL, NULL, "SPECS_NEW_C");
     EXPECT(rc == 0);
     char out_path[1024];
     snprintf(out_path, sizeof out_path,
@@ -257,7 +257,7 @@ static void test_changelog_author_override(const char *tmp)
                              lines, sizeof lines / sizeof lines[0]);
     int rc = pr_modify_spec_file(t, tmp, tmp, "photon-6.0",
                                  "0.2", "%define sha512 bar=NEW",
-                                 0, NULL, "SPECS_NEW_C");
+                                 0, NULL, NULL, "SPECS_NEW_C");
     EXPECT(rc == 0);
     char out_path[1024];
     snprintf(out_path, sizeof out_path,
@@ -288,7 +288,7 @@ static void test_asc_suffix_strip(const char *tmp)
                              lines, sizeof lines / sizeof lines[0]);
     int rc = pr_modify_spec_file(t, tmp, tmp, "photon-dev",
                                  "2.0.tar.asc", "%define sha512 foo=NEW",
-                                 0, NULL, "SPECS_NEW_C");
+                                 0, NULL, NULL, "SPECS_NEW_C");
     EXPECT(rc == 0);
     /* .asc stripped from the filename — PS L 1473. */
     char out_path[1024];


### PR DESCRIPTION
## Summary

Closes the M155+M156+M157 chain end-to-end. When the M81 ext-fallback adopts a new packaging format (`.tar.bz2` → `.tar.xz` for the X.org cluster), the `.prn` col6/7/9/10/11 already populate correctly (M155+M156) and the SHA is computed against the new tarball — but **`SPECS_NEW/<Name>/<base>-<Update>.spec` still carried the spec's OLD Source0 extension**. rpmbuild looks for the bz2 in SOURCES while only the xz/gz exists → build fails.

This PR rewrites the Source0 line's extension in lockstep with the ext-fallback adoption, so SPECS_NEW outputs are **buildable as-is**.

## Changes

- **PS L1496-1505 (ModifySpecFile)**: gain `-Source0NewExt` optional param; rewrite the Source0 line's literal extension when non-empty.
- **PS L5036-5076 (ext-fallback success block)**: record the new ext into `$source0NewExt`.
- **PS L5392-5394 (call sites)**: plumb `$source0NewExt` through the three branches (openjdk8/netcat/else).
- **C `pr_state_t`**: gain `Source0NewExt` (const char *, borrowed pointer into static exts[]).
- **C check_urlhealth.c**: capture `fmt_new` into `state.Source0NewExt` at both `pr_build_update_url` success sites; pass through to `pr_modify_spec_file`.
- **C `pr_modify_spec_file`**: gain `source0_new_ext` param; Source0 handler finds rightmost recognised ext and rewrites it.

## Test plan

- [x] cmake build clean
- [x] ctest 14/14 passes (test_phase6g call sites updated to pass NULL)
- [x] PS regex sanity-test: `Source0: ...libXau-%{version}.tar.bz2` → `Source0: ...libXau-%{version}.tar.xz`
- [ ] gate + parity-gate green (no `.prn`-affecting code)
- [ ] Post-merge spot-check: a SPECS_NEW output for an X.org spec (e.g. `SPECS_NEW/libXau-1.0.12.spec` or `SPECS_NEW_C/libXau-1.0.12.spec`) shows the rewritten `.tar.xz` extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)