### PR TITLE
phase-M task M159: guard 8-digit-date vs dotted-semver as incomparable (Cat-5)

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -1969,6 +1969,21 @@ function CheckURLHealth {
             [string]$Version
         )
 
+        # M159: clearly-incomparable pair guard. An 8-digit YYYYMMDD-style
+        # version vs a dotted decimal-semver version (e.g. libnss-ato
+        # 20240514 vs detected upstream 0.2.0) does not represent a real
+        # "Source0 is higher than detected upstream" relationship — the
+        # two sides aren't on the same number line. Return $null so the
+        # caller treats the comparison as a parse-error (empty col5,
+        # no warning) instead of emitting the misleading
+        # "Source0 version X is higher than detected latest version Y"
+        # warning that Rule 2 would otherwise produce. Mirrors C
+        # pr_version_compare's early -2 return at version.c.
+        $is8DigitDate = { param($s) $s -and ($s -match '^\d{8}$') }
+        $isDottedSemver = { param($s) $s -and ($s -match '^\d+(\.\d+)+$') }
+        if ((& $is8DigitDate $Namelatest) -and (& $isDottedSemver $Version)) { return $null }
+        if ((& $is8DigitDate $Version)    -and (& $isDottedSemver $Namelatest)) { return $null }
+
         try {
             $v1 = Parse-Version -InputVersion $Namelatest
             $v2 = Parse-Version -InputVersion $Version

--- a/photonos-package-report/photonos-package-report/src/version.c
+++ b/photonos-package-report/photonos-package-report/src/version.c
@@ -366,8 +366,41 @@ static int is_date_type(pr_version_type_t t)
     return t == PR_VER_DATE_VERSION || t == PR_VER_VERSION_DATE;
 }
 
+/* M159: an 8-digit YYYYMMDD-style version vs a dotted decimal-semver
+ * version (e.g. libnss-ato 20240514 vs detected upstream 0.2.0) does not
+ * represent a real "Source0 is higher than detected upstream" relationship —
+ * the two sides aren't on the same number line. PS's Rule 2 would treat
+ * the date as higher and emit the misleading "Source0 version X is higher
+ * than detected latest version Y" warning. Catch the pair here and return
+ * -2 (parse-error sentinel — caller emits empty col5, no warning). */
+static int is_8digit_date_str(const char *s)
+{
+    if (s == NULL) return 0;
+    size_t n = strlen(s);
+    if (n != 8) return 0;
+    for (size_t i = 0; i < n; i++) {
+        if (s[i] < '0' || s[i] > '9') return 0;
+    }
+    return 1;
+}
+static int is_dotted_semver_str(const char *s)
+{
+    if (s == NULL || *s == '\0') return 0;
+    if (strchr(s, '.') == NULL) return 0;
+    if (s[0] < '0' || s[0] > '9') return 0;
+    for (const char *p = s; *p; p++) {
+        if ((*p < '0' || *p > '9') && *p != '.') return 0;
+    }
+    return 1;
+}
+
 int pr_version_compare(const char *a, const char *b)
 {
+    /* M159: clearly-incomparable pair (8-digit date vs dotted semver). */
+    if ((is_8digit_date_str(a) && is_dotted_semver_str(b)) ||
+        (is_8digit_date_str(b) && is_dotted_semver_str(a))) {
+        return -2;
+    }
     pr_version_t v1 = {0}, v2 = {0};
     if (pr_version_parse(a, &v1) != 0) return -2;
     if (pr_version_parse(b, &v2) != 0) { pr_version_free(&v1); return -2; }


### PR DESCRIPTION
## Summary

When `pr_version_compare` / `Compare-VersionStrings` receives one side that is a bare 8-digit YYYYMMDD (no dots, all digits) and the other is a dotted decimal-semver (e.g., `0.2.0`), the two sides aren't on the same number line. PS's Rule 2 (date-based takes priority) returns ±1, feeding the L3340 emission of `"Warning: <spec> Source0 version <date> is higher than detected latest version <semver> ."` — a meaningless Cat-5 warning.

Empirical case on 5.0: `libnss-ato.spec` source=`20240514` vs detected `0.2.0`. Source0 carries a date stamp; upstream is on its 0.x semver track. No real "higher than" relationship.

## Fix

- **PS L1972-1985**: pre-check before `try { ... }`; return `$null` when the guard matches. Every emission site already handles `$null` by skipping the Warning assignment (Write-Host log only); col5 stays empty.
- **C src/version.c**: pre-check before `pr_version_parse`; return `-2` (existing parse-error sentinel). Call sites at L2079 + L2887 already handle `rc==-2` → empty col5.

## What's NOT affected

- Both 8-digit dates (Rule 1) — kernel-style dates
- Both dotted-semver (Rule 3) — `linux.spec` 6.12.92 vs 6.1.175
- 8-digit vs single integer — `(20240514, 5)`
- Mixed forms with hyphen / letter — proto, ibmtpm, libmspack (not 8-digit pure)

## Test plan

- [x] cmake build clean
- [x] ctest 14/14 passes
- [x] 7-case sanity test: only the 8-digit-date-vs-dotted-semver pair returns -2; all others return expected ±1/0
- [ ] gate + parity-gate green
- [ ] Dispatched validation: confirm libnss-ato col5 transitions from Warning text to empty on both PS and C in lockstep

## Expected impact

Per Track B agent's audit, Cat-5 cluster on 5.0 has 18 specs; this fix targets the 8-digit-date-vs-semver subset (libnss-ato definite, possibly 1-2 others across all branches). Predicted: 2-7 strict rows closed across the 7 strict branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)