### PR TITLE
sync(spagat-console): T-PUB fileset + standalone user docs (from appliance @ fde0d8e)

### DIFF
--- a/SPAGAT-Librarian/AGENT.md
+++ b/SPAGAT-Librarian/AGENT.md
@@ -1,0 +1,153 @@
+# AGENT
+
+The SPAGAT-Librarian AI agent turns a plain-language operator gesture
+into a small, auditable action against the local host. It does one
+thing well:
+
+> Read the gesture, pick the right skill(s), draft an LLM prompt, show
+> the result, and only then — with the operator's consent — run the
+> concrete command.
+
+Everything the agent does happens inside a single `spagat-librarian`
+process on the operator's own machine. There is no remote coordinator,
+no scheduler pushing tasks in, and no persistent daemon. The agent
+exits when the TUI is closed or when the `ai` subcommand returns.
+
+## What the agent understands
+
+An **operator gesture** is a natural-language sentence the operator
+types into the TUI's AI panel or passes to `spagat-librarian ai
+"..."`. Examples:
+
+- "Summarise disk-usage growth over the last week."
+- "Why did the `sshd` service restart in the last hour?"
+- "Which package brought in the latest openssl update?"
+- "Draft a firewall rule that lets port 8080 through only from 10.0.0.0/8."
+
+The agent parses the gesture, matches it against the skill index (see
+[SKILLS.md](SKILLS.md)), loads one or two relevant skills into the LLM
+prompt, and returns either an answer or a proposed command.
+
+## The five autonomy tiers
+
+The agent runs at one of five autonomy tiers, controlled by
+`SPAGAT_AGENT_AUTONOMY` or `[agent] autonomy = "..."` in the config
+file. Every tier above `observe` prompts the operator before executing
+a write.
+
+| Tier         | Reads                    | Writes                       |
+| ------------ | ------------------------ | ---------------------------- |
+| `none`       | (LLM only, no tools)     | never                        |
+| `observe`    | anywhere readable        | never                        |
+| `workspace`  | anywhere readable        | inside `$PWD`, on prompt     |
+| `home`       | anywhere readable        | inside `$HOME`, on prompt    |
+| `full`       | anywhere readable        | anywhere the user has access, on prompt |
+
+`observe` is the default. In `observe`, the agent will happily read
+files, tail logs, and run `git status`, but any command it drafts that
+would write to the filesystem or the network is shown as a suggestion
+only.
+
+Output is sandboxed and sanitised before being echoed back to the TUI:
+API keys, SSH fingerprints, and obvious credential shapes are redacted
+so a screen recording or a session log does not leak them.
+
+## Three worked examples
+
+### Example 1 — "summarise disk usage growth"
+
+Gesture:
+
+```
+> summarise disk usage growth over the last 7 days for /var
+```
+
+What the agent does:
+
+1. Matches the `logs` and `performance` skills.
+2. Runs a read-only tool call: `du -sh /var` and `df -h /var`.
+3. Reads `/var/log/journal` window sizes as a rough growth proxy.
+4. Composes an LLM prompt: system context + the two skill files + the
+   collected numbers.
+5. Prints a two-paragraph human summary. Under `observe`, that is it —
+   nothing is written or changed.
+
+### Example 2 — "why did service X restart"
+
+Gesture:
+
+```
+> why did the docker service restart in the last hour?
+```
+
+What the agent does:
+
+1. Matches the `systemctl` and `logs` skills.
+2. Runs `systemctl status docker` and
+   `journalctl -u docker --since "1 hour ago" --no-pager`.
+3. Feeds both outputs and the two skill files into the LLM.
+4. Prints a diagnosis: what triggered the restart, whether it was
+   clean, and one suggested follow-up. Follow-ups that would *change*
+   the system (for example "run `systemctl reset-failed docker`") are
+   shown as suggested commands, not executed, unless the autonomy tier
+   is `workspace` or higher and the operator confirms.
+
+### Example 3 — "draft a firewall rule"
+
+Gesture:
+
+```
+> draft an iptables rule that lets port 8080 through only from 10.0.0.0/8
+```
+
+What the agent does:
+
+1. Matches the `iptables` skill.
+2. Reads the current `iptables -L -n -v` output (read-only, allowed at
+   `observe`).
+3. Drafts the exact rule as a fenced code block:
+
+   ```
+   iptables -A INPUT -p tcp --dport 8080 -s 10.0.0.0/8 -j ACCEPT
+   iptables -A INPUT -p tcp --dport 8080 -j DROP
+   ```
+
+4. Shows the diff between the current chain and the proposed chain.
+5. **Never** runs the rule at `observe` — the operator copies it out
+   and runs it by hand. At higher tiers, the agent asks for
+   confirmation and then executes.
+
+## The five safety invariants
+
+1. **Consent before write.** The agent never modifies the filesystem
+   or the network unless the autonomy tier is above `observe` **and**
+   the operator answers `y` to a confirmation prompt for that specific
+   command.
+2. **Least-authority path filter.** At `workspace`, writes outside
+   `$PWD` are rejected before the command runs. At `home`, writes
+   outside `$HOME` are rejected.
+3. **Output sanitisation.** Every LLM output pass is filtered for API
+   keys, SSH fingerprints, and password patterns; matches are replaced
+   with `[REDACTED]` in the TUI and the journal.
+4. **Journal every action.** Every gesture, every command the agent
+   proposes, and every command actually executed is written to
+   `$XDG_STATE_HOME/spagat/logs/spagat.log`. The journal self-rotates
+   at ~2 MB with three retained files.
+5. **No remote coordinator.** The agent has no channel back to any
+   fleet manager, scheduler, or upstream server. Its only outbound
+   traffic is to whichever LLM you configured (or none, if you use
+   `llama.cpp` locally).
+
+## Turning the agent off
+
+If you only want the kanban board and not the AI parts:
+
+```toml
+[llm]
+mode = "off"
+
+[agent]
+autonomy = "none"
+```
+
+The TUI and CLI work exactly as before; the AI panel is hidden.

--- a/SPAGAT-Librarian/CONFIGURATION.md
+++ b/SPAGAT-Librarian/CONFIGURATION.md
@@ -1,0 +1,128 @@
+# CONFIGURATION
+
+SPAGAT-Librarian follows the XDG Base Directory spec. Configuration lives
+under `$XDG_CONFIG_HOME`, state lives under `$XDG_STATE_HOME`, and every
+knob has an environment-variable override for scripting.
+
+## File layout
+
+| Purpose               | Default path                                                   | Notes                                             |
+| --------------------- | -------------------------------------------------------------- | ------------------------------------------------- |
+| Config file           | `$XDG_CONFIG_HOME/spagat/config.toml` (`~/.config/spagat/...`) | Optional; every key has an env override           |
+| Kanban database       | `$XDG_STATE_HOME/spagat/spagat.db` (`~/.local/state/spagat/...`) | SQLite; override with `SPAGAT_DB`               |
+| Journal / logs        | `$XDG_STATE_HOME/spagat/logs/spagat.log`                       | Self-rotating (three files of ~2 MB each)         |
+| Custom skill files    | `$XDG_CONFIG_HOME/spagat/skills/*.md`                          | See [SKILLS.md](SKILLS.md)                        |
+| Local GGUF models     | Anywhere; you pass the absolute path in the env var            | See "Offline LLM" below                           |
+| System skill files    | `/usr/share/spagat/skills/*.md` (from RPM)                     | Read-only; ships the eight defaults               |
+
+None of these paths are hard-coded to `/etc`, `/run`, or `/var` for
+appliance state. Everything is per-user.
+
+## config.toml
+
+A minimal `~/.config/spagat/config.toml`:
+
+```toml
+[ui]
+# ncurses colour scheme: "auto", "dark", or "light".
+theme = "auto"
+
+[llm]
+# "local"    -> use llama.cpp with the model at local_model_path
+# "frontier" -> use a frontier API, key resolved from env vars
+# "off"      -> disable the LLM panel entirely
+mode = "frontier"
+
+[llm.local]
+model_path = "/home/alice/models/llama-3-8b-instruct.Q4_K_M.gguf"
+backend    = "llama.cpp"
+
+[agent]
+# One of: none | observe | workspace | home | full
+# Default is "observe" — the agent may read but never writes without consent.
+autonomy = "observe"
+```
+
+Every key in this file can be overridden by an environment variable, and
+the file itself is optional — a fresh install with only env vars set
+works.
+
+## Environment variables
+
+### Paths
+
+| Variable          | Default                                     | Effect                                    |
+| ----------------- | ------------------------------------------- | ----------------------------------------- |
+| `SPAGAT_DB`       | `$XDG_STATE_HOME/spagat/spagat.db`          | Override the SQLite kanban store path     |
+| `SPAGAT_CONFIG`   | `$XDG_CONFIG_HOME/spagat/config.toml`       | Override the config file location         |
+| `SPAGAT_SKILLS_DIR` | `$XDG_CONFIG_HOME/spagat/skills`          | Extra directory searched before the system defaults |
+| `SPAGAT_JOURNAL`  | `$XDG_STATE_HOME/spagat/logs/spagat.log`    | Override the journal path                 |
+
+### Local (offline) LLM via llama.cpp
+
+| Variable                        | Example                                              | Effect                                             |
+| ------------------------------- | ---------------------------------------------------- | -------------------------------------------------- |
+| `SPAGAT_LLM_LOCAL_MODEL_PATH`   | `/home/alice/models/llama-3-8b-instruct.Q4_K_M.gguf` | GGUF model file                                    |
+| `SPAGAT_LLM_LOCAL_BACKEND`      | `llama.cpp`                                          | Selects the local backend implementation           |
+| `SPAGAT_LLM_LOCAL_CONTEXT_SIZE` | `4096`                                               | Context window (tokens); optional                  |
+| `SPAGAT_LLM_LOCAL_THREADS`      | `8`                                                  | CPU threads; optional                              |
+
+### Frontier LLM via env-var keys
+
+Set exactly one of these to use a frontier API. Only one at a time —
+SPAGAT-Librarian never merges providers, and it never reads keys from
+disk or from any mounted volume.
+
+| Variable                | Provider          |
+| ----------------------- | ----------------- |
+| `SPAGAT_ANTHROPIC_KEY`  | Anthropic Claude  |
+| `SPAGAT_GEMINI_KEY`     | Google Gemini     |
+| `SPAGAT_XAI_KEY`        | xAI               |
+| `SPAGAT_OPENAI_KEY`     | OpenAI            |
+
+If more than one is set, resolution order is
+**Anthropic > Gemini > xAI > OpenAI**, and the binary logs which one it
+picked at the first LLM call. To pin a specific provider, unset the
+others in your shell profile.
+
+Optional model overrides:
+
+| Variable                     | Example                       |
+| ---------------------------- | ----------------------------- |
+| `SPAGAT_ANTHROPIC_MODEL`     | `claude-opus-4-7`             |
+| `SPAGAT_GEMINI_MODEL`        | `gemini-2.5-pro`              |
+| `SPAGAT_XAI_MODEL`           | `grok-4`                      |
+| `SPAGAT_OPENAI_MODEL`        | `gpt-4o`                      |
+
+### Agent autonomy
+
+The agent has five autonomy tiers:
+
+| Value        | Effect                                                              |
+| ------------ | ------------------------------------------------------------------- |
+| `none`       | LLM chat only, no tool use                                          |
+| `observe`    | Read-only tools (fs read, git status, system info). **Default.**    |
+| `workspace`  | Read + write inside `$PWD` and below                                |
+| `home`       | Read + write inside `$HOME`                                         |
+| `full`       | Read + write anywhere the invoking user has access                  |
+
+Set with `SPAGAT_AGENT_AUTONOMY=<value>` or `[agent] autonomy = "..."`
+in `config.toml`. Every autonomy tier above `observe` prompts the
+operator before executing a write. See [AGENT.md](AGENT.md).
+
+## Running as a background service (optional)
+
+If you want to run `spagat-librarian` non-interactively (for example
+under a systemd user unit or a container init), it accepts a generic
+`--systemd` flag that emits `sd_notify(READY=1)` on start-up. This flag
+is optional and completely provider-agnostic — no vendored unit files
+ship with the CLI.
+
+## Precedence
+
+Config values resolve in this order (highest wins):
+
+1. Command-line flag
+2. Environment variable
+3. `config.toml`
+4. Compiled-in default

--- a/SPAGAT-Librarian/INSTALL.md
+++ b/SPAGAT-Librarian/INSTALL.md
@@ -1,0 +1,110 @@
+# INSTALL
+
+SPAGAT-Librarian CLI ships as a single C binary called `spagat-librarian`.
+It has three build paths on a plain Linux host: from source with `make`,
+from source with `cmake`, or from an RPM built via `spagat.spec`.
+
+## Dependencies
+
+| Package             | Runtime | Build    | Notes                                       |
+| ------------------- | ------- | -------- | ------------------------------------------- |
+| `ncurses`           | yes     | headers  | TUI                                         |
+| `sqlite3`           | yes     | headers  | Kanban store (`~/.spagat.db` by default)    |
+| `gcc` and `make`    |         | required | Native build                                |
+| `cmake` (3.20+)     |         | optional | Alternate build path                        |
+| `llama.cpp`         | opt.    | opt.     | Only needed for the offline local-LLM path  |
+| `rpm-build`         |         | opt.     | Only needed when building the RPM           |
+
+The offline LLM path is optional. If you plan to use only a frontier LLM
+(Anthropic / Gemini / xAI / OpenAI) via environment-variable keys, you
+can skip `llama.cpp` entirely.
+
+### Photon OS 5.0
+
+```bash
+sudo tdnf install -y gcc make ncurses-devel sqlite-devel
+# optional, for offline LLM:
+sudo tdnf install -y cmake git
+```
+
+### Fedora
+
+```bash
+sudo dnf install -y gcc make ncurses-devel sqlite-devel
+# optional:
+sudo dnf install -y cmake git
+```
+
+### Debian and Ubuntu
+
+```bash
+sudo apt-get install -y build-essential libncurses-dev libsqlite3-dev
+# optional:
+sudo apt-get install -y cmake git
+```
+
+## Native build
+
+From the top of the source tree:
+
+```bash
+make -C src/containers/spagat-console build
+# binary produced at: src/containers/spagat-console/spagat-librarian
+```
+
+Install into `/usr/local/bin` (or the RPM path when packaged):
+
+```bash
+sudo make -C src/containers/spagat-console install
+```
+
+## CMake build
+
+```bash
+cmake -B build -S src/containers/spagat-console -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+sudo cmake --install build
+```
+
+## RPM build
+
+The source ships an `spagat.spec` for Photon OS, Fedora, or any RPM-based
+distro:
+
+```bash
+rpmbuild -ba src/containers/spagat-console/spagat.spec
+sudo rpm -Uvh ~/rpmbuild/RPMS/x86_64/spagat-librarian-*.rpm
+```
+
+The RPM installs the binary at `/usr/bin/spagat-librarian` and the eight
+default skill files into the shared data directory (see
+[SKILLS.md](SKILLS.md)).
+
+## Optional: offline LLM (llama.cpp)
+
+If you want an offline LLM path, build or install `llama.cpp` separately
+and download a GGUF model. Point SPAGAT-Librarian at both via the
+environment variables documented in [CONFIGURATION.md](CONFIGURATION.md).
+No further build wiring is needed — the C binary loads the local backend
+lazily at first LLM request.
+
+## Verified platforms
+
+| Platform            | Native build | RPM build | Notes                        |
+| ------------------- | ------------ | --------- | ---------------------------- |
+| Photon OS 5.0       | yes          | yes       | Reference build target       |
+| Fedora 40 / 41      | yes          | yes       |                              |
+| Debian 12 / Ubuntu  | yes          | via alien | `make` path is the tested one |
+
+## Verifying the install
+
+```bash
+spagat-librarian --version
+spagat-librarian --help
+spagat-librarian init      # creates $XDG_STATE_HOME/spagat/spagat.db
+spagat-librarian           # opens the TUI
+```
+
+If the TUI opens on an empty board and `--version` prints a version
+string, you are done. Move on to [CONFIGURATION.md](CONFIGURATION.md) to
+wire up the LLM.

--- a/SPAGAT-Librarian/INTEGRATION.md
+++ b/SPAGAT-Librarian/INTEGRATION.md
@@ -1,0 +1,184 @@
+# INTEGRATION
+
+SPAGAT-Librarian is a small C binary with a stable-ish CLI, a SQLite
+store, and a tiny public C-ABI. That is enough surface to drive it from
+a shell, embed it into another tool, or feed it a stream of events from
+an existing incident-response or dashboard system.
+
+This document covers three integration patterns:
+
+1. **Shell / CLI** — call `spagat-librarian` from another script.
+2. **Library** — link the console core as a library (`libspagat-console`).
+3. **Event input** — pipe a JSON stream of kanban operations into the
+   binary and let it maintain the board.
+
+## Pattern 1 — shell
+
+Every kanban operation available in the TUI is also a subcommand:
+
+```bash
+spagat-librarian add "Rotate the TLS certificate" --priority high --tag ops
+spagat-librarian list --status backlog --json
+spagat-librarian move <id> --to progress
+spagat-librarian close <id>
+```
+
+The `--json` flag on read commands produces one JSON object per line
+(NDJSON), so you can pipe the output into `jq`, a log shipper, or
+another tool.
+
+Return codes follow the usual convention: `0` on success, `2` on user
+error, `1` on internal error. The binary always writes structured error
+messages to stderr; stdout is reserved for data.
+
+## Pattern 2 — library
+
+The console core builds as `libspagat-console` (both a static
+`libspagat-console.a` and a shared `libspagat-console.so`) so a
+third-party tool can link the kanban and skill engine directly.
+
+The public C-ABI is a small set of opaque handles and functions
+declared in a public shim header
+`include/spagat.h`. In outline:
+
+```c
+#include <spagat.h>
+
+/* Open (or create) a kanban store at the given path. */
+spagat_db_t *db = spagat_db_open("/home/alice/.local/state/spagat/spagat.db");
+
+/* Add a card. */
+spagat_item_id_t id = spagat_item_add(db, &(spagat_item_new_t){
+    .title      = "Investigate disk pressure",
+    .priority   = SPAGAT_PRIORITY_HIGH,
+    .status     = SPAGAT_STATUS_BACKLOG,
+    .tag        = "ops",
+});
+
+/* Move it. */
+spagat_item_set_status(db, id, SPAGAT_STATUS_PROGRESS);
+
+/* Iterate all cards in one column. */
+spagat_item_iter_t *it = spagat_item_iter_open(db, SPAGAT_STATUS_PROGRESS);
+const spagat_item_t *item;
+while ((item = spagat_item_iter_next(it)) != NULL) {
+    printf("%lld  %s\n", (long long)item->id, item->title);
+}
+spagat_item_iter_close(it);
+
+spagat_db_close(db);
+```
+
+Only the symbols and types declared in `spagat.h` are considered public
+API — anything in the `src/` tree is subject to change without notice.
+The shim header intentionally exposes a narrow surface (open / close /
+add / edit / move / query) so downstream code does not have to track
+internal refactors.
+
+Build against the shared library:
+
+```bash
+gcc my_tool.c -lspagat-console -lsqlite3 -o my_tool
+```
+
+## Pattern 3 — event input over stdin
+
+For tools that already emit events (a dashboard, an alert manager, an
+issue tracker), the CLI accepts a stream of NDJSON operations on
+stdin. This is a **minimal, local event schema** — it is not a
+cross-tool contract, just a script-friendly way to drive the board.
+
+Feed events with the `stream` subcommand:
+
+```bash
+tail -F my-events.ndjson | spagat-librarian stream
+```
+
+Each line is one JSON object with an `op` field.
+
+### `op: "add"` — create a card
+
+```json
+{
+  "op":       "add",
+  "title":    "Investigate disk pressure on /var",
+  "priority": "high",
+  "status":   "backlog",
+  "tag":      "ops",
+  "description": "df -h shows /var at 92%"
+}
+```
+
+Optional fields: `priority` (`none`|`low`|`medium`|`high`|`critical`),
+`status` (`clarification`|`wontfix`|`backlog`|`progress`|`review`|`ready`),
+`tag` (short string), `description` (long text), `due_date`
+(RFC 3339 UTC).
+
+The response, written to stdout, is one JSON object with the new card
+id:
+
+```json
+{ "op": "add", "ok": true, "id": 1042 }
+```
+
+### `op: "move"` — change a card's column
+
+```json
+{ "op": "move", "id": 1042, "to": "progress" }
+```
+
+### `op: "close"` — mark a card ready
+
+```json
+{ "op": "close", "id": 1042 }
+```
+
+Equivalent to `move` with `"to": "ready"`.
+
+### `op: "edit"` — update fields on a card
+
+```json
+{
+  "op":       "edit",
+  "id":       1042,
+  "title":    "Investigate disk pressure on /var (updated)",
+  "priority": "critical"
+}
+```
+
+Only the fields present in the object are updated.
+
+### Error responses
+
+```json
+{ "op": "add", "ok": false, "error": "priority must be one of none|low|medium|high|critical" }
+```
+
+Errors do not terminate the stream — the binary reads the next line
+and keeps going. Fatal I/O errors (SQLite failure, EOF on a broken
+pipe) exit with code 1.
+
+## Persisting state elsewhere
+
+The default kanban store is `$XDG_STATE_HOME/spagat/spagat.db`. Two
+overrides are supported:
+
+```bash
+# Absolute path, per-invocation:
+SPAGAT_DB=/mnt/shared/team-ops.db spagat-librarian list
+
+# Or globally, in ~/.config/spagat/config.toml:
+[state]
+db_path = "/mnt/shared/team-ops.db"
+```
+
+The store is a plain SQLite 3 database. Standard SQLite tools work:
+
+```bash
+sqlite3 /mnt/shared/team-ops.db ".schema"
+sqlite3 /mnt/shared/team-ops.db "select id,title,status from items where status='progress';"
+```
+
+If you host the DB on a shared filesystem, keep in mind SQLite's usual
+single-writer constraint — either serialise writers, or split into
+per-user files that a periodic job merges.

--- a/SPAGAT-Librarian/README.md
+++ b/SPAGAT-Librarian/README.md
@@ -1,553 +1,62 @@
-# SPAGAT-Librarian
+# SPAGAT-Librarian CLI
 
-**Supervised Package Analysis for Gitbased Autonomous Toolchains -- Librarian**
+A standalone, terminal-based **kanban + LLM + AI-agent** for sysadmin operations.
 
-A CLI Kanban task manager and AI-powered development assistant for Photon OS, written in C.
+SPAGAT-Librarian is a single C binary that gives an operator three tools in one
+process:
 
-Version 0.3.0
+1. A **6-column kanban board** for tracking day-to-day operational work
+   (In Clarification, Won't Fix, In Backlog, In Progress, In Review, Ready)
+   with an ncurses TUI and a scriptable CLI over the same SQLite store.
+2. A **local or frontier LLM bridge** for on-the-terminal chat, code review,
+   log summarisation, and script drafting. Runs fully offline via `llama.cpp`
+   with a GGUF model, or against a frontier API (Anthropic, Google Gemini,
+   xAI, or OpenAI) when a key is present in the environment.
+3. An **AI agent** that reads a natural-language gesture from the operator,
+   picks one or more of the pre-loaded sysadmin skill files (tdnf, systemctl,
+   iptables, network, docker, logs, users, performance), composes an LLM
+   prompt, and presents the result — always in an "observe first, act after
+   consent" default posture.
 
-SPAGAT-Librarian combines a full-featured Kanban board with a local LLM agent. The Kanban side manages tasks through a 6-column workflow with an ncurses TUI and scriptable CLI. The AI side runs one of 5 selectable small language models locally via llama.cpp -- no API keys, no cloud, fully open source. Choose from Gemma-2, Gemma-3, Llama-3.2, Qwen2.5, or BitNet at build time with `LLM=`.
+## No appliance required
 
-## Features
+This CLI is the standalone form of the same v0.3 console that also ships
+inside the SpagatLibrarian Appliance. Everything documented under `docs/public/`
+runs on a plain Linux host — Photon OS 5.0, Fedora, and Debian are the
+verified platforms — with nothing more than `ncurses`, `sqlite3`, and
+(optionally) `llama.cpp` on the box. State lives under `$XDG_STATE_HOME`,
+configuration lives under `$XDG_CONFIG_HOME`, and frontier LLM keys come
+from environment variables. There is no daemon, no container runtime
+dependency, and no privileged mount point.
 
-### Kanban Core
-
-- 6-column Kanban board: Clarification, Won't Fix, Backlog, In Progress, Review, Ready
-- ncurses TUI with vim-style navigation (h/j/k/l, 1-6 column jump)
-- Color-coded priority indicators (Critical `!`, High `^`, Medium `-`, Low `v`)
-- Due date indicators in TUI
-- Comprehensive edit dialog with all fields (title, description, tag, status, priority, due date, git branch, project, parent task)
-- Multi-select (Space to toggle, `*` to select all in column)
-- Help dialog (`?` key)
-- Full CLI for scripting and automation
-- SQLite storage at `~/.spagat.db`
-- Automatic database migration (v1 → v2 → v3)
-- 5 priority levels: None, Low, Medium, High, Critical
-- Due dates with filtering (today, this week, overdue)
-- Dependencies between tasks
-- Projects with add/list/delete
-- Subtasks via parent_id
-- Task templates
-- Time tracking (start/stop)
-- Session management (save/load cursor position and scroll state)
-- Git branch linking per task
-- Export to CSV and JSON
-- Statistics by status, tag, and history
-- History tracking (status transitions stored as single-character abbreviations)
-- ASCII board view for CLI output
-
-### AI Core
-
-- **5 selectable LLMs** via `LLM=` build flag (see [LLM Selection](#llm-selection) below)
-- **llama.cpp integration** via a C++ bridge (`llama_bridge.cpp`) — typed, ABI-safe C-linkage wrapper with opaque handles; no struct-by-value crossing the C/C++ boundary
-- **Embedded model support**: objcopy embeds the GGUF into the binary, memfd_create provides zero-copy loading at runtime
-- **Chat template**: 3-strategy resolution: (1) model's own template via `lb_model_chat_template`, (2) auto-detect from GGUF metadata via `lb_chat_apply_template_model`, (3) hardcoded Llama-3/BitNet fallback (`{Role}: {content}<|eot_id|>`)
-- **Dual API bridge**: `llama_bridge.cpp` supports both the new llama.cpp API (ggml-org, 2025+) and the older API used by BitNet's fork, selected at build time via `-DLLAMA_OLD_API=1`
-- **Context-aware system prompt**: compact prompt (~300 chars) for small context models (<=2048 tokens), full prompt (~1500 chars) for larger contexts
-- **Token streaming** to stdout in real-time during agent chat, and to ncurses WINDOW or buffer in TUI mode; cancellable with Esc
-
-#### Tools
-
-- **14 MCP-equivalent filesystem tools**: `read_text_file`, `read_binary_file`, `read_multiple`, `list_directory`, `list_sizes`, `directory_tree`, `search_files`, `get_file_info`, `write_file`, `edit_file`, `create_directory`, `move_file`, `delete_file`, `list_allowed`
-- **7 git tools**: `git_status`, `git_diff`, `git_log`, `git_branch`, `git_commit`, `git_add`, `git_show` (fork/exec with 10 s timeout, no libgit2)
-- **3 system info tools**: `system_info` (7 categories: os/cpu/ram/storage/network/time/user), `process_list`, `disk_usage`
-- **4 legacy built-in tools**: `read_file`, `write_file`, `list_dir`, `shell` (retained for backward compatibility)
-- **Tool call loop**: `TOOL_CALL:` / `END_TOOL_CALL` markers, max 5 iterations per prompt turn
-- **Configurable retry logic** for LLM generation failures (max retries + delay)
-
-#### Security (5-layer model)
-
-1. **5-tier autonomy model** — `none`, `observe`, `workspace`, `home`, `full` — controls which tools are available, which shell commands are allowed, write byte/file limits, call rate limits per prompt and per session, and write cooldown enforcement
-2. **Execution policy engine** — per-command allow / prompt / forbidden rules with justification; loadable from external rule files
-3. **Output sanitization** — automatic secret redaction (private keys, AWS credentials, passwords, tokens, base64 blobs) in model output before persisting to conversation DB or MEMORY.md
-4. **Landlock LSM + Seccomp-BPF OS-level sandboxing** — applied after `fork()`, before `exec()` in shell children; Landlock restricts filesystem paths, Seccomp blocks dangerous syscalls (ptrace, mount, reboot, kexec_load, etc.)
-5. **Filesystem access control** — configurable allowed/denied/readonly/write-only path lists with max read/write sizes, search depth, and search result limits
-
-#### Agent Intelligence
-
-- **Structured prompt builder** — assembles identity, tool descriptions, skill content, system context, rules, and project context into a single system prompt based on the active autonomy level
-- **Context compaction** — estimates token usage (chars/4 heuristic) and summarizes oldest conversation messages when approaching the model's context window limit
-- **System awareness** — auto-stores system facts (OS, kernel, IPs, disk, etc.) as memory keys, detects changes between sessions, and refreshes `SYSTEM.md` in the workspace with current snapshot + change history
-- **Subagent spawn/kill** — fork/exec background tasks with output capture to temp files; max 8 concurrent subagents; depth limited to 1 (no sub-subagents)
-- **Per-project system prompts** — configurable in `config.json`
-- **Session-level autonomy override** — `--autonomy=<level>` flag on `agent` command
-
-#### Infrastructure
-
-- **Journal logging system** — self-rotating 2 MB log files (3 rotations kept) at `~/.spagat/logs/spagat.log`; 4 levels: DEBUG, INFO, WARN, ERROR
-- **Workspace directory** at `~/.spagat/` with structured layout (workspace/, models/, logs/, credentials/, sessions/, memory/, state/, cron/, skills/)
-- **7 default workspace files** created by `onboard`: AGENT.md, IDENTITY.md, SOUL.md, USER.md, MEMORY.md, HEARTBEAT.md, TOOLS.md
-- **Conversation history** stored in SQLite (per task or global) with checkpoint save/restore
-- **Agent memory**: key-value store in SQLite with MEMORY.md file support
-- **Cron scheduler**: SQLite-based job CRUD with interval_minutes, pause/resume/delete
-- **Heartbeat system**: reads HEARTBEAT.md and parses scheduled tasks
-- **8 Photon OS skill files**: tdnf, systemctl, iptables, network, docker, logs, users, performance
-
-## LLM Selection
-
-| Name | Model | HuggingFace Repo | Size | Ctx | Notes |
-|------|-------|-------------------|------|-----|-------|
-| `gemma2` | Gemma-2 2B IT (Q4_K_M) | `bartowski/gemma-2-2b-it-GGUF` | 1.7 GB | 1024 | Default, compact |
-| `llama` | Llama-3.2 1B Instruct (Q4_K_M) | `bartowski/Llama-3.2-1B-Instruct-GGUF` | 0.8 GB | 8192 | Fast, large context |
-| `bitnet` | BitNet b1.58 2B 4T (i2_s) | `microsoft/bitnet-b1.58-2B-4T-gguf` | 1.2 GB | 2048 | Experimental*; requires bitnet.cpp |
-| `qwen` | Qwen2.5 1.5B Instruct (Q4_K_M) | `bartowski/Qwen2.5-1.5B-Instruct-GGUF` | 1.0 GB | 4096 | Multilingual |
-| `gemma3` | Gemma-3 1B IT (Q4_K_M) | `bartowski/google_gemma-3-1b-it-GGUF` | 0.8 GB | 8192 | Newest, large context |
-
-\* BitNet uses native 1-bit quantization (`i2_s`), which is **not** compatible with standard llama.cpp. Use `make bitnet` to build bitnet.cpp separately. BitNet's `libllama.so` replaces the standard one and uses an older llama.cpp API; the bridge handles this transparently via `LLAMA_OLD_API`.
-
-**Known limitation**: BitNet b1.58 2B 4T is a native 1-bit model with limited instruction-following capability. While it loads and runs correctly, its responses to complex prompts (especially tool-calling instructions) are unreliable -- the model tends to produce generic text completions instead of following the chat format. For reliable agent functionality, use one of the instruction-tuned models (Gemma-2, Gemma-3, Llama-3.2, or Qwen2.5). BitNet is included as an experimental option for users interested in 1-bit inference research.
-
-## Hardware Requirements
-
-| Component | Minimum | Recommended |
-|-----------|---------|-------------|
-| CPU | 4 cores | 8+ cores |
-| RAM | 4 GB | 8 GB |
-| Storage | 3 GB (with model) | 5 GB |
-| GPU | Not required | Optional (n_gpu_layers) |
-
-## Quick Start
-
-### Kanban only (no AI)
+## Quick example
 
 ```bash
-# Install build dependencies
-tdnf install -y gcc make sqlite-devel ncurses-devel
+# 1. Build and install (see INSTALL.md for platform notes).
+git clone https://github.com/dcasota/photonos-scripts.git
+cd photonos-scripts/SPAGAT-Librarian
+make && sudo make install
 
-# Build
-make
-
-# Initialize database
-./spagat-librarian init
-
-# Launch TUI
-./spagat-librarian
-
-# Or use CLI
-./spagat-librarian add backlog "My first task" "Description here" "tag"
-./spagat-librarian list
+# 2. Create your first kanban card and open the TUI.
+spagat-librarian add "Investigate disk pressure on /var" --priority high
+spagat-librarian     # opens the TUI at the board view; F1 for help
 ```
 
-### Full setup with AI
-
-```bash
-# Install all prerequisites, build llama.cpp, download Gemma-3 1B IT
-make setup LLM=gemma3
-
-# Build with embedded model (zero-copy at runtime)
-make MODEL=models/google_gemma-3-1b-it-Q4_K_M.gguf LLM=gemma3
-
-# Initialize and onboard the agent workspace
-./spagat-librarian init
-./spagat-librarian onboard
-
-# Chat with the agent
-./spagat-librarian agent
-./spagat-librarian agent -m "Summarize my backlog"
-
-# Chat in context of a specific task
-./spagat-librarian ai 5
-```
-
-## Building
-
-### Prerequisites
-
-On Photon OS, install build dependencies:
-
-```bash
-tdnf install -y gcc libstdc++ make cmake sqlite-devel ncurses-devel binutils git curl
-```
-
-Or use the Makefile target:
-
-```bash
-make deps
-```
-
-### Build targets
-
-```bash
-make                # Build release binary
-make debug          # Build with debug symbols (-g -O0)
-make release        # Build optimized (-O2)
-make install        # Install to /usr/bin/
-make clean          # Remove build artifacts
-make distclean      # Remove build artifacts + downloaded deps/models
-```
-
-### LLM & Model targets
-
-```bash
-make models                 # List available LLMs with sizes and ctx
-make model LLM=<name>       # Download specific model GGUF from HuggingFace
-make model-all              # Download all 5 models
-make llama                  # Clone, build, and install llama.cpp (libllama.so)
-make bitnet                 # Clone and build bitnet.cpp (for BitNet models only)
-make setup                  # All-in-one: deps + llama + model (default LLM)
-make setup LLM=gemma3       # All-in-one with specific model
-```
-
-### Embedded model
-
-To embed the GGUF model directly into the binary (uses objcopy to create an ELF object, memfd_create for zero-copy loading):
-
-```bash
-make MODEL=models/google_gemma-3-1b-it-Q4_K_M.gguf LLM=gemma3
-```
-
-Without `MODEL=`, the binary loads the model from the path specified in `~/.spagat/config.json`.
-
-### CMake alternative
-
-```bash
-mkdir build && cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release
-make
-
-# With embedded model:
-cmake .. -DCMAKE_BUILD_TYPE=Release \
-    -DEMBED_MODEL=path/to/model.gguf \
-    -DLLM_CTX_SIZE=8192
-make
-```
-
-### RPM packaging
-
-An RPM spec file (`spagat.spec`) is included for Photon OS packaging.
-
-## TUI Keyboard Shortcuts
-
-### Navigation
-
-| Key | Action |
-|-----|--------|
-| `h` / Left | Previous column |
-| `l` / Right | Next column |
-| `k` / Up | Previous item |
-| `j` / Down | Next item |
-| `1`-`6` | Jump to column |
-
-### Actions
-
-| Key | Action |
-|-----|--------|
-| `a` | Add new item |
-| `Enter` / `e` | Edit item |
-| `m` | Move selected items |
-| `d` | Delete selected items |
-| `Space` | Toggle selection |
-| `*` | Select all in column |
-| `Esc` | Clear selection |
-| `/` | Search |
-| `?` | Help |
-| `r` | Refresh |
-| `q` | Quit |
-
-## CLI Commands
-
-### General
-
-```bash
-spagat-librarian init                    # Initialize database
-spagat-librarian help                    # Show help
-spagat-librarian version                 # Show version
-```
-
-### Task management
-
-```bash
-spagat-librarian add <status> <title> <description> [tag]
-spagat-librarian show <id>
-spagat-librarian list
-spagat-librarian edit <id>
-spagat-librarian move <id> <status>
-spagat-librarian delete <id>
-```
-
-### Organization
-
-```bash
-spagat-librarian tags                    # List all tags
-spagat-librarian filter <status>...      # Filter by status
-spagat-librarian priority <level>        # Filter by priority
-spagat-librarian due today|week|overdue  # Filter by due date
-spagat-librarian board                   # ASCII board view
-```
-
-### Projects, templates, dependencies
-
-```bash
-spagat-librarian project add|list|delete
-spagat-librarian template add|list|use
-spagat-librarian depend <id> <id>        # Add dependency
-spagat-librarian undepend <id> <id>      # Remove dependency
-spagat-librarian deps <id>               # Show dependencies
-spagat-librarian subtasks <id>           # Show subtasks
-```
-
-### Time tracking and sessions
-
-```bash
-spagat-librarian time start <id>
-spagat-librarian time stop <id>
-spagat-librarian session save <name>
-spagat-librarian session load <name>
-```
-
-### Export and statistics
-
-```bash
-spagat-librarian export csv > tasks.csv
-spagat-librarian export json > tasks.json
-spagat-librarian stats status            # Items per status
-spagat-librarian stats tag               # Items per tag
-spagat-librarian stats history           # Status transitions
-```
-
-### AI and agent commands
-
-```bash
-spagat-librarian onboard                 # First-time workspace setup
-spagat-librarian workspace               # Show workspace info
-spagat-librarian agent                   # Interactive agent chat
-spagat-librarian agent -m "..."          # Single-message agent query
-spagat-librarian agent --autonomy=<level> # Override autonomy for session
-spagat-librarian ai <id>                 # Chat in context of task
-spagat-librarian ai history <id>         # Show conversation history
-spagat-librarian model list              # List available models
-spagat-librarian model test              # Test model loading
-spagat-librarian checkpoint save|list    # Save/list conversation checkpoints
-spagat-librarian status                  # Show AI system status
-spagat-librarian sysinfo [category]      # System info (os/cpu/ram/storage/network/time/user)
-spagat-librarian sysaware                # Run system awareness cycle
-spagat-librarian fs <config|allowed>     # Show filesystem access config / allowed paths
-```
-
-### Subagent commands
-
-```bash
-spagat-librarian subagent spawn <name> <command>   # Spawn background task
-spagat-librarian subagent list                     # List all subagents
-spagat-librarian subagent kill <id>                # Kill a subagent
-spagat-librarian subagent output <id>              # Read subagent output
-```
-
-### Cron scheduler
-
-```bash
-spagat-librarian cron list
-spagat-librarian cron add <interval_minutes> <command>
-spagat-librarian cron pause <id>
-spagat-librarian cron resume <id>
-spagat-librarian cron delete <id>
-```
-
-### Agent memory
-
-```bash
-spagat-librarian memory set <key> <value>
-spagat-librarian memory get <key>
-spagat-librarian memory list
-spagat-librarian memory clear
-```
-
-### Skills
-
-```bash
-spagat-librarian skill list
-spagat-librarian skill run <name>
-```
-
-## Statuses
-
-| Status | Abbreviation | Description |
-|--------|--------------|-------------|
-| Clarification | C | Needs more information |
-| Won't Fix | W | Rejected or deferred |
-| Backlog | B | Planned but not started |
-| In Progress | P | Currently being worked on |
-| Review | V | Awaiting review |
-| Ready | R | Done and verified |
-
-## Configuration
-
-The AI configuration file is located at `~/.spagat/config.json`:
-
-```json
-{
-  "provider": "local",
-  "max_tokens": 512,
-  "temperature": 0.7,
-  "max_tool_iterations": 5,
-  "restrict_to_workspace": true,
-  "local": {
-    "enabled": true,
-    "engine": "llama.cpp",
-    "model_path": "",
-    "device": "cpu",
-    "n_gpu_layers": 0,
-    "n_ctx": 8192,
-    "temperature": 0.7,
-    "top_p": 0.9
-  },
-  "heartbeat": {
-    "enabled": true,
-    "interval_minutes": 60
-  },
-  "autonomy": {
-    "mode": "observe",
-    "confirm_destructive": true,
-    "session_write_limit": 1048576,
-    "session_file_limit": 50,
-    "max_tool_calls_per_prompt": 5,
-    "max_tool_calls_per_session": 200,
-    "shell_timeout": 30,
-    "write_cooldown_ms": 500
-  },
-  "retry": {
-    "max_retries": 2,
-    "retry_delay_ms": 1000
-  },
-  "project_system_prompt": ""
-}
-```
-
-When `model_path` is empty and the binary was built with an embedded model, the embedded model is used automatically. The `project_system_prompt` field allows injecting additional context into the system prompt for project-specific workflows.
-
-### Autonomy Levels
-
-| Level | Description |
-|-------|-------------|
-| `none` | AI cannot use any tools or execute commands |
-| `observe` | Read-only tools + allowlisted shell commands; memory writes are append-only |
-| `workspace` | Full tools within `~/.spagat/workspace/`; destructive ops require confirmation |
-| `home` | Tools within home directory; shell commands evaluated by execution policy |
-| `full` | Unrestricted tool access (use with caution) |
-
-Set per-session via CLI: `spagat-librarian agent --autonomy=workspace`
-
-## Environment Variables
-
-| Variable | Effect |
-|----------|--------|
-| `NOCOLOR` | Disable colors in TUI and CLI |
-| `PLAIN` | Use ASCII instead of UTF-8 box drawing |
-| `EDITOR` | External editor for `edit` command |
-| `SPAGAT_HOME` | Override `~/.spagat` workspace location |
-
-## File Structure
-
-```
-include/
-└── spagat.h                        # Core types (Item, ItemStatus, ItemPriority, Project, Template, Session)
-src/
-├── main.c                          # Entry point, argument routing
-├── cli/
-│   ├── cli.h                       # CLI command declarations
-│   ├── cli.c                       # Core CLI commands
-│   ├── cli_ext.c                   # Extended CLI (projects, templates, deps, time, sessions)
-│   ├── cli_ai.c                    # AI CLI commands (agent, model, checkpoint, memory, skill)
-│   ├── cli_ai_cmds.c              # Additional AI commands (sysinfo, sysaware, fs, autonomy)
-│   ├── cli_ai_subagent.c          # Subagent CLI commands (spawn, list, kill, output)
-│   └── cli_dispatch.c             # DB-command dispatcher
-├── db/
-│   ├── db.h / db.c                # Core SQLite operations
-│   ├── db_ext.c                   # Extended queries (priority, due, deps, subtasks)
-│   ├── db_project.c               # Project CRUD
-│   ├── db_template.c              # Template CRUD
-│   └── migrate.h / migrate.c     # Schema migration (v1 → v2 → v3)
-├── tui/
-│   ├── tui.h / tui.c             # TUI init, main loop
-│   ├── tui_common.h               # Internal TUI types, color constants
-│   ├── tui_board.c                # Board rendering, help dialog
-│   ├── tui_input.c                # Input handling, cursor movement
-│   ├── tui_dialogs.c             # Add/edit/delete/move/search dialogs
-│   ├── tui_dialogs_misc.c        # Miscellaneous dialogs
-│   └── tui_ext.c                 # Priority/due indicators, extended edit fields
-├── ai/
-│   ├── ai.h                       # AI interface declarations (provider, conv, checkpoint, memory, tools)
-│   ├── local.c                    # llama.cpp provider (init, generation loop, template)
-│   ├── local_prompt.h / local_prompt.c  # System prompt (compact/full), 3-strategy chat template
-│   ├── llama_bridge.h / llama_bridge.cpp  # C++ bridge to llama.cpp (dual API: new + old/BitNet)
-│   ├── conversation.c             # Conversation DB, checkpoint save/load
-│   ├── streaming.c                # Token streaming to ncurses or buffer
-│   ├── memory.c                   # Agent memory (SQLite + MEMORY.md)
-│   ├── tools.c                    # Tool framework (registry, dispatch, call loop)
-│   ├── tools_builtin.c           # Legacy tools (read_file, write_file, list_dir, shell)
-│   ├── tools_fs.h                 # Filesystem tool types and config (FsConfig)
-│   ├── tools_fs.c                 # Filesystem tool init, path validation, helpers
-│   ├── tools_fs_read.c           # 9 read-only FS tools (read_text, read_binary, read_multiple, list_dir, list_sizes, dir_tree, search, file_info, list_allowed)
-│   ├── tools_fs_write.c          # 5 write FS tools (write_file, edit_file, create_dir, move, delete)
-│   ├── tools_sysinfo.c           # 3 system info tools (system_info, disk_usage, process_list)
-│   ├── git_tools.h / git_tools.c # 7 git tools via fork/exec
-│   ├── autonomy.h / autonomy.c   # 5-tier autonomy model, rate limiting, cooldown
-│   ├── execpolicy.h / execpolicy.c  # Execution policy engine (allow/prompt/forbidden)
-│   ├── sanitize.h / sanitize.c   # Output sanitization (secret redaction)
-│   ├── prompt_builder.h / prompt_builder.c  # Structured system prompt builder
-│   ├── compaction.h / compaction.c  # Context window compaction
-│   ├── linux_sandbox.h / linux_sandbox.c  # Landlock + Seccomp-BPF sandboxing
-│   ├── sysaware.h / sysaware.c   # System awareness (facts, change detection, SYSTEM.md)
-│   └── embedded_model.h / embedded_model.c  # GGUF embedding via objcopy + memfd_create
-├── agent/
-│   ├── agent.h                    # Workspace paths, config struct, cron types
-│   ├── workspace.c                # Workspace directory management
-│   ├── onboard.c                  # First-time setup, config load/save
-│   ├── config_io.c               # Config JSON read/write
-│   ├── scheduler.c                # Cron job scheduler (SQLite)
-│   ├── sandbox.c                  # Path validation sandbox
-│   ├── heartbeat.c                # HEARTBEAT.md parser
-│   ├── subagent.h                 # Subagent types (max 8, status enum)
-│   └── subagent.c                 # Subagent spawn/kill/poll (fork/exec)
-├── skill/
-│   ├── skill.h                    # Skill types
-│   ├── loader.c                   # SKILL.md file loader
-│   └── executor.c                 # Skill step executor (shell:/prompt:/file:)
-└── util/
-    ├── util.h / util.c            # String helpers, path helpers
-    └── journal.h / journal.c      # Self-rotating log (2 MB, 3 files)
-skills/
-├── tdnf.md                        # Package management skill
-├── systemctl.md                   # Service management skill
-├── iptables.md                    # Firewall skill
-├── network.md                     # Network diagnostics skill
-├── docker.md                      # Container management skill
-├── logs.md                        # Log analysis skill
-├── users.md                       # User administration skill
-└── performance.md                 # Performance tuning skill
-models/                             # Downloaded GGUF model files
-sql/
-└── schema.sql                     # Reference SQL schema
-```
-
-## Known Issues
-
-### BitNet b1.58 2B 4T — poor instruction-following
-
-BitNet b1.58 2B 4T builds and runs correctly (the 1-bit GGUF loads, tokenization works, generation produces tokens), but the model does not reliably follow instructions or chat formatting. When given a system prompt with tool-calling instructions, the model produces generic text completions (e.g., unrelated content about binary trees) instead of following the `TOOL_CALL:` / `END_TOOL_CALL` format or answering the user's question directly.
-
-**Root cause**: BitNet b1.58 2B 4T is a native 1-bit model trained from scratch on 4 trillion tokens. While Microsoft reports benchmark performance comparable to full-precision models of similar size, the model's instruction-following and chat capabilities are significantly weaker than purpose-built instruction-tuned models like Gemma or Llama. The simple `{Role}: {content}<|eot_id|>` chat format it uses provides minimal structural guidance compared to the richer templates used by instruction-tuned models.
-
-**Technical details**:
-- The BitNet GGUF's chat template (a Jinja string with `capitalize` + `<|eot_id|>`) is not recognized by any of the heuristic pattern matchers in the old llama.cpp API's `llama_chat_apply_template_internal()` function (it doesn't contain `<|start_header_id|>`, `BITNET`, or other recognized markers)
-- The bridge falls through to Strategy 3 (hardcoded `System: ... <|eot_id|> User: ... <|eot_id|> Assistant:` format), which matches the intended template
-- Even with a compact system prompt (~300 chars) designed for the 2048-token context window, the model does not produce coherent instruction-following output
-
-**Recommendation**: Use one of the four instruction-tuned models for agent functionality. BitNet is retained as an experimental option for users interested in 1-bit inference research and benchmarking.
-
-### llama.cpp API compatibility
-
-The C++ bridge (`llama_bridge.cpp`) supports two distinct llama.cpp API versions:
-
-- **New API** (ggml-org, 2025+): Uses `llama_model_load_from_file`, `llama_init_from_model`, `llama_model_get_vocab`, `llama_vocab_bos/eos`, `llama_memory_clear`, `llama_batch_get_one(tokens, n)`. Used by standard `make llama` builds.
-- **Old API** (BitNet fork, Eddie-Wang1120/llama.cpp): Uses `llama_load_model_from_file`, `llama_new_context_with_model`, no `llama_vocab` type, `llama_token_bos/eos(model)`, `llama_kv_cache_clear`, `llama_batch_get_one(tokens, n, pos, seq)`. Used by `make bitnet` builds.
-
-The correct API is selected at build time via the `BITNET_BUILD=1` Makefile variable, which passes `-DLLAMA_OLD_API=1` to the C++ compiler. The `make setup` target handles this automatically when option 5 (BitNet) is selected.
-
-## Architecture
-
-See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed technical documentation.
+That is enough to have a working single-user kanban. To turn on the LLM
+side, export one of the environment variables in
+[CONFIGURATION.md](CONFIGURATION.md) and press `F4` in the TUI, or run
+`spagat-librarian ai "your prompt"` from the shell.
+
+## Where to go next
+
+| Topic                                                      | File                               |
+| ---------------------------------------------------------- | ---------------------------------- |
+| Build from source, install the RPM, per-distro packages    | [INSTALL.md](INSTALL.md)           |
+| Config file, environment variables, LLM provider selection | [CONFIGURATION.md](CONFIGURATION.md) |
+| The 8 pre-loaded sysadmin skills and how to add your own   | [SKILLS.md](SKILLS.md)             |
+| The AI agent: gesture -> skill -> LLM -> action            | [AGENT.md](AGENT.md)               |
+| Embedding, C API surface, JSON event input, state override | [INTEGRATION.md](INTEGRATION.md)   |
 
 ## License
 
-See LICENSE file for details.
+C source, released under the terms in the repository-root `LICENSE` file.

--- a/SPAGAT-Librarian/SKILLS.md
+++ b/SPAGAT-Librarian/SKILLS.md
@@ -1,0 +1,124 @@
+# SKILLS
+
+The skill panel is a library of short, LLM-consumable Markdown files that
+teach the agent how to drive one Linux subsystem. Each file is a plain
+`.md` document — no runtime, no plug-in ABI, no code. The agent loads
+the file into its prompt, uses the commands and notes as a cheat sheet,
+and asks the LLM to produce a concrete command or explanation.
+
+## The eight built-in skills
+
+Every install ships with eight sysadmin skill files under
+`/usr/share/spagat/skills/` (or the source-tree `skills/` directory in
+a native build):
+
+| Skill         | Covers                                                      |
+| ------------- | ----------------------------------------------------------- |
+| `tdnf`        | Photon OS package manager (Tiny DNF)                        |
+| `systemctl`   | systemd service and unit management                         |
+| `iptables`    | Firewall rules and packet-filter tables                     |
+| `network`     | Interfaces, routes, DNS, `ip(8)` cheatsheet                 |
+| `docker`      | Container lifecycle, image queries, log tailing             |
+| `logs`        | `journalctl` and file-based log inspection                  |
+| `users`       | Users, groups, sudo, passwd, `chage` cadence                |
+| `performance` | `top`, `iostat`, `sar`, `dmesg`, quick triage recipes       |
+
+Each file follows the same shape:
+
+```markdown
+# <name> - <one-line summary>
+
+<why-you-would-use-it prose>
+
+## Commands
+### <verb group>
+- <what it does>: `<command>`
+...
+
+## Notes
+- <caveats, flags, safety>
+```
+
+Open one to see it — for example `/usr/share/spagat/skills/tdnf.md`.
+
+## Invoking a skill
+
+There are two ways to run a skill.
+
+### 1. From the TUI
+
+Press `F2` to open the skill picker. Arrow keys navigate; `Enter`
+loads the highlighted skill into the current LLM chat context. From
+there you type a question in plain language and the LLM answers using
+that skill's cheat sheet.
+
+Or, at the TUI prompt, type the colon-command directly:
+
+```
+:skill tdnf
+```
+
+### 2. From the shell (non-interactive)
+
+```bash
+spagat-librarian ai --skill tdnf "how do I upgrade only kernel packages?"
+```
+
+The output is written to stdout; no state is changed unless the agent
+autonomy tier is above `observe` and the operator confirms the write.
+
+## Adding your own skill
+
+Drop a Markdown file into `$XDG_CONFIG_HOME/spagat/skills/`:
+
+```bash
+mkdir -p ~/.config/spagat/skills
+cat > ~/.config/spagat/skills/postgres.md <<'EOF'
+# postgres - PostgreSQL admin
+
+Common PostgreSQL admin recipes for a single-node install.
+
+## Commands
+### Connect
+- Local, as superuser: `sudo -u postgres psql`
+- With a DSN: `psql "postgresql://user:pass@host:5432/dbname"`
+
+### Inspect
+- List databases: `\l`
+- List tables:    `\dt`
+- Explain plan:   `EXPLAIN ANALYZE <sql>;`
+
+## Notes
+- Config: /etc/postgresql/16/main/postgresql.conf
+- Logs:   /var/log/postgresql/
+EOF
+```
+
+Restart the TUI (or re-open the skill picker) and `postgres` appears in
+the list. Files in `$XDG_CONFIG_HOME/spagat/skills/` shadow files with
+the same name in `/usr/share/spagat/skills/`, so you can override a
+built-in skill with a local edit without touching the system copy.
+
+## Search order
+
+1. `$SPAGAT_SKILLS_DIR` (if set)
+2. `$XDG_CONFIG_HOME/spagat/skills/`
+3. `/usr/share/spagat/skills/`
+
+The first match by base filename wins.
+
+## What a skill file may contain
+
+- Prose paragraphs (loaded verbatim into the LLM context).
+- Bulleted or numbered lists of commands.
+- Fenced code blocks (bash, sql, toml, etc.).
+- Local file-path hints ("Config: `/etc/foo`").
+
+What a skill file must **not** contain:
+
+- Executable code that the console runs directly. Skills are context
+  documents; only the agent, via the LLM, ever synthesises a command
+  to run — and only when the autonomy tier permits it.
+- Secrets, keys, or credentials of any kind. Skills go into the LLM
+  prompt; assume that anything in a skill is visible to the LLM
+  provider.

--- a/SPAGAT-Librarian/include/appliance/hidpi.h
+++ b/SPAGAT-Librarian/include/appliance/hidpi.h
@@ -1,0 +1,77 @@
+/*
+ * appliance/hidpi.h — adapter shim for the external HiDPI framebuffer
+ * tier probe.
+ *
+ * See appliance/hitl.h for the two-mode adapter pattern. The HiDPI tier
+ * probe is an appliance feature; the standalone build simply reports
+ * the legacy 80x25 tier from the pure decision function and no-ops the
+ * probe stages.
+ */
+
+#ifndef SPAGAT_APPLIANCE_HIDPI_SHIM_H
+#define SPAGAT_APPLIANCE_HIDPI_SHIM_H
+
+#ifdef SPAGAT_APPLIANCE_BUILD
+
+#include "spagat_hidpi.h"
+
+#else  /* !SPAGAT_APPLIANCE_BUILD — standalone / public build */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    TIER_80x25 = 0,
+    TIER_160x60,
+    TIER_AUTO
+} SpagatHidpiTier;
+
+typedef struct SpagatHidpiProbe {
+    bool fb0_readable;
+    bool drm_card0_present;
+    int  fb_width_px;
+    int  fb_height_px;
+    int  font_cell_w;
+    int  font_cell_h;
+    bool habv4_gesture_present;
+} SpagatHidpiProbe;
+
+static inline int spagat_hidpi_parse_boot_param(const char *cmdline,
+                                                SpagatHidpiProbe *out) {
+    (void)cmdline; (void)out;
+    return 0;
+}
+
+static inline int spagat_hidpi_probe_vt_ioctl(SpagatHidpiProbe *out) {
+    (void)out;
+    return 0;
+}
+
+static inline int spagat_hidpi_measure_font_cell(SpagatHidpiProbe *out) {
+    (void)out;
+    return 0;
+}
+
+static inline SpagatHidpiTier spagat_hidpi_decide_tier(
+    const SpagatHidpiProbe *p) {
+    (void)p;
+    /* Legacy tier is the safe default for the public build. */
+    return TIER_80x25;
+}
+
+static inline int spagat_hidpi_subscribe_console(SpagatHidpiTier tier) {
+    (void)tier;
+    return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SPAGAT_APPLIANCE_BUILD */
+
+#endif /* SPAGAT_APPLIANCE_HIDPI_SHIM_H */

--- a/SPAGAT-Librarian/include/appliance/hitl.h
+++ b/SPAGAT-Librarian/include/appliance/hitl.h
@@ -1,0 +1,93 @@
+/*
+ * appliance/hitl.h — adapter shim for the external HITL approval overlay.
+ *
+ * This header is the T-PUB boundary between the generic console TUI and
+ * the appliance-integration implementation living under
+ * src/tui/appliance/. Two build modes:
+ *
+ *   - Appliance build  (-DSPAGAT_APPLIANCE_BUILD): this header forwards
+ *     to the real appliance interface header; the implementation in
+ *     src/tui/appliance/tui_hitl.c is linked into the binary.
+ *
+ *   - Standalone build (no SPAGAT_APPLIANCE_BUILD):  this header supplies
+ *     a minimal HitlState struct + inline no-op function bodies so the
+ *     kanban TUI compiles and links WITHOUT the appliance overlay. The
+ *     public console never surfaces the HITL overlay in this mode.
+ *
+ * Callers should include this shim (not the underlying appliance header)
+ * so the same source compiles cleanly under both build modes. See task
+ * #569 refactor + tier-manifest T-PUB / T-INT split.
+ */
+
+#ifndef SPAGAT_APPLIANCE_HITL_SHIM_H
+#define SPAGAT_APPLIANCE_HITL_SHIM_H
+
+#ifdef SPAGAT_APPLIANCE_BUILD
+
+/* Appliance build: real interface is defined in spagat_hitl.h and the
+ * matching implementation is linked from src/tui/appliance/tui_hitl.c. */
+#include "spagat_hitl.h"
+
+#else  /* !SPAGAT_APPLIANCE_BUILD — standalone / public build */
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Public-build stub type. The kanban TUI holds this by value so it
+ * must have a concrete layout; only the fields the T-PUB TUI callers
+ * directly reference are exposed. `active` is always false in this
+ * build — the overlay is not available and the caller's guard
+ * (`if (state->hitl.active) ...`) short-circuits cleanly. */
+typedef struct HitlState {
+    bool active;
+    int _reserved_public_stub;
+} HitlState;
+
+typedef struct HitlVerdict {
+    int _reserved_public_stub;
+} HitlVerdict;
+
+/* No-op stubs — the public build has no HITL overlay to drive. Every
+ * entry point becomes a silent no-op. Return values pick the "nothing
+ * happened" branch on the caller side. */
+static inline void hitl_init(HitlState *state) { (void)state; }
+static inline void hitl_toggle(HitlState *state) { (void)state; }
+static inline int  hitl_refresh(HitlState *state) { (void)state; return 0; }
+static inline int  hitl_decide(HitlState *state, bool approve) {
+    (void)state; (void)approve; return 0;
+}
+static inline void hitl_cursor_up(HitlState *state) { (void)state; }
+static inline void hitl_cursor_down(HitlState *state) { (void)state; }
+static inline const HitlVerdict *hitl_current(const HitlState *state) {
+    (void)state; return NULL;
+}
+static inline const char *hitl_inbox_path(void) { return ""; }
+static inline const char *hitl_unsigned_path(void) { return ""; }
+static inline bool hitl_is_known_source_schema(const char *schema) {
+    (void)schema; return false;
+}
+
+/* The two rendering entry points also become no-ops. They take the
+ * terminal dimensions in the appliance interface; ignore them here. */
+static inline void tui_hitl_draw(HitlState *state,
+                                 int term_height,
+                                 int term_width) {
+    (void)state; (void)term_height; (void)term_width;
+}
+static inline void tui_hitl_show_details(HitlState *state,
+                                         int term_height,
+                                         int term_width) {
+    (void)state; (void)term_height; (void)term_width;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SPAGAT_APPLIANCE_BUILD */
+
+#endif /* SPAGAT_APPLIANCE_HITL_SHIM_H */

--- a/SPAGAT-Librarian/include/appliance/scheduler_view.h
+++ b/SPAGAT-Librarian/include/appliance/scheduler_view.h
@@ -1,0 +1,83 @@
+/*
+ * appliance/scheduler_view.h — adapter shim for the external fleet
+ * scheduler view.
+ *
+ * See appliance/hitl.h for the two-mode adapter pattern. The scheduler
+ * view is an appliance-integration feature; the standalone build
+ * exposes only stub entry points that report "no calendar available".
+ */
+
+#ifndef SPAGAT_APPLIANCE_SCHEDULER_VIEW_SHIM_H
+#define SPAGAT_APPLIANCE_SCHEDULER_VIEW_SHIM_H
+
+#ifdef SPAGAT_APPLIANCE_BUILD
+
+#include "spagat_scheduler_view.h"
+
+#else  /* !SPAGAT_APPLIANCE_BUILD — standalone / public build */
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct SpagatScheduleWindow {
+    int _reserved_public_stub;
+} SpagatScheduleWindow;
+
+typedef enum {
+    EDIT_APPLIED = 0,
+    EDIT_GATED_L4,
+    EDIT_RATE_LIMITED,
+    EDIT_REJECTED
+} SpagatScheduleEditOutcome;
+
+static inline int spagat_scheduler_view_load(const char *calendar_path,
+                                             SpagatScheduleWindow **out,
+                                             size_t *n) {
+    (void)calendar_path;
+    if (out) { *out = NULL; }
+    if (n) { *n = 0; }
+    /* Non-zero return signals "no calendar available". */
+    return -1;
+}
+
+static inline void spagat_scheduler_view_free(SpagatScheduleWindow *w,
+                                              size_t n) {
+    (void)w; (void)n;
+}
+
+static inline int spagat_scheduler_view_save(const char *calendar_path,
+                                             const SpagatScheduleWindow *w,
+                                             size_t n) {
+    (void)calendar_path; (void)w; (void)n;
+    return -1;
+}
+
+static inline SpagatScheduleEditOutcome spagat_scheduler_view_edit(
+    SpagatScheduleWindow *w, const char *signed_gesture_or_null) {
+    (void)w; (void)signed_gesture_or_null;
+    return EDIT_REJECTED;
+}
+
+static inline int spagat_scheduler_view_reset(
+    const char *calendar_path, const char *default_calendar_path) {
+    (void)calendar_path; (void)default_calendar_path;
+    return -1;
+}
+
+static inline int spagat_scheduler_view_emit_critical_deviation(
+    const SpagatScheduleWindow *w, const char *bridge_dir) {
+    (void)w; (void)bridge_dir;
+    return -1;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SPAGAT_APPLIANCE_BUILD */
+
+#endif /* SPAGAT_APPLIANCE_SCHEDULER_VIEW_SHIM_H */

--- a/SPAGAT-Librarian/include/appliance/settings.h
+++ b/SPAGAT-Librarian/include/appliance/settings.h
@@ -1,0 +1,129 @@
+/*
+ * appliance/settings.h — adapter shim for the external Settings mode.
+ *
+ * See appliance/hitl.h for the two-mode adapter pattern; this file uses
+ * the same convention for the Settings overlay. Under the standalone
+ * build the Settings mode is not available (no external config manifest
+ * to render), so every entry point is a no-op stub.
+ */
+
+#ifndef SPAGAT_APPLIANCE_SETTINGS_SHIM_H
+#define SPAGAT_APPLIANCE_SETTINGS_SHIM_H
+
+#ifdef SPAGAT_APPLIANCE_BUILD
+
+#include "spagat_settings.h"
+
+#else  /* !SPAGAT_APPLIANCE_BUILD — standalone / public build */
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Public-build stub context. Callers hold a pointer to this and the
+ * T-PUB code only reads `active` from it before any real action — the
+ * short-circuit `if (state->settings && state->settings->active) …`
+ * pattern compiles cleanly this way. spagat_settings_load returns NULL
+ * in this build so the branch is never taken. */
+typedef struct spagat_settings_ctx {
+    bool active;
+    int _reserved_public_stub;
+} spagat_settings_ctx_t;
+
+typedef enum {
+    SPAGAT_SETTINGS_SECTION_STUB = 0
+} SpagatSettingsSection;
+
+typedef struct SpagatSettingsField {
+    int _reserved_public_stub;
+} SpagatSettingsField;
+
+/* Load / free — the load always returns NULL in the public build so the
+ * TUI never enters Settings mode. */
+static inline const char *spagat_settings_effective_path(void) { return ""; }
+static inline spagat_settings_ctx_t *spagat_settings_load(const char *p) {
+    (void)p; return NULL;
+}
+static inline void spagat_settings_free(spagat_settings_ctx_t *ctx) {
+    (void)ctx;
+}
+
+/* Overlay + cursor + query surface. All no-ops. */
+static inline void spagat_settings_toggle(spagat_settings_ctx_t *ctx) {
+    (void)ctx;
+}
+static inline void spagat_settings_cursor_up(spagat_settings_ctx_t *ctx) {
+    (void)ctx;
+}
+static inline void spagat_settings_cursor_down(spagat_settings_ctx_t *ctx) {
+    (void)ctx;
+}
+static inline const SpagatSettingsField *spagat_settings_current(
+    const spagat_settings_ctx_t *ctx) {
+    (void)ctx; return NULL;
+}
+static inline void spagat_settings_elide_fingerprint(const char *raw,
+                                                     char *out,
+                                                     size_t out_size) {
+    (void)raw;
+    if (out && out_size) { out[0] = '\0'; }
+}
+static inline const char *spagat_settings_section_label(
+    SpagatSettingsSection section) {
+    (void)section; return "";
+}
+static inline void spagat_settings_draw(spagat_settings_ctx_t *ctx) {
+    (void)ctx;
+}
+static inline void spagat_settings_show_details(spagat_settings_ctx_t *ctx) {
+    (void)ctx;
+}
+static inline int spagat_settings_handle_key(spagat_settings_ctx_t *ctx,
+                                             int ch) {
+    (void)ctx; (void)ch;
+    /* Return 1 to signal "exit back to previous mode" — the standalone
+     * build has no Settings state to hold in. */
+    return 1;
+}
+
+/* Edit + emit surface — every call is a no-op / failure in this mode. */
+static inline int spagat_settings_field_editable(
+    const spagat_settings_ctx_t *ctx) {
+    (void)ctx; return 0;
+}
+static inline int spagat_settings_edit_current_field(
+    spagat_settings_ctx_t *ctx, const char *new_value) {
+    (void)ctx; (void)new_value; return -1;
+}
+static inline int spagat_settings_has_pending(
+    const spagat_settings_ctx_t *ctx) {
+    (void)ctx; return 0;
+}
+static inline const char *spagat_settings_event_path(void) { return ""; }
+static inline int spagat_settings_commit_pending(
+    spagat_settings_ctx_t *ctx, const char *event_path) {
+    (void)ctx; (void)event_path; return 0;
+}
+static inline int spagat_settings_serialise_pending(
+    const spagat_settings_ctx_t *ctx, char *out, size_t out_size) {
+    (void)ctx;
+    if (out && out_size) { out[0] = '\0'; }
+    return 0;
+}
+
+/* Deterministic clock hook — accept + ignore. */
+typedef long (*spagat_settings_time_fn)(void);
+static inline void spagat_settings_set_time_fn(spagat_settings_time_fn fn) {
+    (void)fn;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SPAGAT_APPLIANCE_BUILD */
+
+#endif /* SPAGAT_APPLIANCE_SETTINGS_SHIM_H */

--- a/SPAGAT-Librarian/src/agent/agent.h
+++ b/SPAGAT-Librarian/src/agent/agent.h
@@ -8,7 +8,10 @@
 #define SPAGAT_MODELS_DIR "models"
 #define SPAGAT_CONFIG_FILE "config.json"
 #define SPAGAT_LOGS_DIR "logs"
-#define SPAGAT_CREDENTIALS_DIR "credentials"
+/* Per-user credentials subdirectory name under ~/.spagat. Kept as a
+ * plain generic token — this is NOT an appliance-managed credential
+ * path (that lives in the appliance-only integration layer). */
+#define SPAGAT_KEYSTORE_SUBDIR "credentials"
 
 #define SPAGAT_PATH_MAX 1024
 

--- a/SPAGAT-Librarian/src/agent/workspace.c
+++ b/SPAGAT-Librarian/src/agent/workspace.c
@@ -98,7 +98,7 @@ bool workspace_init(WorkspacePaths *paths) {
     snprintf(paths->logs_dir, sizeof(paths->logs_dir),
              "%s/%s", base, SPAGAT_LOGS_DIR);
     snprintf(paths->credentials_dir, sizeof(paths->credentials_dir),
-             "%s/%s", base, SPAGAT_CREDENTIALS_DIR);
+             "%s/%s", base, SPAGAT_KEYSTORE_SUBDIR);
 
     /* Cache for later retrieval */
     memcpy(&cached_paths, paths, sizeof(WorkspacePaths));

--- a/SPAGAT-Librarian/src/db/db.c
+++ b/SPAGAT-Librarian/src/db/db.c
@@ -107,7 +107,8 @@ bool db_item_get(int64_t id, Item *item) {
     
     const char *sql = 
         "SELECT id, status, title, description, tag, history, priority, due_date, "
-        "project_id, parent_id, git_branch, time_spent, created_at, updated_at "
+        "project_id, parent_id, git_branch, time_spent, created_at, updated_at, "
+        "upstream_commit, backport_commit, cve_ids "
         "FROM items WHERE id = ?";
     sqlite3_stmt *stmt;
     
@@ -134,8 +135,20 @@ bool db_item_get(int64_t id, Item *item) {
     item->time_spent = sqlite3_column_int64(stmt, 11);
     item->created_at = sqlite3_column_int64(stmt, 12);
     item->updated_at = sqlite3_column_int64(stmt, 13);
+    /* M48-KanbanCVECard columns 14/15/16. Legacy rows migrated from
+     * v3 store empty strings by default, so the safe_copy below
+     * yields a zero-length target — no NULL deref risk. */
+    str_safe_copy(item->upstream_commit,
+                  (const char *)sqlite3_column_text(stmt, 14),
+                  sizeof(item->upstream_commit));
+    str_safe_copy(item->backport_commit,
+                  (const char *)sqlite3_column_text(stmt, 15),
+                  sizeof(item->backport_commit));
+    str_safe_copy(item->cve_ids,
+                  (const char *)sqlite3_column_text(stmt, 16),
+                  sizeof(item->cve_ids));
     item->selected = false;
-    
+
     sqlite3_finalize(stmt);
     return true;
 }
@@ -143,14 +156,15 @@ bool db_item_get(int64_t id, Item *item) {
 bool db_item_update(const Item *item) {
     if (!db || !item) return false;
     
-    const char *sql = 
+    const char *sql =
         "UPDATE items SET status = ?, title = ?, description = ?, tag = ?, history = ?, "
         "priority = ?, due_date = ?, project_id = ?, parent_id = ?, git_branch = ?, "
+        "upstream_commit = ?, backport_commit = ?, cve_ids = ?, "
         "updated_at = strftime('%s', 'now') WHERE id = ?";
     sqlite3_stmt *stmt;
-    
+
     if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK) return false;
-    
+
     sqlite3_bind_text(stmt, 1, STATUS_NAMES[item->status], -1, SQLITE_STATIC);
     sqlite3_bind_text(stmt, 2, item->title, -1, SQLITE_STATIC);
     sqlite3_bind_text(stmt, 3, item->description, -1, SQLITE_STATIC);
@@ -161,7 +175,12 @@ bool db_item_update(const Item *item) {
     sqlite3_bind_int64(stmt, 8, item->project_id);
     sqlite3_bind_int64(stmt, 9, item->parent_id);
     sqlite3_bind_text(stmt, 10, item->git_branch, -1, SQLITE_STATIC);
-    sqlite3_bind_int64(stmt, 11, item->id);
+    /* M48-KanbanCVECard bindings 11/12/13 — commit SHAs + CVE list.
+     * All three are optional (empty string). */
+    sqlite3_bind_text(stmt, 11, item->upstream_commit, -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 12, item->backport_commit, -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 13, item->cve_ids, -1, SQLITE_STATIC);
+    sqlite3_bind_int64(stmt, 14, item->id);
     
     int rc = sqlite3_step(stmt);
     sqlite3_finalize(stmt);
@@ -223,9 +242,10 @@ bool db_items_list(ItemList *list, ItemStatus *filter_statuses, int filter_count
     char sql[512];
     int offset = 0;
     if (filter_count > 0) {
-        offset = snprintf(sql, sizeof(sql), 
+        offset = snprintf(sql, sizeof(sql),
             "SELECT id, status, title, description, tag, history, priority, due_date, "
-            "project_id, parent_id, git_branch, time_spent, created_at, updated_at "
+            "project_id, parent_id, git_branch, time_spent, created_at, updated_at, "
+            "upstream_commit, backport_commit, cve_ids "
             "FROM items WHERE status IN (");
         for (int i = 0; i < filter_count && offset < (int)sizeof(sql) - 32; i++) {
             offset += snprintf(sql + offset, sizeof(sql) - offset, "%s'%s'",
@@ -233,9 +253,10 @@ bool db_items_list(ItemList *list, ItemStatus *filter_statuses, int filter_count
         }
         snprintf(sql + offset, sizeof(sql) - offset, ") ORDER BY id");
     } else {
-        snprintf(sql, sizeof(sql), 
+        snprintf(sql, sizeof(sql),
             "SELECT id, status, title, description, tag, history, priority, due_date, "
-            "project_id, parent_id, git_branch, time_spent, created_at, updated_at "
+            "project_id, parent_id, git_branch, time_spent, created_at, updated_at, "
+            "upstream_commit, backport_commit, cve_ids "
             "FROM items ORDER BY id");
     }
     
@@ -261,11 +282,21 @@ bool db_items_list(ItemList *list, ItemStatus *filter_statuses, int filter_count
         item->time_spent = sqlite3_column_int64(stmt, 11);
         item->created_at = sqlite3_column_int64(stmt, 12);
         item->updated_at = sqlite3_column_int64(stmt, 13);
+        /* M48-KanbanCVECard columns 14/15/16. */
+        str_safe_copy(item->upstream_commit,
+                      (const char *)sqlite3_column_text(stmt, 14),
+                      sizeof(item->upstream_commit));
+        str_safe_copy(item->backport_commit,
+                      (const char *)sqlite3_column_text(stmt, 15),
+                      sizeof(item->backport_commit));
+        str_safe_copy(item->cve_ids,
+                      (const char *)sqlite3_column_text(stmt, 16),
+                      sizeof(item->cve_ids));
         item->selected = false;
-        
+
         list->count++;
     }
-    
+
     sqlite3_finalize(stmt);
     return true;
 }

--- a/SPAGAT-Librarian/src/db/db_ext.c
+++ b/SPAGAT-Librarian/src/db/db_ext.c
@@ -7,20 +7,34 @@
 
 extern sqlite3 *db_get_handle(void);
 
+/* M48-KanbanCVECard CVE-tracking columns.
+ *
+ * The three columns upstream_commit / backport_commit / cve_ids are
+ * OPTIONAL; the C-side render treats empty as "not set" (single-line
+ * card, "(none)" in the details popup). Populating them is done via:
+ *
+ *   - the extended Add-Item dialog (`a` on the board)
+ *   - the Edit dialog / Git-Branch dialog (`e` / `b` on the board)
+ *   - direct sqlite3 UPDATE from an operator script
+ *
+ * Any external enrichment pipeline that wants to auto-populate these
+ * columns is out-of-scope for the console binary itself.
+ */
 bool db_item_add_full(const Item *item, int64_t *out_id) {
     sqlite3 *db = db_get_handle();
     if (!db || !item) return false;
     
-    const char *sql = 
+    const char *sql =
         "INSERT INTO items (status, title, description, tag, history, priority, "
-        "due_date, project_id, parent_id, git_branch, time_spent) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        "due_date, project_id, parent_id, git_branch, time_spent, "
+        "upstream_commit, backport_commit, cve_ids) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
     sqlite3_stmt *stmt;
-    
+
     if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK) return false;
-    
+
     char history[4] = {STATUS_ABBREV[item->status], '\0'};
-    
+
     sqlite3_bind_text(stmt, 1, STATUS_NAMES[item->status], -1, SQLITE_STATIC);
     sqlite3_bind_text(stmt, 2, item->title, -1, SQLITE_STATIC);
     sqlite3_bind_text(stmt, 3, item->description, -1, SQLITE_STATIC);
@@ -32,6 +46,10 @@ bool db_item_add_full(const Item *item, int64_t *out_id) {
     sqlite3_bind_int64(stmt, 9, item->parent_id);
     sqlite3_bind_text(stmt, 10, item->git_branch, -1, SQLITE_STATIC);
     sqlite3_bind_int64(stmt, 11, item->time_spent);
+    /* M48-KanbanCVECard bindings 12/13/14. */
+    sqlite3_bind_text(stmt, 12, item->upstream_commit, -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 13, item->backport_commit, -1, SQLITE_STATIC);
+    sqlite3_bind_text(stmt, 14, item->cve_ids, -1, SQLITE_STATIC);
     
     int rc = sqlite3_step(stmt);
     if (rc == SQLITE_DONE && out_id) {
@@ -53,7 +71,8 @@ bool db_items_list_full(ItemList *list, int64_t project_id, ItemStatus *filter_s
     char sql[1024];
     int offset = snprintf(sql, sizeof(sql),
         "SELECT id, status, title, description, tag, history, priority, "
-        "due_date, project_id, parent_id, git_branch, time_spent, created_at, updated_at "
+        "due_date, project_id, parent_id, git_branch, time_spent, created_at, updated_at, "
+        "upstream_commit, backport_commit, cve_ids "
         "FROM items WHERE project_id = %lld", (long long)project_id);
     
     if (filter_count > 0) {
@@ -91,8 +110,18 @@ bool db_items_list_full(ItemList *list, int64_t project_id, ItemStatus *filter_s
         item->time_spent = sqlite3_column_int64(stmt, 11);
         item->created_at = sqlite3_column_int64(stmt, 12);
         item->updated_at = sqlite3_column_int64(stmt, 13);
+        /* M48-KanbanCVECard columns 14/15/16. */
+        str_safe_copy(item->upstream_commit,
+                      (const char *)sqlite3_column_text(stmt, 14),
+                      sizeof(item->upstream_commit));
+        str_safe_copy(item->backport_commit,
+                      (const char *)sqlite3_column_text(stmt, 15),
+                      sizeof(item->backport_commit));
+        str_safe_copy(item->cve_ids,
+                      (const char *)sqlite3_column_text(stmt, 16),
+                      sizeof(item->cve_ids));
         item->selected = false;
-        
+
         list->count++;
     }
     
@@ -110,7 +139,8 @@ bool db_items_by_parent(ItemList *list, int64_t parent_id) {
     
     const char *sql = 
         "SELECT id, status, title, description, tag, history, priority, "
-        "due_date, project_id, parent_id, git_branch, time_spent, created_at, updated_at "
+        "due_date, project_id, parent_id, git_branch, time_spent, created_at, updated_at, "
+        "upstream_commit, backport_commit, cve_ids "
         "FROM items WHERE parent_id = ? ORDER BY id";
     
     sqlite3_stmt *stmt;
@@ -139,8 +169,18 @@ bool db_items_by_parent(ItemList *list, int64_t parent_id) {
         item->time_spent = sqlite3_column_int64(stmt, 11);
         item->created_at = sqlite3_column_int64(stmt, 12);
         item->updated_at = sqlite3_column_int64(stmt, 13);
+        /* M48-KanbanCVECard columns 14/15/16. */
+        str_safe_copy(item->upstream_commit,
+                      (const char *)sqlite3_column_text(stmt, 14),
+                      sizeof(item->upstream_commit));
+        str_safe_copy(item->backport_commit,
+                      (const char *)sqlite3_column_text(stmt, 15),
+                      sizeof(item->backport_commit));
+        str_safe_copy(item->cve_ids,
+                      (const char *)sqlite3_column_text(stmt, 16),
+                      sizeof(item->cve_ids));
         item->selected = false;
-        
+
         list->count++;
     }
     
@@ -158,7 +198,8 @@ bool db_items_by_priority(ItemList *list, ItemPriority priority) {
     
     const char *sql = 
         "SELECT id, status, title, description, tag, history, priority, "
-        "due_date, project_id, parent_id, git_branch, time_spent, created_at, updated_at "
+        "due_date, project_id, parent_id, git_branch, time_spent, created_at, updated_at, "
+        "upstream_commit, backport_commit, cve_ids "
         "FROM items WHERE priority = ? ORDER BY due_date ASC, id";
     
     sqlite3_stmt *stmt;
@@ -187,8 +228,18 @@ bool db_items_by_priority(ItemList *list, ItemPriority priority) {
         item->time_spent = sqlite3_column_int64(stmt, 11);
         item->created_at = sqlite3_column_int64(stmt, 12);
         item->updated_at = sqlite3_column_int64(stmt, 13);
+        /* M48-KanbanCVECard columns 14/15/16. */
+        str_safe_copy(item->upstream_commit,
+                      (const char *)sqlite3_column_text(stmt, 14),
+                      sizeof(item->upstream_commit));
+        str_safe_copy(item->backport_commit,
+                      (const char *)sqlite3_column_text(stmt, 15),
+                      sizeof(item->backport_commit));
+        str_safe_copy(item->cve_ids,
+                      (const char *)sqlite3_column_text(stmt, 16),
+                      sizeof(item->cve_ids));
         item->selected = false;
-        
+
         list->count++;
     }
     
@@ -206,7 +257,8 @@ bool db_items_due_before(ItemList *list, time_t deadline) {
     
     const char *sql = 
         "SELECT id, status, title, description, tag, history, priority, "
-        "due_date, project_id, parent_id, git_branch, time_spent, created_at, updated_at "
+        "due_date, project_id, parent_id, git_branch, time_spent, created_at, updated_at, "
+        "upstream_commit, backport_commit, cve_ids "
         "FROM items WHERE due_date > 0 AND due_date <= ? "
         "AND status NOT IN ('ready', 'wontfix') ORDER BY due_date ASC";
     
@@ -236,8 +288,18 @@ bool db_items_due_before(ItemList *list, time_t deadline) {
         item->time_spent = sqlite3_column_int64(stmt, 11);
         item->created_at = sqlite3_column_int64(stmt, 12);
         item->updated_at = sqlite3_column_int64(stmt, 13);
+        /* M48-KanbanCVECard columns 14/15/16. */
+        str_safe_copy(item->upstream_commit,
+                      (const char *)sqlite3_column_text(stmt, 14),
+                      sizeof(item->upstream_commit));
+        str_safe_copy(item->backport_commit,
+                      (const char *)sqlite3_column_text(stmt, 15),
+                      sizeof(item->backport_commit));
+        str_safe_copy(item->cve_ids,
+                      (const char *)sqlite3_column_text(stmt, 16),
+                      sizeof(item->cve_ids));
         item->selected = false;
-        
+
         list->count++;
     }
     

--- a/SPAGAT-Librarian/src/db/migrate.c
+++ b/SPAGAT-Librarian/src/db/migrate.c
@@ -6,6 +6,7 @@
 
 static bool migrate_v1_to_v2(sqlite3 *db);
 static bool migrate_v2_to_v3(sqlite3 *db);
+static bool migrate_v3_to_v4(sqlite3 *db);
 static bool table_has_column(sqlite3 *db, const char *table, const char *column);
 static bool ensure_version_table(sqlite3 *db);
 
@@ -112,15 +113,23 @@ static int detect_schema_version(sqlite3 *db) {
     if (!table_exists(db, "items")) {
         return 0;
     }
-    
+
+    /* M48-KanbanCVECard: v4 layers on top of v3 by adding
+     * upstream_commit / backport_commit / cve_ids. Detection order
+     * flows newest-first so a legacy DB missing only the v4 columns
+     * still reports v3 and drives the ALTER-only migration below. */
+    if (table_has_column(db, "items", "cve_ids")) {
+        return 4;
+    }
+
     if (table_has_column(db, "items", "priority")) {
         return 3;
     }
-    
+
     if (table_has_column(db, "items", "title")) {
         return 2;
     }
-    
+
     return 1;
 }
 
@@ -227,6 +236,41 @@ static bool migrate_v2_to_v3(sqlite3 *db) {
     return true;
 }
 
+/* M48-KanbanCVECard: v3 → v4. Adds three optional columns to `items`:
+ *   upstream_commit  TEXT DEFAULT ''  — 40-hex upstream SHA
+ *   backport_commit  TEXT DEFAULT ''  — 40-hex spagat-side SHA
+ *   cve_ids          TEXT DEFAULT ''  — comma-separated CVE-IDs
+ * The migration is idempotent: a "duplicate column" error from ALTER
+ * TABLE is swallowed so re-running the check on an already-v4 DB
+ * (e.g. an operator downgraded then upgraded again) stays green. */
+static bool migrate_v3_to_v4(sqlite3 *db) {
+    printf("Migrating database from version 3 to version 4 (M48-KanbanCVECard)...\n");
+    char *err = NULL;
+
+    const char *migrations[] = {
+        "ALTER TABLE items ADD COLUMN upstream_commit TEXT DEFAULT ''",
+        "ALTER TABLE items ADD COLUMN backport_commit TEXT DEFAULT ''",
+        "ALTER TABLE items ADD COLUMN cve_ids TEXT DEFAULT ''",
+        NULL
+    };
+
+    for (int i = 0; migrations[i] != NULL; i++) {
+        if (sqlite3_exec(db, migrations[i], NULL, NULL, &err) != SQLITE_OK) {
+            if (err && strstr(err, "duplicate column") == NULL) {
+                fprintf(stderr, "Migration v3->v4 failed: %s\nSQL: %s\n",
+                        err, migrations[i]);
+                sqlite3_free(err);
+                return false;
+            }
+            if (err) sqlite3_free(err);
+            err = NULL;
+        }
+    }
+
+    printf("  Migration to version 4 complete.\n");
+    return true;
+}
+
 bool db_migrate_check_and_run(void) {
     sqlite3 *db = db_get_handle();
     if (!db) return false;
@@ -259,7 +303,14 @@ bool db_migrate_check_and_run(void) {
         }
         current_version = 3;
     }
-    
+
+    if (current_version < 4) {
+        if (!migrate_v3_to_v4(db)) {
+            return false;
+        }
+        current_version = 4;
+    }
+
     if (!db_set_version(SPAGAT_DB_VERSION)) {
         fprintf(stderr, "Failed to update schema version.\n");
         return false;

--- a/SPAGAT-Librarian/src/db/migrate.h
+++ b/SPAGAT-Librarian/src/db/migrate.h
@@ -3,7 +3,10 @@
 
 #include <stdbool.h>
 
-#define SPAGAT_DB_VERSION 3
+/* M48-KanbanCVECard: v4 adds upstream_commit / backport_commit /
+ * cve_ids columns to `items`. Old rows migrate cleanly with empty
+ * defaults; the migration is idempotent on already-v4 schemas. */
+#define SPAGAT_DB_VERSION 4
 
 bool db_migrate_check_and_run(void);
 int db_get_version(void);

--- a/SPAGAT-Librarian/src/tui/tui.c
+++ b/SPAGAT-Librarian/src/tui/tui.c
@@ -32,52 +32,113 @@ bool tui_init(TUIState *state) {
         init_pair(COLOR_PRI_MED, COLOR_YELLOW, -1);
         init_pair(COLOR_COL_TITLE, COLOR_WHITE, COLOR_BLACK);
         init_pair(COLOR_COL_SEL, COLOR_BLACK, COLOR_WHITE);
+        /* M48-KanbanCVECard branch badges. Order MUST match the
+         * SpagatM48BranchColor enum in include/spagat_m48.h — the render
+         * code walks the enum value straight to init_pair index. */
+        init_pair(COLOR_PAIR_BRANCH_40,       COLOR_BLUE,    -1);
+        init_pair(COLOR_PAIR_BRANCH_50,       COLOR_GREEN,   -1);
+        init_pair(COLOR_PAIR_BRANCH_SPECS_90, COLOR_YELLOW,  -1);
+        init_pair(COLOR_PAIR_BRANCH_SPECS_91, COLOR_MAGENTA, -1);
+        init_pair(COLOR_PAIR_BRANCH_60,       COLOR_CYAN,    -1);
+        init_pair(COLOR_PAIR_BRANCH_OTHER,    COLOR_WHITE,   -1);
     }
     
+    /* M48-KanbanBranchView — default to Status view; the operator can
+     * flip to Branch view with `b`. Board mode is session-only; NOT
+     * persisted to appliance-config.toml on toggle. */
+    state->board_mode = BOARD_MODE_STATUS;
+
     getmaxyx(stdscr, state->term_height, state->term_width);
-    state->col_width = state->term_width / STATUS_COUNT;
+    state->col_width = state->term_width / board_col_count(state->board_mode);
     if (state->col_width < 12) state->col_width = 12;
-    
+
     state->running = true;
     state->needs_refresh = true;
     state->current_col = STATUS_BACKLOG;
     state->current_row = 0;
-    
+
+    /* T7.16.f5 / #338 — initialise the HITL approval overlay state.
+     * Overlay is inactive until the operator presses `v`. */
+    hitl_init(&state->hitl);
+
+    /* Settings context is lazily loaded on first `s` press so we do
+     * not touch the config file at startup (may not exist on first
+     * run). */
+    state->settings = NULL;
+
     tui_refresh_items(state);
-    
+
     return true;
 }
 
 void tui_cleanup(TUIState *state) {
     db_items_free(&state->items);
+    if (state->settings) {
+        spagat_settings_free(state->settings);
+        state->settings = NULL;
+    }
     endwin();
 }
 
 void tui_refresh_items(TUIState *state) {
     db_items_free(&state->items);
     db_items_list(&state->items, NULL, 0);
-    
-    for (int i = 0; i < STATUS_COUNT; i++) {
+
+    /* M48-KanbanBranchView — item_counts must reflect the currently
+     * active board mode. In Status view each slot counts items whose
+     * status equals the slot; in Branch view each slot counts items
+     * whose git_branch resolves to the slot (Other-bucket receives
+     * every non-canonical branch and every empty branch). Recomputed
+     * on refresh AND on `b` toggle (see tui_toggle_board_mode). */
+    for (int i = 0; i < BOARD_COL_COUNT_MAX; i++) {
         state->item_counts[i] = 0;
     }
-    for (int i = 0; i < state->items.count; i++) {
-        state->item_counts[state->items.items[i].status]++;
+    if (state->board_mode == BOARD_MODE_BRANCH) {
+        for (int i = 0; i < state->items.count; i++) {
+            int col = branch_column_for(state->items.items[i].git_branch);
+            state->item_counts[col]++;
+        }
+    } else {
+        for (int i = 0; i < state->items.count; i++) {
+            state->item_counts[state->items.items[i].status]++;
+        }
     }
-    
+
     state->needs_refresh = true;
 }
 
 void tui_run(TUIState *state) {
+    int hitl_poll_counter = 0;
     while (state->running) {
+        /* Tail the HITL inbox every ~10 frames (~1 s at the 100 ms
+         * input timeout). Trigger a redraw if anything new arrived
+         * AND the overlay is visible. */
+        if (hitl_poll_counter++ >= 10) {
+            hitl_poll_counter = 0;
+            int added = hitl_refresh(&state->hitl);
+            if (added > 0 && state->hitl.active) {
+                state->needs_refresh = true;
+            }
+        }
+
         if (state->needs_refresh) {
             clear();
             tui_draw_header(state);
             tui_draw_board(state);
+            if (state->hitl.active) {
+                tui_hitl_draw(&state->hitl, state->term_height,
+                              state->term_width);
+            }
+            /* ADR-0055.f9 Settings overlay renders on top of the
+             * kanban, same layering rule the HITL overlay uses. */
+            if (state->settings && state->settings->active) {
+                spagat_settings_draw(state->settings);
+            }
             tui_draw_footer(state);
             refresh();
             state->needs_refresh = false;
         }
-        
+
         tui_handle_input(state);
     }
 }

--- a/SPAGAT-Librarian/src/tui/tui.h
+++ b/SPAGAT-Librarian/src/tui/tui.h
@@ -2,6 +2,9 @@
 #define TUI_H
 
 #include "spagat.h"
+#include "appliance/hitl.h"
+#include "appliance/settings.h"
+#include "spagat_board_mode.h"
 #include <stdbool.h>
 
 typedef struct {
@@ -10,7 +13,10 @@ typedef struct {
     int col_width;
     int current_col;
     int current_row;
-    int scroll_offset[STATUS_COUNT];
+    /* Scroll + count arrays are sized to the widest board layout so
+     * both modes address the same backing storage. Toggling the mode
+     * preserves per-column scroll offsets so the state is sticky. */
+    int scroll_offset[BOARD_COL_COUNT_MAX];
     bool use_color;
     bool use_utf8;
     bool running;
@@ -18,7 +24,15 @@ typedef struct {
     bool swimlane_mode;
     int64_t current_project;
     ItemList items;
-    int item_counts[STATUS_COUNT];
+    int item_counts[BOARD_COL_COUNT_MAX];
+    HitlState hitl;  /* T7.16.f5 / #338 operator HITL approval overlay */
+    /* ADR-0055.f9 read-only Settings mode. NULL until the operator
+     * presses `s` for the first time; freed by tui_cleanup. */
+    spagat_settings_ctx_t *settings;
+    /* M48-KanbanBranchView — active board layout. Defaults to
+     * BOARD_MODE_STATUS in tui_init(); the `b` keypress toggles.
+     * Session-only; never written to appliance-config.toml. */
+    BoardMode board_mode;
 } TUIState;
 
 bool tui_init(TUIState *state);
@@ -38,6 +52,10 @@ void tui_move_cursor_right(TUIState *state);
 void tui_move_cursor_up(TUIState *state);
 void tui_move_cursor_down(TUIState *state);
 
+/* M48-KanbanBranchView — flip between Status and Branch board layouts
+ * and reset the cursor to (0, 0). Session-only; NOT persisted. */
+void tui_toggle_board_mode(TUIState *state);
+
 void tui_toggle_select(TUIState *state);
 void tui_select_all_in_column(TUIState *state);
 void tui_clear_selection(TUIState *state);
@@ -46,6 +64,7 @@ int tui_count_selected(TUIState *state);
 void tui_dialog_add(TUIState *state);
 void tui_dialog_move(TUIState *state);
 void tui_dialog_edit(TUIState *state);
+void tui_dialog_details(TUIState *state);
 void tui_dialog_delete(TUIState *state);
 void tui_dialog_search(TUIState *state);
 

--- a/SPAGAT-Librarian/src/tui/tui_board.c
+++ b/SPAGAT-Librarian/src/tui/tui_board.c
@@ -1,33 +1,72 @@
 #include "tui_common.h"
+#include "spagat_m48.h"
 #include <time.h>
+
+/* M48-KanbanCVECard — map the pure-C branch enum to the ncurses
+ * COLOR_PAIR indices declared in tui_common.h. Kept as a lookup table
+ * so the mapping is one-touch to maintain and the render code stays
+ * declarative. Indexed by SpagatM48BranchColor value. */
+static const int M48_BRANCH_PAIR[M48_BRANCH_COLOR_COUNT] = {
+    [M48_BRANCH_COLOR_40]       = COLOR_PAIR_BRANCH_40,
+    [M48_BRANCH_COLOR_50]       = COLOR_PAIR_BRANCH_50,
+    [M48_BRANCH_COLOR_SPECS_90] = COLOR_PAIR_BRANCH_SPECS_90,
+    [M48_BRANCH_COLOR_SPECS_91] = COLOR_PAIR_BRANCH_SPECS_91,
+    [M48_BRANCH_COLOR_60]       = COLOR_PAIR_BRANCH_60,
+    [M48_BRANCH_COLOR_OTHER]    = COLOR_PAIR_BRANCH_OTHER,
+};
 
 void tui_draw_header(TUIState *state) {
     if (state->use_color) attron(COLOR_PAIR(COLOR_HEADER) | A_BOLD);
-    
+
     mvhline(0, 0, ' ', state->term_width);
-    mvprintw(0, 2, "SPAGAT-Librarian v%s", SPAGAT_VERSION);
-    
+    /* Version + board-mode badge share the left slot. The board-mode
+     * badge ([Board: Status] / [Board: Branch]) surfaces the current
+     * view mode after the version, matching the operator scope for
+     * M48-KanbanBranchView. Fixed offsets are preserved so the tests
+     * can grep the emitted bytes deterministically. */
+    int written = mvprintw(0, 2, "SPAGAT-Librarian v%s", SPAGAT_VERSION);
+    (void)written;
+    /* Column 20 leaves ~5 chars of visual padding after the version
+     * string on standard terminals — the version itself is short. */
+    mvprintw(0, 20, "[Board: %s]",
+             board_mode_label(state->board_mode));
+
     if (state->current_project > 0) {
         Project proj;
         if (db_project_get(state->current_project, &proj)) {
-            mvprintw(0, 30, "[Project: %s]", proj.name);
+            /* Nudged right of the board-mode badge so the two never
+             * overlap on standard 80-col terminals. */
+            mvprintw(0, 40, "[Project: %s]", proj.name);
         }
     }
-    
+
     int selected = tui_count_selected(state);
     if (selected > 0) {
         mvprintw(0, state->term_width - 20, "[%d selected]", selected);
     }
-    
+
     if (state->use_color) attroff(COLOR_PAIR(COLOR_HEADER) | A_BOLD);
 }
 
 void tui_draw_footer(TUIState *state) {
     int y = state->term_height - 1;
-    
+
     if (state->use_color) attron(COLOR_PAIR(COLOR_HELP));
     mvhline(y, 0, ' ', state->term_width);
-    mvprintw(y, 1, "q:Quit a:Add e:Edit m:Move d:Del ?:Help");
+    if (state->settings && state->settings->active) {
+        mvprintw(y, 1,
+                 "[Settings] Up/Down:Move Enter:Details q/s:Close");
+    } else if (state->hitl.active) {
+        mvprintw(y, 1, "[HITL] A:Approve R:Reject D:Details j/k:Move v:Close q:Quit");
+    } else {
+        /* M48-KanbanBranchView — `b:View` inserted between `d:Del`
+         * and `v:HITL` so the operator can discover the toggle
+         * without opening the help panel. `g:Branch` replaces the
+         * pre-M48 `b:Branch` quick-action binding (the letter `b`
+         * is now reserved for the view toggle; see tui_input.c). */
+        mvprintw(y, 1, "q:Quit a:Add e:Edit m:Move d:Del b:View "
+                       "v:HITL g:Branch s:Settings ?:Help");
+    }
     if (state->use_color) attroff(COLOR_PAIR(COLOR_HELP));
 }
 
@@ -62,8 +101,19 @@ void tui_draw_box(int y, int x, int h, int w, const char *title) {
     mvaddch(y + h - 1, x + w - 1, ACS_LRCORNER);
 }
 
+/* Draw the column-title label plus box borders. `title_color_pair` is
+ * the ncurses COLOR_PAIR to use for the title text when the column is
+ * not the active one; when active, COLOR_COL_SEL wins so the operator
+ * always sees the active column via the same highlight regardless of
+ * board mode. Passing 0 for title_color_pair means "use COLOR_COL_TITLE"
+ * (the historical status-view color).
+ *
+ * M48-KanbanBranchView: branch view supplies title_color_pair =
+ * M48_BRANCH_PAIR[col] so column headers paint in the same palette
+ * that the card branch badge uses on line 1. */
 static void draw_column_box(int y, int x, int h, int w, bool active,
-                            const char *title, int count, bool use_color) {
+                            const char *title, int count, bool use_color,
+                            int title_color_pair) {
     /* Top border */
     mvaddch(y, x, ACS_ULCORNER);
     for (int i = 1; i < w - 1; i++) mvaddch(y, x + i, ACS_HLINE);
@@ -76,13 +126,17 @@ static void draw_column_box(int y, int x, int h, int w, bool active,
     int lx = x + (w - llen) / 2;
     if (lx < x + 1) lx = x + 1;
 
+    int applied_pair = 0;
     if (active) {
-        if (use_color) attron(COLOR_PAIR(COLOR_COL_SEL) | A_BOLD);
+        applied_pair = COLOR_COL_SEL;
+    } else if (title_color_pair > 0) {
+        applied_pair = title_color_pair;
     } else {
-        if (use_color) attron(COLOR_PAIR(COLOR_COL_TITLE) | A_BOLD);
+        applied_pair = COLOR_COL_TITLE;
     }
+    if (use_color) attron(COLOR_PAIR(applied_pair) | A_BOLD);
     mvprintw(y, lx, "%s", label);
-    if (use_color) attroff(COLOR_PAIR(COLOR_COL_SEL) | COLOR_PAIR(COLOR_COL_TITLE) | A_BOLD);
+    if (use_color) attroff(COLOR_PAIR(applied_pair) | A_BOLD);
 
     /* Side borders */
     for (int i = 1; i < h - 1; i++) {
@@ -96,137 +150,325 @@ static void draw_column_box(int y, int x, int h, int w, bool active,
     mvaddch(y + h - 1, x + w - 1, ACS_LRCORNER);
 }
 
-void tui_draw_board(TUIState *state) {
+/* M48-KanbanBranchView — return true iff the item belongs in the given
+ * board column under the current board_mode.
+ *
+ *   BOARD_MODE_STATUS  → item->status matches col.
+ *   BOARD_MODE_BRANCH  → branch_column_for(item->git_branch) matches col.
+ *
+ * Kept out of tui.h so the header stays small; used both by the
+ * renderer (this TU) and by the input dispatcher (tui_input.c) via
+ * a corresponding helper there. */
+static bool item_belongs_in_column(const TUIState *state,
+                                   const Item *item, int col) {
+    if (state->board_mode == BOARD_MODE_BRANCH) {
+        return branch_column_for(item->git_branch) == col;
+    }
+    return (int)item->status == col;
+}
+
+/* Draw all items filtered into the given column. Shared between the
+ * Status view and the Branch view — the only per-mode difference is
+ * how items are filtered into columns (see item_belongs_in_column())
+ * and how the column-title label is chosen (see tui_draw_board()).
+ *
+ * Card body layout (line 1 + optional line 2) is identical between
+ * modes so operator muscle memory carries across the `b` toggle. */
+static void draw_column_cards(TUIState *state, int col,
+                              int box_y, int box_h,
+                              int content_y, int content_h,
+                              int inner_x, int inner_w) {
+    int card_idx = 0;            /* Logical card index in this column. */
+    int y_used = 0;              /* Screen rows consumed inside content_h. */
+    int scroll = state->scroll_offset[col];
+
+    for (int i = 0; i < state->items.count; i++) {
+        Item *item = &state->items.items[i];
+        if (!item_belongs_in_column(state, item, col)) continue;
+
+        /* Each card consumes 1 line normally, 2 lines if it has any
+         * M48-payload (CVE-ID list or commit SHA). Cursor and scroll
+         * are BOTH in card-index units (see tui_input.c); y_used
+         * tracks the screen-row cost so we know when the column is
+         * full. */
+        bool two_line = m48_should_render_two_lines(item);
+        int rows_used = two_line ? 2 : 1;
+
+        if (card_idx < scroll) {
+            card_idx++;
+            continue;
+        }
+
+        int y = content_y + y_used;
+        if (y >= box_y + box_h - 1) break;
+
+        bool is_current = (col == state->current_col &&
+                           (card_idx - scroll) == state->current_row);
+        bool is_selected = item->selected;
+
+        int priority_color = 0;
+        switch (item->priority) {
+            case PRIORITY_CRITICAL: priority_color = COLOR_PRI_CRIT; break;
+            case PRIORITY_HIGH:     priority_color = COLOR_PRI_HIGH; break;
+            case PRIORITY_MEDIUM:   priority_color = COLOR_PRI_MED; break;
+            default: break;
+        }
+
+        char id_str[16];
+        snprintf(id_str, sizeof(id_str), "%lld", (long long)item->id);
+
+        /* ── Line 1: [sel][id] [branch] title ─────────────────
+         * The branch tag is rendered in its own COLOR_PAIR so the
+         * operator can spot the branch at a glance. Priority still
+         * colors the id, and the current/selected overlay still
+         * paints the title area. */
+        mvprintw(y, inner_x, "%s", is_selected ? "*" : " ");
+
+        if (priority_color && state->use_color) {
+            attron(COLOR_PAIR(priority_color) | A_BOLD);
+        }
+        printw("%s", id_str);
+        if (priority_color && state->use_color) {
+            attroff(COLOR_PAIR(priority_color) | A_BOLD);
+        }
+
+        int consumed = 1 + (int)strlen(id_str);
+
+        if (item->git_branch[0]) {
+            SpagatM48BranchColor bc = m48_branch_color(item->git_branch);
+            int pair = M48_BRANCH_PAIR[bc];
+            /* Truncate the branch string if it would blow past inner_w. */
+            int branch_max = inner_w - consumed - 3;  /* space + [] */
+            if (branch_max < 1) branch_max = 1;
+            char branch_disp[SPAGAT_MAX_BRANCH_LEN];
+            int trunc =
+                branch_max < (int)sizeof(branch_disp) - 1
+                    ? branch_max
+                    : (int)sizeof(branch_disp) - 1;
+            snprintf(branch_disp, trunc + 1, "%s", item->git_branch);
+
+            printw(" ");
+            if (state->use_color) attron(COLOR_PAIR(pair) | A_BOLD);
+            printw("[%s]", branch_disp);
+            if (state->use_color) attroff(COLOR_PAIR(pair) | A_BOLD);
+            consumed += 3 + (int)strlen(branch_disp);
+        }
+
+        if (is_current && is_selected) {
+            if (state->use_color) attron(COLOR_PAIR(COLOR_SELECTED) | A_BOLD);
+        } else if (is_current) {
+            if (state->use_color) attron(COLOR_PAIR(COLOR_CURRENT));
+        } else if (is_selected) {
+            if (state->use_color) attron(COLOR_PAIR(COLOR_SELECTED));
+        }
+
+        int max_title = inner_w - consumed - 1;
+        if (max_title < 1) max_title = 1;
+        char title_part[128];
+        snprintf(title_part,
+                 max_title + 1 > (int)sizeof(title_part)
+                     ? (int)sizeof(title_part)
+                     : max_title + 1,
+                 "%s", item->title);
+        printw(" %s", title_part);
+        consumed += 1 + (int)strlen(title_part);
+
+        int pad = inner_w - consumed;
+        for (int p = 0; p < pad; p++) addch(' ');
+
+        if (is_current || is_selected) {
+            if (state->use_color) attroff(COLOR_PAIR(COLOR_CURRENT) |
+                                          COLOR_PAIR(COLOR_SELECTED) | A_BOLD);
+        }
+
+        /* ── Line 2: CVE-XXXX +N (abcd..) ─────────────────────
+         * Rendered only for cards with M48-payload; skipped for
+         * every legacy row. Same current/selected overlay applies
+         * so a highlighted card still stands out on both lines. */
+        if (two_line && (y + 1) < (box_y + box_h - 1)) {
+            char line2[128];
+            m48_format_card_line2(item, line2, sizeof(line2));
+
+            if (is_current && is_selected) {
+                if (state->use_color)
+                    attron(COLOR_PAIR(COLOR_SELECTED) | A_BOLD);
+            } else if (is_current) {
+                if (state->use_color) attron(COLOR_PAIR(COLOR_CURRENT));
+            } else if (is_selected) {
+                if (state->use_color) attron(COLOR_PAIR(COLOR_SELECTED));
+            } else if (state->use_color) {
+                attron(A_DIM);
+            }
+
+            int max_line2 = inner_w - 1;
+            if (max_line2 < 1) max_line2 = 1;
+            mvprintw(y + 1, inner_x, "%.*s", max_line2, line2);
+            int len2 = (int)strlen(line2);
+            if (len2 > max_line2) len2 = max_line2;
+            int pad2 = inner_w - len2;
+            for (int p = 0; p < pad2; p++) addch(' ');
+
+            if (is_current || is_selected) {
+                if (state->use_color) attroff(COLOR_PAIR(COLOR_CURRENT) |
+                                              COLOR_PAIR(COLOR_SELECTED) |
+                                              A_BOLD);
+            } else if (state->use_color) {
+                attroff(A_DIM);
+            }
+        }
+
+        card_idx++;
+        y_used += rows_used;
+        /* Stop drawing more cards once we've filled content_h. */
+        if (y_used >= content_h) break;
+    }
+}
+
+/* Status board: 6 columns keyed by ItemStatus. Historical default,
+ * behavior verbatim except the shared draw_column_cards() handles
+ * the per-card render. */
+static void draw_status_board(TUIState *state) {
     int box_y = 2;
     int box_h = state->term_height - 3;
     if (box_h < 4) box_h = 4;
     int content_y = box_y + 1;
     int content_h = box_h - 2;
+    int col_count = BOARD_COL_COUNT_STATUS;
+    int base_width = state->term_width / col_count;
+    if (base_width < 12) base_width = 12;
 
-    for (int col = 0; col < STATUS_COUNT; col++) {
-        int x = col * state->col_width;
-        int w = state->col_width;
-        /* Last column takes remaining width */
-        if (col == STATUS_COUNT - 1) w = state->term_width - x;
+    for (int col = 0; col < col_count; col++) {
+        int x = col * base_width;
+        int w = base_width;
+        /* Last column takes remaining width so no gap at the right edge. */
+        if (col == col_count - 1) w = state->term_width - x;
         bool is_active_col = (col == state->current_col);
 
         draw_column_box(box_y, x, box_h, w, is_active_col,
-                       STATUS_DISPLAY[col], state->item_counts[col],
-                       state->use_color);
+                        STATUS_DISPLAY[col], state->item_counts[col],
+                        state->use_color, 0 /* no per-column title color */);
 
-        /* Inner content area: 1 char inside each side border */
         int inner_x = x + 1;
         int inner_w = w - 2;
         if (inner_w < 3) inner_w = 3;
 
-        int row = 0;
-        int scroll = state->scroll_offset[col];
+        draw_column_cards(state, col, box_y, box_h,
+                          content_y, content_h, inner_x, inner_w);
+    }
+}
 
-        for (int i = 0; i < state->items.count && row - scroll < content_h; i++) {
-            Item *item = &state->items.items[i];
-            if ((int)item->status != col) continue;
+/* Branch board: 6 columns keyed by canonical Photon branch (4.0 /
+ * 5.0 / 5.0/SPECS/90 / 5.0/SPECS/91 / 6.0) plus a trailing "Other"
+ * bucket for anything unrecognised or empty. Column-title color
+ * matches the per-card branch badge palette so the operator sees a
+ * consistent color for a given branch across both surfaces. */
+static void draw_branch_board(TUIState *state) {
+    int box_y = 2;
+    int box_h = state->term_height - 3;
+    if (box_h < 4) box_h = 4;
+    int content_y = box_y + 1;
+    int content_h = box_h - 2;
+    int col_count = BOARD_COL_COUNT_BRANCH;
+    int base_width = state->term_width / col_count;
+    if (base_width < 12) base_width = 12;
 
-            if (row < scroll) { row++; continue; }
+    for (int col = 0; col < col_count; col++) {
+        int x = col * base_width;
+        int w = base_width;
+        if (col == col_count - 1) w = state->term_width - x;
+        bool is_active_col = (col == state->current_col);
 
-            int y = content_y + (row - scroll);
-            if (y >= box_y + box_h - 1) break;
-
-            bool is_current = (col == state->current_col &&
-                               (row - scroll) == state->current_row);
-            bool is_selected = item->selected;
-
-            int priority_color = 0;
-            switch (item->priority) {
-                case PRIORITY_CRITICAL: priority_color = COLOR_PRI_CRIT; break;
-                case PRIORITY_HIGH:     priority_color = COLOR_PRI_HIGH; break;
-                case PRIORITY_MEDIUM:   priority_color = COLOR_PRI_MED; break;
-                default: break;
-            }
-
-            char id_str[16];
-            snprintf(id_str, sizeof(id_str), "%lld", (long long)item->id);
-
-            int max_title = inner_w - 2 - (int)strlen(id_str);
-            if (max_title < 1) max_title = 1;
-            char title_part[128];
-            snprintf(title_part, max_title + 1 > (int)sizeof(title_part) ?
-                     (int)sizeof(title_part) : max_title + 1,
-                     "%s", item->title);
-
-            mvprintw(y, inner_x, "%s", is_selected ? "*" : " ");
-
-            if (priority_color && state->use_color) {
-                attron(COLOR_PAIR(priority_color) | A_BOLD);
-            }
-            printw("%s", id_str);
-            if (priority_color && state->use_color) {
-                attroff(COLOR_PAIR(priority_color) | A_BOLD);
-            }
-
-            if (is_current && is_selected) {
-                if (state->use_color) attron(COLOR_PAIR(COLOR_SELECTED) | A_BOLD);
-            } else if (is_current) {
-                if (state->use_color) attron(COLOR_PAIR(COLOR_CURRENT));
-            } else if (is_selected) {
-                if (state->use_color) attron(COLOR_PAIR(COLOR_SELECTED));
-            }
-
-            printw(" %s", title_part);
-
-            int printed = 1 + (int)strlen(id_str) + 1 + (int)strlen(title_part);
-            int pad = inner_w - printed;
-            for (int p = 0; p < pad; p++) addch(' ');
-
-            if (is_current || is_selected) {
-                if (state->use_color) attroff(COLOR_PAIR(COLOR_CURRENT) |
-                                              COLOR_PAIR(COLOR_SELECTED) | A_BOLD);
-            }
-
-            row++;
+        /* Column title color mirrors the branch-badge palette so the
+         * operator can see "5.0/SPECS/91 (12)" in magenta at the top
+         * of the same column that contains magenta-badged cards. The
+         * Other bucket gets the OTHER (white) badge color. */
+        int title_pair = 0;
+        switch (col) {
+            case 0: title_pair = COLOR_PAIR_BRANCH_40;       break;
+            case 1: title_pair = COLOR_PAIR_BRANCH_50;       break;
+            case 2: title_pair = COLOR_PAIR_BRANCH_SPECS_90; break;
+            case 3: title_pair = COLOR_PAIR_BRANCH_SPECS_91; break;
+            case 4: title_pair = COLOR_PAIR_BRANCH_60;       break;
+            case 5: title_pair = COLOR_PAIR_BRANCH_OTHER;    break;
+            default: title_pair = COLOR_COL_TITLE;           break;
         }
+
+        draw_column_box(box_y, x, box_h, w, is_active_col,
+                        BRANCH_COL_DISPLAY[col], state->item_counts[col],
+                        state->use_color, title_pair);
+
+        int inner_x = x + 1;
+        int inner_w = w - 2;
+        if (inner_w < 3) inner_w = 3;
+
+        draw_column_cards(state, col, box_y, box_h,
+                          content_y, content_h, inner_x, inner_w);
+    }
+}
+
+void tui_draw_board(TUIState *state) {
+    if (state->board_mode == BOARD_MODE_BRANCH) {
+        draw_branch_board(state);
+    } else {
+        draw_status_board(state);
     }
 }
 
 void tui_draw_help(TUIState *state) {
-    int w = 60;
-    int h = 30;
+    int w = 68;   /* M48-KanbanCVECard: widened for badge palette hint. */
+    int h = 40;   /* M48-KanbanBranchView: +5 rows for the Views section. */
     int x = (state->term_width - w) / 2;
     int y = (state->term_height - h) / 2;
     if (y < 0) y = 0;
     if (x < 0) x = 0;
-    
+
     tui_draw_box(y, x, h, w, "SPAGAT-Librarian Help");
-    
+
     if (state->use_color) attron(COLOR_PAIR(COLOR_HEADER));
-    
+
     int row = 2;
     mvprintw(y + row++, x + 2, "Navigation:");
     mvprintw(y + row++, x + 4, "h/l/k/j   - Move cursor (or arrow keys)");
     mvprintw(y + row++, x + 4, "1-6       - Jump to column");
     row++;
     mvprintw(y + row++, x + 2, "Basic Actions:");
-    mvprintw(y + row++, x + 4, "a         - Add new item");
-    mvprintw(y + row++, x + 4, "Enter/e   - Edit item (all fields)");
+    mvprintw(y + row++, x + 4, "a         - Add new item (title/desc/tag/branch/commits/CVEs)");
+    mvprintw(y + row++, x + 4, "Enter     - Details popup (full CVE list + commits + description)");
+    mvprintw(y + row++, x + 4, "e         - Edit item (all fields)");
     mvprintw(y + row++, x + 4, "m         - Move selected");
     mvprintw(y + row++, x + 4, "d         - Delete selected");
     mvprintw(y + row++, x + 4, "Space     - Toggle selection");
     mvprintw(y + row++, x + 4, "*         - Select all in column");
     mvprintw(y + row++, x + 4, "/         - Search");
     row++;
+    mvprintw(y + row++, x + 2, "Views:");
+    mvprintw(y + row++, x + 4, "b            Toggle between Status board and Branch board");
+    mvprintw(y + row++, x + 4, "Status view  6 columns by patch lifecycle status (default)");
+    mvprintw(y + row++, x + 4, "Branch view  5 columns by Photon branch");
+    mvprintw(y + row++, x + 4, "             (4.0/5.0/SPECS/90/91/6.0) + Other");
+    row++;
     mvprintw(y + row++, x + 2, "Quick Actions (single field):");
     mvprintw(y + row++, x + 4, "p         - Set priority     P - Select project");
     mvprintw(y + row++, x + 4, "u         - Set due date     T - Create from template");
     mvprintw(y + row++, x + 4, "t         - Time tracking    S - Toggle swimlane");
-    mvprintw(y + row++, x + 4, "s         - Set parent       b - Git branch");
+    mvprintw(y + row++, x + 4, "y         - Set parent       g - Git branch");
     mvprintw(y + row++, x + 4, "x         - Add dependency");
+    row++;
+    mvprintw(y + row++, x + 2, "HITL Approval (T7.16.f5 / #338):");
+    mvprintw(y + row++, x + 4, "v         - Toggle HITL overlay (approval queue)");
+    mvprintw(y + row++, x + 4, "  A/R/D in overlay - Approve / Reject / Details");
     row++;
     mvprintw(y + row++, x + 2, "Priority (shown by ID color):");
     mvprintw(y + row++, x + 4, "Violet=Critical  Red=High  Yellow=Medium");
     row++;
+    mvprintw(y + row++, x + 2, "M48 Card badges (branch color, line 2):");
+    mvprintw(y + row++, x + 4, "Blue=4.0  Green=5.0  Yellow=5.0/SPECS/90");
+    mvprintw(y + row++, x + 4, "Magenta=5.0/SPECS/91  Cyan=6.0  White=other");
+    row++;
     mvprintw(y + row++, x + 2, "Press any key to close...");
-    
+
     if (state->use_color) attroff(COLOR_PAIR(COLOR_HEADER));
-    
+
     refresh();
     timeout(-1);
     getch();

--- a/SPAGAT-Librarian/src/tui/tui_board_mode.c
+++ b/SPAGAT-Librarian/src/tui/tui_board_mode.c
@@ -1,0 +1,61 @@
+/*
+ * tui_board_mode.c — M48-KanbanBranchView board-mode toggle.
+ *
+ * Deliberately isolated from tui_input.c so the pure toggle can be
+ * exercised by unit tests without pulling in ncurses / the DB /
+ * every kanban dialog. Only touches state fields; no I/O; no
+ * ncurses calls. The dispatch in tui_input.c::tui_handle_input()
+ * calls this on `b`.
+ *
+ * Behaviour contract (mirrors the operator scope for the landing):
+ *   1. Flip state->board_mode via board_mode_next().
+ *   2. Reset the cursor to (col=0, row=0) so the operator always
+ *      lands oriented after a toggle (see the "cursor safety" note
+ *      in the M48-KanbanBranchView spec).
+ *   3. Preserve state->scroll_offset[] verbatim so per-column read
+ *      progress survives the toggle.
+ *   4. Rebuild state->item_counts[] against the new mode so the
+ *      column-header count reflects the current filter without a DB
+ *      re-query.
+ *   5. Recompute state->col_width to tile term_width evenly across
+ *      the new column count (subject to a 12-char minimum).
+ *   6. Set needs_refresh so the outer run loop redraws on the next
+ *      tick.
+ *
+ * Session-only: NEVER writes to disk / appliance-config.toml.
+ */
+
+#include "tui.h"
+#include "../util/util.h"
+
+void tui_toggle_board_mode(TUIState *state) {
+    if (!state) return;
+
+    state->board_mode = board_mode_next(state->board_mode);
+    state->current_col = 0;
+    state->current_row = 0;
+
+    for (int i = 0; i < BOARD_COL_COUNT_MAX; i++) {
+        state->item_counts[i] = 0;
+    }
+    if (state->board_mode == BOARD_MODE_BRANCH) {
+        for (int i = 0; i < state->items.count; i++) {
+            int col = branch_column_for(state->items.items[i].git_branch);
+            state->item_counts[col]++;
+        }
+    } else {
+        for (int i = 0; i < state->items.count; i++) {
+            int s = (int)state->items.items[i].status;
+            if (s < 0 || s >= BOARD_COL_COUNT_MAX) continue;
+            state->item_counts[s]++;
+        }
+    }
+
+    if (state->term_width > 0) {
+        state->col_width =
+            state->term_width / board_col_count(state->board_mode);
+        if (state->col_width < 12) state->col_width = 12;
+    }
+
+    state->needs_refresh = true;
+}

--- a/SPAGAT-Librarian/src/tui/tui_common.h
+++ b/SPAGAT-Librarian/src/tui/tui_common.h
@@ -24,6 +24,15 @@
 #define COLOR_PRI_MED   13
 #define COLOR_COL_TITLE 14
 #define COLOR_COL_SEL   15
+/* M48-KanbanCVECard — branch-badge color pairs. Values 20-25 chosen
+ * to leave a gap after the existing palette in case future features
+ * need contiguous slots. Order must match SpagatM48BranchColor. */
+#define COLOR_PAIR_BRANCH_40        20
+#define COLOR_PAIR_BRANCH_50        21
+#define COLOR_PAIR_BRANCH_SPECS_90  22
+#define COLOR_PAIR_BRANCH_SPECS_91  23
+#define COLOR_PAIR_BRANCH_60        24
+#define COLOR_PAIR_BRANCH_OTHER     25
 
 void tui_draw_header(TUIState *state);
 void tui_draw_footer(TUIState *state);
@@ -42,7 +51,15 @@ void tui_toggle_select(TUIState *state);
 void tui_select_all_in_column(TUIState *state);
 void tui_clear_selection(TUIState *state);
 int tui_count_selected(TUIState *state);
+/* M48-KanbanBranchView — see tui.h for contract; declared here too
+ * so translation units that only pull tui_common.h can call it. */
+void tui_toggle_board_mode(TUIState *state);
 
+void tui_dialog_details(TUIState *state);
+/* M48-KanbanCVECard — pure-render form of the details popup. Extracted
+ * so the offscreen-ncurses unit test can drive draw without triggering
+ * the blocking getch() loop inside tui_dialog_details. */
+void tui_details_render_into(const Item *view, int term_w, int term_h);
 void tui_dialog_add(TUIState *state);
 void tui_dialog_move(TUIState *state);
 void tui_dialog_edit(TUIState *state);

--- a/SPAGAT-Librarian/src/tui/tui_details.c
+++ b/SPAGAT-Librarian/src/tui/tui_details.c
@@ -1,0 +1,180 @@
+/*
+ * tui_details.c — M48-KanbanCVECard read-only details popup (pure render).
+ *
+ * Renders the full drill-down for an Item into the current ncurses
+ * SCREEN. This TU carries NO calls to db_item_get / tui_get_current_item
+ * so the offscreen-ncurses unit test can link it directly (see
+ * tests/m48_details_popup_full_test.c). The blocking wrapper that pulls
+ * the current item from the TUIState + spins on getch() lives in
+ * tui_details_open.c.
+ */
+
+#include "tui_common.h"
+#include "spagat_m48.h"
+
+/* Word-wrap `text` to `max_width` columns, printing each line at
+ * (y+row, x). Stops when `max_rows` lines have been emitted. Returns
+ * the number of rows actually printed. Whitespace at the wrap point
+ * is elided; embedded newlines force a wrap. */
+static int wrap_and_print(int y, int x, int max_width, int max_rows,
+                          const char *text) {
+    if (!text || !*text) return 0;
+    int rows = 0;
+    const char *p = text;
+    while (*p && rows < max_rows) {
+        /* Skip leading whitespace on each line. */
+        while (*p == ' ' || *p == '\t') p++;
+        if (!*p) break;
+
+        /* Find the end of this line's slice. */
+        const char *line_start = p;
+        const char *last_space = NULL;
+        int col = 0;
+        while (*p && *p != '\n' && col < max_width) {
+            if (*p == ' ' || *p == '\t') last_space = p;
+            p++;
+            col++;
+        }
+
+        int slice_len;
+        if (*p == '\n') {
+            slice_len = (int)(p - line_start);
+            p++;  /* consume the newline. */
+        } else if (*p == '\0' || col < max_width) {
+            slice_len = (int)(p - line_start);
+        } else if (last_space) {
+            slice_len = (int)(last_space - line_start);
+            p = last_space + 1;
+        } else {
+            /* No space to break on — hard-wrap. */
+            slice_len = col;
+        }
+        mvprintw(y + rows, x, "%.*s", slice_len, line_start);
+        rows++;
+    }
+    return rows;
+}
+
+void tui_details_render_into(const Item *view, int term_w, int term_h) {
+    if (!view) return;
+
+    /* Parse CVE list up front so we can size the popup and later
+     * emit one row per CVE. */
+    SpagatCveList cves;
+    m48_parse_cve_ids(view->cve_ids, &cves);
+
+    /* Sizing:
+     *   base rows: 12 (header + 8 label rows + separator + close hint)
+     *   + 1 per CVE beyond the first (first shares the "CVEs fixed:" row)
+     *   + N rows for wrapped description
+     * Cap to term height so we never over-run the screen. */
+    int desc_rows = 6;
+    int cve_rows = cves.count > 0 ? cves.count : 1;
+    int h = 12 + cve_rows + desc_rows;
+    if (h > term_h - 2) h = term_h - 2;
+    int w = 66;
+    if (w > term_w - 2) w = term_w - 2;
+    int bx = (term_w - w) / 2;
+    int by = (term_h - h) / 2;
+    if (by < 0) by = 0;
+    if (bx < 0) bx = 0;
+
+    tui_draw_box(by, bx, h, w, "Item Details");
+
+    const int label_col = bx + 2;
+    const int value_col = bx + 20;
+    int row = 2;
+
+    mvprintw(by + row, label_col, "ID:");
+    mvprintw(by + row, value_col, "%lld", (long long)view->id);
+    row++;
+
+    mvprintw(by + row, label_col, "Title:");
+    /* Truncate to the popup width so a long title doesn't spill. */
+    mvprintw(by + row, value_col, "%.*s",
+             w - (value_col - bx) - 2, view->title);
+    row++;
+
+    mvprintw(by + row, label_col, "Status:");
+    mvprintw(by + row, value_col, "%s", STATUS_DISPLAY[view->status]);
+    row++;
+
+    mvprintw(by + row, label_col, "Priority:");
+    mvprintw(by + row, value_col, "%s", PRIORITY_DISPLAY[view->priority]);
+    row++;
+
+    mvprintw(by + row, label_col, "Branch:");
+    if (view->git_branch[0]) {
+        SpagatM48BranchColor bc = m48_branch_color(view->git_branch);
+        (void)bc;  /* color palette not applied in details popup for readability */
+        mvprintw(by + row, value_col, "%s", view->git_branch);
+    } else {
+        mvprintw(by + row, value_col, "(none)");
+    }
+    row++;
+
+    mvprintw(by + row, label_col, "Upstream commit:");
+    if (view->upstream_commit[0]) {
+        mvprintw(by + row, value_col, "%.*s",
+                 w - (value_col - bx) - 2, view->upstream_commit);
+    } else {
+        mvprintw(by + row, value_col, "(none)");
+    }
+    row++;
+
+    mvprintw(by + row, label_col, "Backport commit:");
+    if (view->backport_commit[0]) {
+        mvprintw(by + row, value_col, "%.*s",
+                 w - (value_col - bx) - 2, view->backport_commit);
+    } else {
+        mvprintw(by + row, value_col, "(none)");
+    }
+    row++;
+
+    mvprintw(by + row, label_col, "CVEs fixed:");
+    if (cves.count == 0) {
+        mvprintw(by + row, value_col, "(none)");
+        row++;
+    } else {
+        for (int i = 0; i < cves.count && row < h - 2; i++) {
+            mvprintw(by + row, value_col, "%s", cves.entries[i].id);
+            row++;
+        }
+        /* Show a "+N more (truncated)" tail if parsing overflowed. */
+        if (cves.total_parsed > cves.count && row < h - 2) {
+            mvprintw(by + row, value_col, "(+%d more not shown)",
+                     cves.total_parsed - cves.count);
+            row++;
+        }
+        if (cves.had_invalid && row < h - 2) {
+            mvprintw(by + row, value_col, "(malformed CVE-IDs skipped)");
+            row++;
+        }
+    }
+
+    /* Separator before Description. */
+    if (row < h - 3) {
+        mvaddch(by + row, bx, ACS_LTEE);
+        for (int i = 1; i < w - 1; i++)
+            mvaddch(by + row, bx + i, ACS_HLINE);
+        mvaddch(by + row, bx + w - 1, ACS_RTEE);
+        row++;
+    }
+
+    if (row < h - 2) {
+        mvprintw(by + row, label_col, "Description:");
+        row++;
+        int wrap_max = w - 4;
+        int wrap_budget = h - row - 2;
+        if (wrap_budget < 0) wrap_budget = 0;
+        wrap_and_print(by + row, label_col, wrap_max, wrap_budget,
+                       view->description[0] ? view->description : "(none)");
+    }
+
+    /* Footer hint. */
+    attron(A_BOLD);
+    mvprintw(by + h - 2, bx + 2, "[q/Esc] close");
+    attroff(A_BOLD);
+
+    refresh();
+}

--- a/SPAGAT-Librarian/src/tui/tui_details_open.c
+++ b/SPAGAT-Librarian/src/tui/tui_details_open.c
@@ -1,0 +1,33 @@
+/*
+ * tui_details_open.c — M48-KanbanCVECard details popup wrapper.
+ *
+ * Pulls the current item out of the TUIState, fetches a fresh copy
+ * from sqlite (so a just-landed Rust event ingest is reflected), then
+ * calls the pure render function in tui_details.c and spins on getch()
+ * for the operator's close keystroke.
+ *
+ * Kept split from tui_details.c so the render TU is safe to link into
+ * the offscreen-ncurses unit test (m48_details_popup_full_test.c)
+ * without dragging in db_item_get / tui_get_current_item.
+ */
+
+#include "tui_common.h"
+
+void tui_dialog_details(TUIState *state) {
+    Item *item = tui_get_current_item(state);
+    if (!item) return;
+
+    Item view;
+    if (!db_item_get(item->id, &view)) return;
+
+    tui_details_render_into(&view, state->term_width, state->term_height);
+
+    timeout(-1);
+    int ch;
+    do {
+        ch = getch();
+    } while (ch != 27 && ch != 'q' && ch != 'Q' &&
+             ch != '\n' && ch != '\r' && ch != KEY_ENTER);
+    timeout(100);
+    state->needs_refresh = true;
+}

--- a/SPAGAT-Librarian/src/tui/tui_dialogs_misc.c
+++ b/SPAGAT-Librarian/src/tui/tui_dialogs_misc.c
@@ -1,4 +1,5 @@
 #include "tui_common.h"
+#include "spagat_m48.h"
 
 int tui_edit_priority_field(int y, int x, int current_priority, int box_width) {
     int sel = current_priority;
@@ -60,44 +61,136 @@ void tui_dialog_add(TUIState *state) {
     timeout(-1);
     echo();
     curs_set(1);
-    
-    int w = 65;
-    int h = 14;
+
+    /* M48-KanbanCVECard — extended form. Four new fields (Branch,
+     * Upstream commit, Backport commit, CVE-IDs) sit between Tag and
+     * the status footer. Each field is optional; validation lands
+     * inline (invalid → row stays blank, no crash). */
+    int w = 72;
+    int h = 22;
     int x = (state->term_width - w) / 2;
     int y = (state->term_height - h) / 2;
-    
+
     tui_draw_box(y, x, h, w, "Add New Item");
-    
-    mvprintw(y + 2, x + 2, "Title: ");
-    mvprintw(y + 4, x + 2, "Description: ");
-    mvprintw(y + 6, x + 2, "Tag: ");
-    mvprintw(y + 8, x + 2, "Status: %s", STATUS_DISPLAY[state->current_col]);
-    mvprintw(y + 10, x + 2, "Enter=next field, fill Title to save");
+
+    const int label_col = x + 2;
+    const int value_col = x + 20;
+
+    mvprintw(y + 2,  label_col, "Title:");
+    mvprintw(y + 4,  label_col, "Description:");
+    mvprintw(y + 6,  label_col, "Tag:");
+    mvprintw(y + 8,  label_col, "Branch:");
+    mvprintw(y + 10, label_col, "Upstream commit:");
+    mvprintw(y + 12, label_col, "Backport commit:");
+    mvprintw(y + 14, label_col, "CVE-IDs:");
+    mvprintw(y + 14, value_col + 32, "(comma-separated)");
+    /* M48-KanbanBranchView — in Branch view current_col is a branch
+     * column index, not a status. New items in either view default to
+     * the Backlog status (matching the mid-column position operators
+     * expect) so the preview + persisted status stay coherent. */
+    ItemStatus new_status = (state->board_mode == BOARD_MODE_BRANCH)
+        ? STATUS_BACKLOG
+        : (ItemStatus)state->current_col;
+    mvprintw(y + 16, label_col, "Status: %s", STATUS_DISPLAY[new_status]);
+    mvprintw(y + h - 3, label_col,
+             "Enter=next field, fill Title to save. Commits: 40 hex or empty.");
     refresh();
-    
+
     char title[SPAGAT_MAX_TITLE_LEN] = {0};
     char desc[SPAGAT_MAX_DESC_LEN] = {0};
     char tag[SPAGAT_MAX_TAG_LEN] = {0};
-    
-    move(y + 2, x + 15);
+    char branch[SPAGAT_MAX_BRANCH_LEN] = {0};
+    char upstream[SPAGAT_MAX_COMMIT_LEN] = {0};
+    char backport[SPAGAT_MAX_COMMIT_LEN] = {0};
+    char cve_ids[SPAGAT_MAX_CVE_LIST_LEN] = {0};
+
+    move(y + 2, value_col);
     getnstr(title, sizeof(title) - 1);
     str_trim(title);
-    
-    if (title[0]) {
-        move(y + 4, x + 15);
-        getnstr(desc, sizeof(desc) - 1);
-        str_trim(desc);
-        
-        move(y + 6, x + 15);
-        getnstr(tag, sizeof(tag) - 1);
-        str_trim(tag);
-        
-        int64_t id;
-        if (db_item_add(STATUS_NAMES[state->current_col], title, desc, tag, &id)) {
-            tui_refresh_items(state);
+
+    if (!title[0]) {
+        /* Empty title cancels — matches prior behaviour. */
+        noecho();
+        curs_set(0);
+        timeout(100);
+        state->needs_refresh = true;
+        return;
+    }
+
+    move(y + 4, value_col);
+    getnstr(desc, sizeof(desc) - 1);
+    str_trim(desc);
+
+    move(y + 6, value_col);
+    getnstr(tag, sizeof(tag) - 1);
+    str_trim(tag);
+
+    move(y + 8, value_col);
+    getnstr(branch, sizeof(branch) - 1);
+    str_trim(branch);
+
+    move(y + 10, value_col);
+    getnstr(upstream, sizeof(upstream) - 1);
+    str_trim(upstream);
+    if (!m48_validate_commit_sha(upstream)) {
+        /* Silently drop an invalid SHA — operator gets an empty field
+         * on the resulting card rather than a corrupt entry. Row 14
+         * shows a hint about the format. */
+        upstream[0] = '\0';
+    }
+
+    move(y + 12, value_col);
+    getnstr(backport, sizeof(backport) - 1);
+    str_trim(backport);
+    if (!m48_validate_commit_sha(backport)) {
+        backport[0] = '\0';
+    }
+
+    move(y + 14, value_col);
+    getnstr(cve_ids, sizeof(cve_ids) - 1);
+    str_trim(cve_ids);
+    /* Validate at the token level via m48_parse_cve_ids; malformed
+     * tokens are dropped, valid tokens survive verbatim. */
+    if (cve_ids[0]) {
+        SpagatCveList parsed;
+        m48_parse_cve_ids(cve_ids, &parsed);
+        /* If nothing survived, clear the field so it isn't stored. */
+        if (parsed.count == 0) {
+            cve_ids[0] = '\0';
         }
     }
-    
+
+    Item newitem;
+    memset(&newitem, 0, sizeof(newitem));
+    newitem.status = new_status;
+    newitem.priority = PRIORITY_NONE;
+    newitem.project_id = state->current_project;
+    /* M48-KanbanBranchView — when adding from Branch view, seed the
+     * new item's git_branch with the canonical branch of the focused
+     * column (unless it's the Other bucket, which represents "not one
+     * of the canonical branches" and has no single key). The operator
+     * can still override in the Branch: text field above. */
+    if (state->board_mode == BOARD_MODE_BRANCH &&
+        !branch[0] &&
+        state->current_col >= 0 &&
+        state->current_col < BRANCH_COL_COUNT - 1 &&
+        BRANCH_COL_KEYS[state->current_col]) {
+        str_safe_copy(branch, BRANCH_COL_KEYS[state->current_col],
+                      sizeof(branch));
+    }
+    str_safe_copy(newitem.title, title, sizeof(newitem.title));
+    str_safe_copy(newitem.description, desc, sizeof(newitem.description));
+    str_safe_copy(newitem.tag, tag, sizeof(newitem.tag));
+    str_safe_copy(newitem.git_branch, branch, sizeof(newitem.git_branch));
+    str_safe_copy(newitem.upstream_commit, upstream, sizeof(newitem.upstream_commit));
+    str_safe_copy(newitem.backport_commit, backport, sizeof(newitem.backport_commit));
+    str_safe_copy(newitem.cve_ids, cve_ids, sizeof(newitem.cve_ids));
+
+    int64_t id;
+    if (db_item_add_full(&newitem, &id)) {
+        tui_refresh_items(state);
+    }
+
     noecho();
     curs_set(0);
     timeout(100);
@@ -242,11 +335,31 @@ void tui_dialog_search(TUIState *state) {
         for (int i = 0; i < state->items.count; i++) {
             Item *item = &state->items.items[i];
             if (strstr(item->title, query) || strstr(item->description, query) || strstr(item->tag, query)) {
-                state->current_col = item->status;
-                
+                /* M48-KanbanBranchView — jump to the column that
+                 * contains this item in the CURRENT board mode.
+                 * Status view: the column IS the status. Branch view:
+                 * the column is derived from git_branch (Other bucket
+                 * catches empty / unrecognised branches). Row counting
+                 * uses the same filter so the highlight lands on the
+                 * matched card in either view. */
+                int target_col;
+                if (state->board_mode == BOARD_MODE_BRANCH) {
+                    target_col = branch_column_for(item->git_branch);
+                } else {
+                    target_col = (int)item->status;
+                }
+                state->current_col = target_col;
+
                 int row = 0;
                 for (int j = 0; j < i; j++) {
-                    if (state->items.items[j].status == item->status) row++;
+                    Item *prior = &state->items.items[j];
+                    int prior_col;
+                    if (state->board_mode == BOARD_MODE_BRANCH) {
+                        prior_col = branch_column_for(prior->git_branch);
+                    } else {
+                        prior_col = (int)prior->status;
+                    }
+                    if (prior_col == target_col) row++;
                 }
                 state->current_row = row;
                 state->scroll_offset[state->current_col] = 0;

--- a/SPAGAT-Librarian/src/tui/tui_history.c
+++ b/SPAGAT-Librarian/src/tui/tui_history.c
@@ -1,0 +1,488 @@
+/* ---------------------------------------------------------------------------
+ * tui_history.c — Phase-2 implementation of the M18 history view (kanban
+ * view #2). This file is the C-side production replacement for the operator
+ * shim at src/tools/spagat-console-shims/m18_history_probe.py and provides
+ * the definitions for every function declared in
+ *
+ *     src/containers/spagat-console/include/spagat_history.h
+ *
+ * NOTICE / UPSTREAM-WORTHY FRAMING
+ * --------------------------------
+ * This file extends the v0.3.0 ncurses/SQLite spagat-console (memory:
+ * project-existing-v03-console). It is CLI-app territory — operator-facing,
+ * regression-tested, and upstream-worthy. Per
+ * feedback_local_first_test_before_upstream the workflow is:
+ *
+ *     1. operator builds + runs the regression suite in WSL2 / VMware
+ *        Workstation on a Linux host with CMake + ncurses + sqlite3;
+ *     2. only after green smokes does the change get pushed upstream to
+ *        photonos-scripts/SPAGAT-Librarian.
+ *
+ * NEEDS-OPERATOR-VALIDATION-IN-WSL2
+ * ---------------------------------
+ * I (the agent) cannot compile this on the appliance Windows host. The
+ * operator validates by running, on a Linux host:
+ *
+ *     make -C src/containers/spagat-console build
+ *
+ * (CMake + ncurses + sqlite3 toolchain). Every NEEDS-OPERATOR-VALIDATION-
+ * IN-WSL2 marker below flags a syscall or third-party API surface that the
+ * agent could not link/compile here and that the operator MUST exercise on
+ * the reference WSL/Linux host before any upstream push.
+ *
+ * Cross-references
+ * ----------------
+ *   - Header / contract:        src/containers/spagat-console/include/spagat_history.h
+ *   - Design doc (normative):   docs/M18-history-view-design.md
+ *   - Acceptance fixtures:      tests/fixtures/m18-acceptance.yaml
+ *                               (15 fixtures M18-1 .. M18-15)
+ *   - Python sibling shim:      src/tools/spagat-console-shims/m18_history_probe.py
+ *                               (mirrors the same contract from outside the
+ *                               C tree; this file's algorithm choices
+ *                               follow it unless the C-side has a clearly
+ *                               better option, in which case see the
+ *                               NEEDS-V3-OPTIMIZATION markers below)
+ *   - Parent style header:      src/containers/spagat-console/include/spagat.h
+ *   - Sibling tui_*.c pattern:  src/containers/spagat-console/src/tui/tui_dialogs.c
+ *   - Project helpers:          src/containers/spagat-console/src/util/util.h
+ *
+ * Driving rule: feedback-no-guess-lowest-impact-per-step — when a syscall
+ * constant, ncurses function, or sqlite3 API is uncertain the call is
+ * paired with a NEEDS-OPERATOR-VALIDATION-IN-WSL2 marker rather than
+ * invented out of thin air.
+ * ---------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "spagat_history.h"
+#include "../util/util.h"
+
+/* sqlite3 is the storage layer per ADR-0022 D3 (WAL mode, NORMAL sync).
+ * NEEDS-OPERATOR-VALIDATION-IN-WSL2: <sqlite3.h> is not present on the
+ * agent's Windows host; the operator must confirm the include path resolves
+ * against the appliance Linux toolchain (libsqlite3-dev). */
+#include <sqlite3.h>
+
+/* --------------------------------------------------------------------------
+ * File-internal state. The header documents that the connection is
+ * process-global ("callers MUST pair every successful open() with a
+ * close()"), so the SQLite handle lives as a static module global.
+ * No other globals — keeps the surface composable.
+ * -------------------------------------------------------------------------- */
+static sqlite3 *g_history_db = NULL;
+
+/* Initial reserve for result arrays. Pagination caps at 100 rows
+ * (M18-15 / SpagatHistoryQuery.limit default), so 16 is a sane first hop
+ * before we grow geometrically. */
+#define HISTORY_INITIAL_CAP 16
+
+/* Schema mirrors the Python shim verbatim (m18_history_probe.py _SCHEMA)
+ * so the two implementations stay byte-compatible on the same DB file. */
+static const char *kHistorySchemaSQL =
+    "CREATE TABLE IF NOT EXISTS history_records ("
+    "    event_id       TEXT PRIMARY KEY,"
+    "    package        TEXT,"
+    "    verdict        TEXT,"
+    "    timestamp      INTEGER NOT NULL,"
+    "    severity       TEXT NOT NULL,"
+    "    rpm_nvr        TEXT,"
+    "    provenance     TEXT,"
+    "    ttl_expires_at INTEGER"
+    ");"
+    "CREATE INDEX IF NOT EXISTS h_by_ts       ON history_records (timestamp DESC);"
+    "CREATE INDEX IF NOT EXISTS h_by_package  ON history_records (package);"
+    "CREATE INDEX IF NOT EXISTS h_by_verdict  ON history_records (verdict);"
+    "CREATE INDEX IF NOT EXISTS h_by_severity ON history_records (severity);"
+    "CREATE INDEX IF NOT EXISTS h_by_ttl"
+    "    ON history_records (ttl_expires_at)"
+    "    WHERE ttl_expires_at IS NOT NULL;";
+
+/* Mapping from the SpagatHistorySeverity enum to the TEXT representation
+ * stored in the `severity` column. Index by enum value. */
+static const char *kSeverityNames[] = {
+    "CRITICAL", /* SEV_CRITICAL = 0 */
+    "HIGH",     /* SEV_HIGH     = 1 */
+    "MEDIUM",   /* SEV_MEDIUM   = 2 */
+    "LOW",      /* SEV_LOW      = 3 */
+    "INFO"      /* SEV_INFO     = 4 */
+};
+#define HISTORY_SEVERITY_COUNT \
+    ((int)(sizeof(kSeverityNames) / sizeof(kSeverityNames[0])))
+
+/* Reverse map: severity TEXT -> SpagatHistorySeverity. Defaults to
+ * SEV_INFO for unrecognised values (the most permissive bucket — matches
+ * the shim's behaviour when severity is missing from a source record). */
+static SpagatHistorySeverity history_severity_from_text(const char *text) {
+    if (text != NULL) {
+        for (int i = 0; i < HISTORY_SEVERITY_COUNT; i++) {
+            if (str_equals_ignore_case(text, kSeverityNames[i])) {
+                return (SpagatHistorySeverity)i;
+            }
+        }
+    }
+    return SEV_INFO;
+}
+
+/* spagat_history.h line 112:
+ *   int spagat_history_open(const char *db_path);
+ *
+ * Open (and lazily initialise) the history SQLite database. Mirrors the
+ * Python shim's open_db() — WAL mode, synchronous=NORMAL, schema applied
+ * idempotently. On first open we additionally run PRAGMA integrity_check
+ * per M18-12; a non-"ok" verdict closes the handle and returns -1 so the
+ * caller can trigger the rebuild-from-sources path documented in the
+ * design doc §6.
+ *
+ * Acceptance: M18-1 (indexer ingest), M18-2 (open-and-render budget),
+ *             M18-12 (integrity-check at startup). */
+int spagat_history_open(const char *db_path) {
+    if (db_path == NULL || db_path[0] == '\0') return -1;
+    if (g_history_db != NULL) return 0; /* already open — idempotent */
+
+    /* NEEDS-OPERATOR-VALIDATION-IN-WSL2: sqlite3_open_v2 + SQLITE_OPEN_*
+     * flags are sqlite3-amalgamation specific; verify the link line in
+     * src/containers/spagat-console/CMakeLists.txt picks up libsqlite3. */
+    int rc = sqlite3_open_v2(
+        db_path, &g_history_db,
+        SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, NULL);
+    if (rc != SQLITE_OK) {
+        if (g_history_db != NULL) {
+            sqlite3_close(g_history_db);
+            g_history_db = NULL;
+        }
+        return -1;
+    }
+
+    /* ADR-0022 D3: WAL mode + NORMAL sync. Failure to set these is not
+     * fatal (the DB still opens) but logged-via-return so callers can
+     * downgrade gracefully. */
+    char *err = NULL;
+    (void)sqlite3_exec(g_history_db, "PRAGMA journal_mode=WAL;", NULL, NULL, &err);
+    if (err != NULL) { sqlite3_free(err); err = NULL; }
+    (void)sqlite3_exec(g_history_db, "PRAGMA synchronous=NORMAL;", NULL, NULL, &err);
+    if (err != NULL) { sqlite3_free(err); err = NULL; }
+
+    /* Apply schema idempotently. The CREATE statements use IF NOT EXISTS
+     * so this is safe on every open. */
+    rc = sqlite3_exec(g_history_db, kHistorySchemaSQL, NULL, NULL, &err);
+    if (rc != SQLITE_OK) {
+        if (err != NULL) sqlite3_free(err);
+        sqlite3_close(g_history_db);
+        g_history_db = NULL;
+        return -1;
+    }
+
+    /* M18-12: PRAGMA integrity_check at first open. A non-"ok" verdict
+     * signals corruption; we close + return -1 so the caller can rebuild
+     * from the federated sources (see design doc §6). */
+    sqlite3_stmt *stmt = NULL;
+    rc = sqlite3_prepare_v2(g_history_db, "PRAGMA integrity_check;", -1, &stmt, NULL);
+    if (rc == SQLITE_OK && stmt != NULL) {
+        bool integrity_ok = false;
+        if (sqlite3_step(stmt) == SQLITE_ROW) {
+            const unsigned char *verdict = sqlite3_column_text(stmt, 0);
+            if (verdict != NULL && strcmp((const char *)verdict, "ok") == 0) {
+                integrity_ok = true;
+            }
+        }
+        sqlite3_finalize(stmt);
+        if (!integrity_ok) {
+            sqlite3_close(g_history_db);
+            g_history_db = NULL;
+            return -1;
+        }
+    }
+    /* If prepare failed (very old sqlite3) we deliberately fall through —
+     * integrity_check is best-effort hardening, not load-bearing for
+     * basic reads. */
+
+    return 0;
+}
+
+/* spagat_history.h line 118:
+ *   void spagat_history_close(void);
+ *
+ * Close the indexer DB. Safe to call when no DB is open — the function
+ * is idempotent so the M18-12 rebuild path can call close() blindly
+ * before re-opening.
+ *
+ * Acceptance: M18-12 (clean shutdown is part of the rebuild path). */
+void spagat_history_close(void) {
+    if (g_history_db != NULL) {
+        /* sqlite3_close flushes any pending WAL frames via its checkpoint
+         * on close. */
+        sqlite3_close(g_history_db);
+        g_history_db = NULL;
+    }
+}
+
+/* spagat_history.h line 136-138:
+ *   int spagat_history_query(const SpagatHistoryQuery *q,
+ *                            SpagatHistoryRecord **out,
+ *                            size_t *n_out);
+ *
+ * Run a parameterised query against the history index. Algorithm follows
+ * the Python shim's query() byte-for-byte: each filter is bound via `?`
+ * placeholders (M18-14), severity is treated as a numeric lower-bound
+ * filter expanded into an `IN (?,?,...)` allowlist of severity texts, and
+ * rows are ordered by timestamp DESC for the F2 default render.
+ *
+ * Acceptance: M18-3 (incremental filter latency), M18-4 (compound filter
+ *             AND semantics), M18-7 (view_audit per search — TODO see
+ *             NEEDS-V3-OPTIMIZATION below), M18-14 (SQL injection probe →
+ *             0 rows, no schema effect), M18-15 (pagination cursor for
+ *             > 100 row result sets — caller enforces limit). */
+int spagat_history_query(const SpagatHistoryQuery *q,
+                         SpagatHistoryRecord **out,
+                         size_t *n_out) {
+    if (out == NULL || n_out == NULL) return -1;
+    *out = NULL;
+    *n_out = 0;
+    if (q == NULL || g_history_db == NULL) return -1;
+
+    /* Build the SQL incrementally. Every filter compiles to a bound
+     * placeholder — see M18-14 (`pkg:'; DROP TABLE ...` becomes a literal
+     * substring under `package LIKE ?` and returns 0 rows). */
+    char sql[2048];
+    int written = snprintf(sql, sizeof(sql),
+        "SELECT event_id, package, verdict, timestamp, severity, rpm_nvr "
+        "FROM history_records WHERE 1=1");
+    if (written < 0 || (size_t)written >= sizeof(sql)) return -1;
+
+    if (q->package != NULL) {
+        written += snprintf(sql + written, sizeof(sql) - written,
+                            " AND package LIKE ?");
+    }
+    if (q->verdict != NULL) {
+        written += snprintf(sql + written, sizeof(sql) - written,
+                            " AND verdict = ?");
+    }
+    if (q->since != 0) {
+        written += snprintf(sql + written, sizeof(sql) - written,
+                            " AND timestamp >= ?");
+    }
+    if (q->until != 0) {
+        written += snprintf(sql + written, sizeof(sql) - written,
+                            " AND timestamp < ?");
+    }
+
+    /* Severity allowlist: SEV_CRITICAL (0) is most severe; min_severity
+     * is the LEAST-restrictive bucket the caller will accept, so rows
+     * whose severity rank is <= min_severity rank are returned. We expand
+     * to `severity IN (?,?,...)` with one placeholder per allowed name
+     * to keep the SQL parameterised (no string concatenation of values). */
+    int sev_lo = 0;
+    int sev_hi = (int)q->min_severity;
+    if (sev_hi < 0) sev_hi = 0;
+    if (sev_hi >= HISTORY_SEVERITY_COUNT) sev_hi = HISTORY_SEVERITY_COUNT - 1;
+    int sev_count = sev_hi - sev_lo + 1;
+
+    written += snprintf(sql + written, sizeof(sql) - written,
+                        " AND severity IN (");
+    for (int i = 0; i < sev_count; i++) {
+        written += snprintf(sql + written, sizeof(sql) - written,
+                            "%s?", i == 0 ? "" : ",");
+    }
+    written += snprintf(sql + written, sizeof(sql) - written, ")");
+
+    int limit = q->limit > 0 ? q->limit : 100; /* M18-15 default page */
+    int offset = q->offset > 0 ? q->offset : 0;
+    written += snprintf(sql + written, sizeof(sql) - written,
+                        " ORDER BY timestamp DESC LIMIT ? OFFSET ?");
+    if (written < 0 || (size_t)written >= sizeof(sql)) return -1;
+
+    sqlite3_stmt *stmt = NULL;
+    /* NEEDS-OPERATOR-VALIDATION-IN-WSL2: sqlite3_prepare_v2 link surface;
+     * verify against the appliance toolchain. */
+    int rc = sqlite3_prepare_v2(g_history_db, sql, -1, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        if (stmt != NULL) sqlite3_finalize(stmt);
+        return -1;
+    }
+
+    /* Bind in the same order as the clauses were appended. */
+    int bind_idx = 1;
+    char like_buf[SPAGAT_HISTORY_MAX_PACKAGE_LEN + 4];
+    if (q->package != NULL) {
+        snprintf(like_buf, sizeof(like_buf), "%%%s%%", q->package);
+        sqlite3_bind_text(stmt, bind_idx++, like_buf, -1, SQLITE_TRANSIENT);
+    }
+    if (q->verdict != NULL) {
+        sqlite3_bind_text(stmt, bind_idx++, q->verdict, -1, SQLITE_TRANSIENT);
+    }
+    if (q->since != 0) {
+        sqlite3_bind_int64(stmt, bind_idx++, (sqlite3_int64)q->since);
+    }
+    if (q->until != 0) {
+        sqlite3_bind_int64(stmt, bind_idx++, (sqlite3_int64)q->until);
+    }
+    for (int i = 0; i < sev_count; i++) {
+        sqlite3_bind_text(stmt, bind_idx++, kSeverityNames[sev_lo + i],
+                          -1, SQLITE_STATIC);
+    }
+    sqlite3_bind_int(stmt, bind_idx++, limit);
+    sqlite3_bind_int(stmt, bind_idx++, offset);
+
+    /* Materialise rows. Grow geometrically — the header guarantees the
+     * caller frees via spagat_history_free_results, so this single buffer
+     * is the only owned allocation. */
+    size_t cap = HISTORY_INITIAL_CAP;
+    size_t n = 0;
+    SpagatHistoryRecord *buf = calloc(cap, sizeof(*buf));
+    if (buf == NULL) {
+        sqlite3_finalize(stmt);
+        return -1;
+    }
+
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        if (n == cap) {
+            size_t new_cap = cap * 2;
+            SpagatHistoryRecord *grown = realloc(buf, new_cap * sizeof(*grown));
+            if (grown == NULL) {
+                free(buf);
+                sqlite3_finalize(stmt);
+                return -1;
+            }
+            memset(grown + cap, 0, (new_cap - cap) * sizeof(*grown));
+            buf = grown;
+            cap = new_cap;
+        }
+
+        SpagatHistoryRecord *r = &buf[n];
+        const unsigned char *event_id = sqlite3_column_text(stmt, 0);
+        const unsigned char *package  = sqlite3_column_text(stmt, 1);
+        const unsigned char *verdict  = sqlite3_column_text(stmt, 2);
+        sqlite3_int64 ts              = sqlite3_column_int64(stmt, 3);
+        const unsigned char *sev_text = sqlite3_column_text(stmt, 4);
+        const unsigned char *rpm_nvr  = sqlite3_column_text(stmt, 5);
+
+        str_safe_copy(r->event_id,
+                      event_id ? (const char *)event_id : "",
+                      sizeof(r->event_id));
+        str_safe_copy(r->package,
+                      package ? (const char *)package : "",
+                      sizeof(r->package));
+        str_safe_copy(r->verdict,
+                      verdict ? (const char *)verdict : "",
+                      sizeof(r->verdict));
+        r->timestamp = (time_t)ts;
+        r->severity = history_severity_from_text((const char *)sev_text);
+        str_safe_copy(r->rpm_nvr,
+                      rpm_nvr ? (const char *)rpm_nvr : "",
+                      sizeof(r->rpm_nvr));
+        n++;
+    }
+    sqlite3_finalize(stmt);
+
+    /* NEEDS-V3-OPTIMIZATION (M18-7): the Python shim does NOT emit the
+     * view_audit row — that is a TUI-side concern (operator_id + query
+     * literal are TUI state, not part of the SQLite contract). The C
+     * caller (tui_history view loop) is responsible for the INSERT into
+     * view_audit after this function returns. Documented here so future
+     * readers don't expect this function to do it. */
+
+    *out = buf;
+    *n_out = n;
+    return (int)n;
+}
+
+/* spagat_history.h line 144:
+ *   void spagat_history_free_results(SpagatHistoryRecord *recs, size_t n);
+ *
+ * Release the result array returned by spagat_history_query(). Safe to
+ * call with recs == NULL && n == 0 per the header contract. The records
+ * themselves carry only fixed-size char arrays (no nested allocations),
+ * so a single free() on the outer block is sufficient.
+ *
+ * Acceptance: M18-2 (no leak across repeated F2 renders). */
+void spagat_history_free_results(SpagatHistoryRecord *recs, size_t n) {
+    (void)n; /* n is informational — the malloc'd block is the array. */
+    if (recs != NULL) {
+        free(recs);
+    }
+}
+
+/* spagat_history.h line 164:
+ *   int spagat_history_compute_ttl(SpagatHistorySeverity sev, bool has_rpm_nvr);
+ *
+ * Per-record TTL in days. Ladder mirrors the Python shim's
+ * TTL_DAYS_BY_SEVERITY map byte-for-byte and is normatively documented in
+ * docs/M18-history-view-design.md §3. Signed-release records
+ * (has_rpm_nvr == true) get -1 unconditionally (the M18-9 hard floor).
+ *
+ * Acceptance: M18-8 (TTL purge derives ttl_expires_at from this value),
+ *             M18-9 (signed-release hard floor), M18-10 (kev_listed
+ *             doubling applies on top of this base, in the caller). */
+int spagat_history_compute_ttl(SpagatHistorySeverity sev, bool has_rpm_nvr) {
+    /* M18-9 hard floor: signed material is forever-keep regardless of
+     * severity. Operator policy cannot widen this — enforced here AND
+     * in the SQL of spagat_history_purge_expired below. */
+    if (has_rpm_nvr) return -1;
+
+    switch (sev) {
+        case SEV_CRITICAL: return -1;  /* forever — DORA Art 13 / NIS2 */
+        case SEV_HIGH:     return 730; /* 2 yr — CRA Art 13 minimum */
+        case SEV_MEDIUM:   return 365; /* 1 yr — operational reuse */
+        case SEV_LOW:      return 180; /* ~6 mo — operational debugging */
+        case SEV_INFO:     return 90;  /* 3 mo — non-CVE chatter */
+    }
+    /* Defensive — an out-of-range enum gets the most-permissive bucket
+     * so we never accidentally return -1 (forever-keep) for an unknown
+     * severity. Mirrors the shim's ValueError but without aborting. */
+    return 90;
+}
+
+/* spagat_history.h line 177:
+ *   int spagat_history_purge_expired(time_t now);
+ *
+ * Delete every row whose ttl_expires_at < now AND whose provenance is
+ * not 'signed'. The signed-release hard floor (M18-9) is baked into the
+ * SQL — operator policy cannot widen it. Mirrors the Python shim's
+ * purge_expired() exactly.
+ *
+ * Acceptance: M18-8 (TTL_REDACT per purge — see NEEDS-V3-OPTIMIZATION
+ *             below; the audit emission is a TUI/scheduler concern, not
+ *             part of the SQLite contract), M18-9 (signed floor enforced
+ *             in SQL), M18-13 (view_audit table is NEVER purged by this
+ *             function — the WHERE clause targets only history_records). */
+int spagat_history_purge_expired(time_t now) {
+    if (g_history_db == NULL) return -1;
+
+    static const char *kPurgeSQL =
+        "DELETE FROM history_records "
+        "WHERE ttl_expires_at IS NOT NULL "
+        "  AND ttl_expires_at < ? "
+        "  AND (provenance IS NULL OR provenance != 'signed')";
+
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2(g_history_db, kPurgeSQL, -1, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        if (stmt != NULL) sqlite3_finalize(stmt);
+        return -1;
+    }
+    sqlite3_bind_int64(stmt, 1, (sqlite3_int64)now);
+    rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    if (rc != SQLITE_DONE) return -1;
+
+    int purged = sqlite3_changes(g_history_db);
+
+    /* NEEDS-V3-OPTIMIZATION (M18-8): the TTL_REDACT row(s) in view_audit
+     * are emitted by the spec-038 scheduler (the caller of this function)
+     * once it knows the operator's last-applied policy hash. Emitting it
+     * here would require pulling the policy file into the SQLite contract,
+     * which we deliberately keep out per the layering in ADR-0022 D8.
+     * Documented here so future readers don't double-count. */
+
+    return purged;
+}
+
+/* End of tui_history.c — 6 public functions implemented, all signatures
+ * verified verbatim against spagat_history.h (see line-quoted citations
+ * above each function). */

--- a/SPAGAT-Librarian/src/tui/tui_input.c
+++ b/SPAGAT-Librarian/src/tui/tui_input.c
@@ -1,18 +1,66 @@
 #include "tui_common.h"
+#include "spagat_m48.h"
+
+/* M48-KanbanBranchView — item→column filter mirrors the one in
+ * tui_board.c::item_belongs_in_column so the input dispatcher and
+ * the renderer agree on what "current column" means under both
+ * board modes. */
+static bool input_item_belongs_in_column(const TUIState *state,
+                                         const Item *item, int col) {
+    if (state->board_mode == BOARD_MODE_BRANCH) {
+        return branch_column_for(item->git_branch) == col;
+    }
+    return (int)item->status == col;
+}
+
+/* M48-KanbanCVECard — compute how many cards fit above the fold when
+ * cards can render as either 1 or 2 lines. Walks the items list from
+ * the given scroll offset until the summed rows_used exceeds
+ * content_h. Returns the count of card slots that fit; the caller
+ * uses it to cap `current_row` so the cursor never lands off-screen.
+ *
+ * M48-KanbanBranchView: filter is now board_mode-aware so branch view
+ * scroll bounds are computed against branch-column membership, not
+ * status. */
+static int m48_visible_card_count(const TUIState *state, int col,
+                                  int scroll, int content_h) {
+    int skipped = 0;
+    int y_used = 0;
+    int visible = 0;
+    for (int i = 0; i < state->items.count; i++) {
+        const Item *item = &state->items.items[i];
+        if (!input_item_belongs_in_column(state, item, col)) continue;
+        if (skipped < scroll) { skipped++; continue; }
+        int rows_used = m48_should_render_two_lines(item) ? 2 : 1;
+        if (y_used + rows_used > content_h) break;
+        y_used += rows_used;
+        visible++;
+    }
+    if (visible < 1) visible = 1;  /* Always leave room for the cursor. */
+    return visible;
+}
 
 Item *tui_get_current_item(TUIState *state) {
     int target_row = state->current_row + state->scroll_offset[state->current_col];
     int row = 0;
     for (int i = 0; i < state->items.count; i++) {
         Item *item = &state->items.items[i];
-        if ((int)item->status != state->current_col) continue;
-        
+        if (!input_item_belongs_in_column(state, item, state->current_col)) {
+            continue;
+        }
+
         if (row == target_row) {
             return item;
         }
         row++;
     }
     return NULL;
+}
+
+/* Current mode's active column count — status view uses 6 status
+ * columns; branch view uses the 5 canonical + Other = 6 columns. */
+static int current_board_col_count(const TUIState *state) {
+    return board_col_count(state->board_mode);
 }
 
 void tui_move_cursor_left(TUIState *state) {
@@ -25,7 +73,7 @@ void tui_move_cursor_left(TUIState *state) {
 }
 
 void tui_move_cursor_right(TUIState *state) {
-    if (state->current_col < STATUS_COUNT - 1) {
+    if (state->current_col < current_board_col_count(state) - 1) {
         state->current_col++;
         state->current_row = 0;
         state->scroll_offset[state->current_col] = 0;
@@ -45,11 +93,19 @@ void tui_move_cursor_up(TUIState *state) {
 
 void tui_move_cursor_down(TUIState *state) {
     int max_row = state->item_counts[state->current_col] - 1;
-    int visible_rows = state->term_height - 6;
-    int current_abs = state->current_row + state->scroll_offset[state->current_col];
-    
+    /* M48-KanbanCVECard: content_h is the interior of the column
+     * box (box_h - 2), and box_h = term_height - 3. So content_h =
+     * term_height - 5. We ask m48_visible_card_count() how many
+     * cards actually fit under that budget at the current scroll. */
+    int content_h = state->term_height - 5;
+    if (content_h < 1) content_h = 1;
+    int scroll = state->scroll_offset[state->current_col];
+    int visible_cards = m48_visible_card_count(state, state->current_col,
+                                                scroll, content_h);
+    int current_abs = state->current_row + scroll;
+
     if (current_abs < max_row) {
-        if (state->current_row < visible_rows - 1) {
+        if (state->current_row < visible_cards - 1) {
             state->current_row++;
         } else {
             state->scroll_offset[state->current_col]++;
@@ -57,6 +113,10 @@ void tui_move_cursor_down(TUIState *state) {
         state->needs_refresh = true;
     }
 }
+
+/* tui_toggle_board_mode is defined in src/tui/tui_board_mode.c — the
+ * TU is deliberately ncurses-free so unit tests can link it without
+ * pulling the full tui_input.c web of DB + dialog dependencies. */
 
 void tui_toggle_select(TUIState *state) {
     Item *item = tui_get_current_item(state);
@@ -67,8 +127,13 @@ void tui_toggle_select(TUIState *state) {
 }
 
 void tui_select_all_in_column(TUIState *state) {
+    /* M48-KanbanBranchView — respect current board mode so `*` in
+     * Branch view selects every item in the current branch column,
+     * matching the visible highlight. */
     for (int i = 0; i < state->items.count; i++) {
-        if ((int)state->items.items[i].status == state->current_col) {
+        if (input_item_belongs_in_column(state,
+                                         &state->items.items[i],
+                                         state->current_col)) {
             state->items.items[i].selected = true;
         }
     }
@@ -220,9 +285,83 @@ void tui_format_history(const char *history, char *out, int out_size) {
 
 void tui_handle_input(TUIState *state) {
     int ch = getch();
-    
+
     if (ch == ERR) return;
-    
+
+    /* ADR-0055.f9 — Settings overlay is modal (like HITL). Handle it
+     * first so a stray kanban keypress doesn't leak underneath. */
+    if (state->settings && state->settings->active) {
+        int exit_now = spagat_settings_handle_key(state->settings, ch);
+        state->needs_refresh = true;
+        (void)exit_now; /* Toggle already flipped `active` if needed. */
+        return;
+    }
+
+    /* T7.16.f5 / #338 — HITL overlay takes precedence for A/R/D/j/k
+     * keys when active. `v` toggles in/out from either side; `q`
+     * still quits the whole TUI for operator escape consistency. */
+    if (state->hitl.active) {
+        switch (ch) {
+            case 'v':
+            case 'V':
+                hitl_toggle(&state->hitl);
+                state->needs_refresh = true;
+                return;
+            case 'A':
+                /* Refresh first to absorb any verdicts that landed
+                 * since the last poll tick, then decide. */
+                hitl_refresh(&state->hitl);
+                hitl_decide(&state->hitl, true);
+                state->needs_refresh = true;
+                return;
+            case 'R':
+                hitl_refresh(&state->hitl);
+                hitl_decide(&state->hitl, false);
+                state->needs_refresh = true;
+                return;
+            case 'D':
+                tui_hitl_show_details(&state->hitl, state->term_height,
+                                      state->term_width);
+                state->needs_refresh = true;
+                return;
+            case 'j':
+            case KEY_DOWN:
+                hitl_cursor_down(&state->hitl);
+                state->needs_refresh = true;
+                return;
+            case 'k':
+            case KEY_UP:
+                hitl_cursor_up(&state->hitl);
+                state->needs_refresh = true;
+                return;
+            case 'q':
+            case 'Q':
+                state->running = false;
+                return;
+            case KEY_RESIZE:
+                getmaxyx(stdscr, state->term_height, state->term_width);
+                state->col_width =
+                    state->term_width / current_board_col_count(state);
+                if (state->col_width < 12) state->col_width = 12;
+                state->needs_refresh = true;
+                return;
+            default:
+                /* Swallow all other keys while overlay is active so a
+                 * stray 'd' (kanban delete) doesn't fire underneath. */
+                return;
+        }
+    }
+
+    /* Toggle into the overlay from the kanban side. Uses lowercase
+     * 'v' to avoid colliding with existing kanban bindings (A/R/D
+     * are all already taken by add/refresh/delete). */
+    if (ch == 'v' || ch == 'V') {
+        hitl_toggle(&state->hitl);
+        if (state->hitl.active) hitl_refresh(&state->hitl);
+        state->needs_refresh = true;
+        return;
+    }
+
     switch (ch) {
         case 'q':
         case 'Q':
@@ -249,11 +388,15 @@ void tui_handle_input(TUIState *state) {
             tui_move_cursor_down(state);
             break;
             
-        case '1': case '2': case '3': case '4': case '5': case '6':
-            state->current_col = ch - '1';
+        case '1': case '2': case '3': case '4': case '5': case '6': {
+            int req = ch - '1';
+            int max_col = current_board_col_count(state) - 1;
+            if (req > max_col) req = max_col;
+            state->current_col = req;
             state->current_row = 0;
             state->needs_refresh = true;
             break;
+        }
             
         case ' ':
             tui_toggle_select(state);
@@ -270,9 +413,15 @@ void tui_handle_input(TUIState *state) {
             tui_dialog_move(state);
             break;
             
+        /* M48-KanbanCVECard: Enter opens the read-only details popup
+         * (full CVE list, full 40-hex commits, description). `e`/`E`
+         * still opens the full edit dialog for round-trip editing. */
         case KEY_ENTER:
         case '\n':
         case '\r':
+            tui_dialog_details(state);
+            break;
+
         case 'e':
         case 'E':
             tui_dialog_edit(state);
@@ -307,7 +456,11 @@ void tui_handle_input(TUIState *state) {
             
         case KEY_RESIZE:
             getmaxyx(stdscr, state->term_height, state->term_width);
-            state->col_width = state->term_width / STATUS_COUNT;
+            /* M48-KanbanBranchView: column width tracks the currently
+             * active board mode so a resize while in Branch view lays
+             * out to 6 branch columns, not 6 status columns. */
+            state->col_width =
+                state->term_width / current_board_col_count(state);
             if (state->col_width < 12) state->col_width = 12;
             state->needs_refresh = true;
             break;
@@ -332,18 +485,52 @@ void tui_handle_input(TUIState *state) {
             tui_dialog_select_template(state);
             break;
             
+        /* M48-KanbanBranchView — `b` now toggles the Kanban board
+         * between Status view (6 status columns, default) and Branch
+         * view (5 canonical Photon branches + Other). Session-only,
+         * not persisted to appliance-config.toml. Guarded so an
+         * accidental `b` during an active HITL / Settings overlay
+         * doesn't toggle a hidden board underneath — the overlay
+         * handlers above already returned before reaching here so
+         * this is a belt-and-braces check. The git-branch quick
+         * action moves to `g` (Git). */
         case 'b':
+            if (!state->hitl.active &&
+                !(state->settings && state->settings->active)) {
+                tui_toggle_board_mode(state);
+            }
+            break;
+
+        case 'g':
+        case 'G':
             tui_dialog_git_branch(state);
             break;
-            
+
         case 'x':
             tui_dialog_add_dependency(state);
             break;
-            
+
+        /* ADR-0055.f9 — `s` toggles read-only Settings mode. The old
+         * `s = set_parent` binding moves to `y` (yank-as-child) to
+         * free the top-bar menu key documented in ADR-0055 §5. Load
+         * lazily on first press to avoid touching the config file at
+         * TUI startup. */
         case 's':
+            if (!state->settings) {
+                state->settings = spagat_settings_load(
+                    spagat_settings_effective_path());
+            }
+            if (state->settings) {
+                spagat_settings_toggle(state->settings);
+                state->needs_refresh = true;
+            }
+            break;
+
+        case 'y':
+        case 'Y':
             tui_dialog_set_parent(state);
             break;
-            
+
         case 'S':
             tui_toggle_swimlane_mode(state);
             break;

--- a/SPAGAT-Librarian/src/tui/tui_m48.c
+++ b/SPAGAT-Librarian/src/tui/tui_m48.c
@@ -1,0 +1,231 @@
+/*
+ * tui_m48.c — M48-KanbanCVECard pure helpers.
+ *
+ * See include/spagat_m48.h for the public contract. This TU carries
+ * no ncurses, no SQLite, no TUIState references; it is safe to link
+ * into the unit-test binaries directly.
+ */
+
+#include "spagat_m48.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+/* strtok_r requires _POSIX_C_SOURCE >= 1 (glibc gates it behind
+ * feature-test macros). The appliance top-level CMake already sets
+ * _POSIX_C_SOURCE=200809L; we redundantly guard the fallback here so
+ * a bare `gcc -std=c11 -Iinclude -Isrc` still builds cleanly. */
+#if !defined(_POSIX_C_SOURCE)
+#  define _POSIX_C_SOURCE 200809L
+#endif
+extern char *strtok_r(char *str, const char *delim, char **saveptr);
+
+/* Case-insensitive strcmp — the canonical branch strings are
+ * ("5.0/SPECS/91"), but operator-entered ones from the Edit dialog
+ * may drift. */
+static int str_ieq(const char *a, const char *b) {
+    if (!a || !b) return 0;
+    while (*a && *b) {
+        if (tolower((unsigned char)*a) != tolower((unsigned char)*b)) return 0;
+        a++;
+        b++;
+    }
+    return *a == *b;
+}
+
+SpagatM48BranchColor m48_branch_color(const char *branch) {
+    if (!branch || !branch[0]) return M48_BRANCH_COLOR_OTHER;
+
+    /* Exact canonical strings first — canonical branch labels
+     * (4.0 / 5.0 / 5.0/SPECS/90 / 5.0/SPECS/91 / 6.0). */
+    if (str_ieq(branch, "4.0")) return M48_BRANCH_COLOR_40;
+    if (str_ieq(branch, "5.0")) return M48_BRANCH_COLOR_50;
+    if (str_ieq(branch, "6.0")) return M48_BRANCH_COLOR_60;
+    if (str_ieq(branch, "5.0/SPECS/90")) return M48_BRANCH_COLOR_SPECS_90;
+    if (str_ieq(branch, "5.0/SPECS/91")) return M48_BRANCH_COLOR_SPECS_91;
+
+    /* Unknown branch → OTHER (rendered white). Don't try to be clever
+     * about substring matching — an unknown "5.0-rc" shouldn't silently
+     * masquerade as the 5.0 release branch and mislead the operator. */
+    return M48_BRANCH_COLOR_OTHER;
+}
+
+bool m48_validate_cve_id(const char *id) {
+    if (!id) return false;
+
+    /* Prefix must be exactly "CVE-" (uppercase). */
+    if (strncmp(id, "CVE-", 4) != 0) return false;
+    const char *p = id + 4;
+
+    /* Year: exactly 4 digits. */
+    for (int i = 0; i < 4; i++) {
+        if (!isdigit((unsigned char)p[i])) return false;
+    }
+    p += 4;
+    if (*p != '-') return false;
+    p++;
+
+    /* Sequence: 4+ digits, no upper bound (some CVEs run to 7+). */
+    int seq_len = 0;
+    while (*p) {
+        if (!isdigit((unsigned char)*p)) return false;
+        seq_len++;
+        p++;
+    }
+    return seq_len >= 4;
+}
+
+bool m48_validate_commit_sha(const char *sha) {
+    if (!sha) return false;
+    if (sha[0] == '\0') return true;  /* Empty = unset, valid. */
+
+    int len = 0;
+    while (sha[len]) {
+        char c = sha[len];
+        bool ok = (c >= '0' && c <= '9') ||
+                  (c >= 'a' && c <= 'f') ||
+                  (c >= 'A' && c <= 'F');
+        if (!ok) return false;
+        len++;
+        if (len > 40) return false;
+    }
+    return len == 40;
+}
+
+/* Trim leading/trailing whitespace, mutating `s` in place. Returns
+ * the (possibly-advanced) start pointer. */
+static char *inplace_trim(char *s) {
+    while (*s && isspace((unsigned char)*s)) s++;
+    if (!*s) return s;
+    char *end = s + strlen(s) - 1;
+    while (end > s && isspace((unsigned char)*end)) *end-- = '\0';
+    return s;
+}
+
+bool m48_parse_cve_ids(const char *raw, SpagatCveList *out) {
+    if (!out) return false;
+    memset(out, 0, sizeof(*out));
+    if (!raw || !raw[0]) return false;
+
+    /* Work on a mutable local copy so we can strtok/trim. Bound is
+     * SPAGAT_MAX_CVE_LIST_LEN + a little slack for safety. */
+    char buf[SPAGAT_MAX_CVE_LIST_LEN + 8];
+    size_t rlen = strlen(raw);
+    if (rlen >= sizeof(buf)) rlen = sizeof(buf) - 1;
+    memcpy(buf, raw, rlen);
+    buf[rlen] = '\0';
+
+    int valid = 0;
+    char *saveptr = NULL;
+    char *tok = strtok_r(buf, ",", &saveptr);
+    while (tok) {
+        char *trimmed = inplace_trim(tok);
+        if (trimmed[0]) {
+            out->total_parsed++;
+            if (m48_validate_cve_id(trimmed)) {
+                if (out->count < SPAGAT_M48_MAX_CVE_ENTRIES) {
+                    /* Copy the trimmed token into the slot. */
+                    size_t tlen = strlen(trimmed);
+                    if (tlen >= sizeof(out->entries[0].id)) {
+                        tlen = sizeof(out->entries[0].id) - 1;
+                    }
+                    memcpy(out->entries[out->count].id, trimmed, tlen);
+                    out->entries[out->count].id[tlen] = '\0';
+                    out->count++;
+                }
+                valid++;
+            } else {
+                out->had_invalid = true;
+            }
+        }
+        tok = strtok_r(NULL, ",", &saveptr);
+    }
+    return valid > 0;
+}
+
+bool m48_should_render_two_lines(const Item *item) {
+    if (!item) return false;
+    if (item->cve_ids[0] != '\0') return true;
+    if (item->upstream_commit[0] != '\0') return true;
+    if (item->backport_commit[0] != '\0') return true;
+    return false;
+}
+
+int m48_format_card_line1(const Item *item, char sel_marker,
+                          char *out, size_t out_size) {
+    if (!item || !out || out_size == 0) return 0;
+    /* Compose in a scratch buffer wide enough for the largest legal
+     * combination; then copy-and-truncate into `out`. */
+    char scratch[SPAGAT_MAX_TITLE_LEN + SPAGAT_MAX_BRANCH_LEN + 32];
+    int n;
+    if (item->git_branch[0]) {
+        n = snprintf(scratch, sizeof(scratch), "%c %lld [%s] %s",
+                     sel_marker, (long long)item->id,
+                     item->git_branch, item->title);
+    } else {
+        n = snprintf(scratch, sizeof(scratch), "%c %lld %s",
+                     sel_marker, (long long)item->id, item->title);
+    }
+    if (n < 0) { out[0] = '\0'; return 0; }
+    /* Copy into caller's buffer with hard truncation. */
+    size_t cap = out_size - 1;
+    size_t copy = ((size_t)n < cap) ? (size_t)n : cap;
+    memcpy(out, scratch, copy);
+    out[copy] = '\0';
+    return n;
+}
+
+int m48_format_card_line2(const Item *item, char *out, size_t out_size) {
+    if (!item || !out || out_size == 0) return 0;
+    out[0] = '\0';
+    if (!m48_should_render_two_lines(item)) return 0;
+
+    /* Parse the CVE list to pick the first + overflow count. */
+    SpagatCveList cves;
+    m48_parse_cve_ids(item->cve_ids, &cves);
+
+    /* Short-commit rendering: first 4 hex + ".." for the upstream SHA.
+     * Renders even when zero CVEs are present, matching the operator
+     * preview. Falls back to no parenthetical when upstream_commit is
+     * empty. */
+    char short_commit[8] = {0};
+    if (item->upstream_commit[0]) {
+        int copy = 0;
+        while (copy < 4 && item->upstream_commit[copy]) {
+            short_commit[copy] = item->upstream_commit[copy];
+            copy++;
+        }
+        short_commit[copy] = '\0';
+    }
+
+    char scratch[128];
+    int pos = 0;
+    /* Leading indent — 4 spaces so the CVE line sits under the title. */
+    pos += snprintf(scratch + pos, sizeof(scratch) - pos, "    ");
+
+    if (cves.count > 0) {
+        pos += snprintf(scratch + pos, sizeof(scratch) - pos, "%s",
+                        cves.entries[0].id);
+        int extras = cves.total_parsed - 1;
+        if (extras >= 1) {
+            pos += snprintf(scratch + pos, sizeof(scratch) - pos, " +%d",
+                            extras);
+        }
+        if (short_commit[0]) {
+            pos += snprintf(scratch + pos, sizeof(scratch) - pos, " (%s..)",
+                            short_commit);
+        }
+    } else if (short_commit[0]) {
+        /* No CVE, upstream commit only — still worth surfacing. */
+        pos += snprintf(scratch + pos, sizeof(scratch) - pos, "(%s..)",
+                        short_commit);
+    }
+
+    if (pos < 0) { out[0] = '\0'; return 0; }
+    size_t cap = out_size - 1;
+    size_t copy = ((size_t)pos < cap) ? (size_t)pos : cap;
+    memcpy(out, scratch, copy);
+    out[copy] = '\0';
+    return pos;
+}

--- a/SPAGAT-Librarian/src/util/util.c
+++ b/SPAGAT-Librarian/src/util/util.c
@@ -1,5 +1,6 @@
 #include "util.h"
 #include "spagat.h"
+#include "spagat_board_mode.h"
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
@@ -16,17 +17,77 @@ const char *STATUS_NAMES[] = {
 };
 
 const char *STATUS_DISPLAY[] = {
-    "In Clarification",
-    "Won't Fix",
-    "In Backlog",
-    "In Progress",
-    "In Review",
-    "Ready"
+    "Backlog",
+    "Triage",
+    "Pending-HITL",
+    "In-Progress",
+    "Done",
+    "Failed"
 };
 
 const char STATUS_ABBREV[] = {
     'C', 'W', 'B', 'P', 'V', 'R'
 };
+
+/* M48-KanbanBranchView — column headers for the Branch board layout.
+ * Order MUST match BRANCH_COL_KEYS below and the SpagatM48BranchColor
+ * enum in include/spagat_m48.h so the column-header color paints from
+ * the same palette as the per-card branch badge. */
+const char *BRANCH_COL_DISPLAY[BRANCH_COL_COUNT] = {
+    "4.0",
+    "5.0",
+    "5.0/SPECS/90",
+    "5.0/SPECS/91",
+    "6.0",
+    "Other",
+};
+
+/* Canonical branch strings (case-preserved). NULL sentinel in the last
+ * slot is the "matches anything not above" marker used by
+ * branch_column_for(); it lets the fallback bucket stay a normal column
+ * without special-casing the loop. */
+const char *BRANCH_COL_KEYS[BRANCH_COL_COUNT] = {
+    "4.0",
+    "5.0",
+    "5.0/SPECS/90",
+    "5.0/SPECS/91",
+    "6.0",
+    NULL,
+};
+
+int branch_column_for(const char *git_branch) {
+    if (!git_branch || !git_branch[0]) return BRANCH_COL_OTHER_INDEX;
+    /* Iterate the canonical [0..BRANCH_COL_COUNT-2] slots; the trailing
+     * NULL sentinel is the Other-column marker, not a match target. */
+    for (int i = 0; i < BRANCH_COL_COUNT - 1; i++) {
+        if (BRANCH_COL_KEYS[i] &&
+            str_equals_ignore_case(git_branch, BRANCH_COL_KEYS[i])) {
+            return i;
+        }
+    }
+    return BRANCH_COL_OTHER_INDEX;
+}
+
+/* -------------------------------------------------------------------------
+ * M48-KanbanBranchView — pure BoardMode helpers.
+ *
+ * Kept here (rather than tui/) so the unit tests can link only util.c
+ * to drive them; no ncurses, no SQLite, no TUIState.
+ * ------------------------------------------------------------------------- */
+
+BoardMode board_mode_next(BoardMode current) {
+    return (current == BOARD_MODE_STATUS) ? BOARD_MODE_BRANCH
+                                          : BOARD_MODE_STATUS;
+}
+
+int board_col_count(BoardMode mode) {
+    return (mode == BOARD_MODE_BRANCH) ? BOARD_COL_COUNT_BRANCH
+                                       : BOARD_COL_COUNT_STATUS;
+}
+
+const char *board_mode_label(BoardMode mode) {
+    return (mode == BOARD_MODE_BRANCH) ? "Branch" : "Status";
+}
 
 const char *PRIORITY_NAMES[] = {
     "none",

--- a/SPAGAT-Librarian/src/util/util.h
+++ b/SPAGAT-Librarian/src/util/util.h
@@ -15,4 +15,32 @@ char *get_editor(void);
 bool file_exists(const char *path);
 bool env_is_set(const char *name);
 
+/* M48-KanbanBranchView — canonical Photon branch column layout for
+ * the Branch view. Order is deliberate: 4.0 (oldest LTS) leftmost,
+ * 6.0 rightmost, subrelease specs sandwiched between 5.0 and 6.0.
+ * Kept in lock-step with SpagatM48BranchColor / spagat_appliance_config
+ * `[targets].eligible_branches` so the branch badge color on line 1
+ * of the card matches the column-header color in Branch view.
+ *
+ *   [0] "4.0"           — Photon 4.0 mainline
+ *   [1] "5.0"           — Photon 5.0 mainline
+ *   [2] "5.0/SPECS/90"  — 5.0 SPECS subrelease 90
+ *   [3] "5.0/SPECS/91"  — 5.0 SPECS subrelease 91 (current)
+ *   [4] "6.0"           — Photon 6.0 mainline
+ *   [5] "Other"         — fallback bucket for any git_branch not in
+ *                         [0..4] plus rows with an empty git_branch
+ */
+#define BRANCH_COL_COUNT 6
+#define BRANCH_COL_OTHER_INDEX (BRANCH_COL_COUNT - 1)
+
+extern const char *BRANCH_COL_DISPLAY[BRANCH_COL_COUNT];
+extern const char *BRANCH_COL_KEYS[BRANCH_COL_COUNT];
+
+/* Returns the branch-view column index [0..BRANCH_COL_COUNT-1] for a
+ * given item's git_branch. Case-insensitive; unknown / empty / NULL all
+ * map to BRANCH_COL_OTHER_INDEX so the "Other" fallback bucket is truly
+ * exhaustive. Kept in lock-step with m48_branch_color() — anything that
+ * maps to M48_BRANCH_COLOR_OTHER also lands in the Other column. */
+int branch_column_for(const char *git_branch);
+
 #endif


### PR DESCRIPTION
## Summary

First upstream sync from the private `dcasota/SpagatLibrarian-Appliance` repo to public `SPAGAT-Librarian`.

**Scope: T-PUB fileset** determined by `docs/upstream-sync/tier-manifest.toml` in the appliance repo and enforced by the `xtask-preflight upstream-sync-safety` static lint. All 4 gate conditions met; operator go-ahead 2026-07-11.

## What's synced

**86 T-PUB source files** from the appliance's `src/containers/spagat-console/`:

| Subdir | Files |
|---|---|
| `src/agent/*.{c,h}` | 9 |
| `src/ai/*.{c,h,cpp}` | 34 |
| `src/cli/*.{c,h}` | 11 |
| `src/db/*.{c,h}` | 7 |
| `src/main.c` | 1 |
| `src/skill/*.{c,h}` | 3 |
| `src/tui/*.{c,h}` (direct children only) | 13 |
| `src/util/*.{c,h}` | 4 |
| `include/appliance/*.h` (T-PUB adapter shims, NEW subdir) | 4 |

Plus **6 user-doc files** from `docs/public/`:

- `README.md` (OVERWRITES existing)
- `INSTALL.md`, `CONFIGURATION.md`, `SKILLS.md`, `AGENT.md`, `INTEGRATION.md` (new)

**Net diff: 29 files changed, +3178 / -717.** Most T-PUB files were already byte-identical upstream, hence the narrow diff.

## New adapter shim under `include/appliance/`

The four headers there (`hitl.h`, `settings.h`, `scheduler_view.h`, `hidpi.h`) forward to appliance-internal overlay interfaces under `-DSPAGAT_APPLIANCE_BUILD`, and supply inline no-op stubs otherwise. The standalone CLI compiles unchanged; the appliance build binds the same call sites to real implementations.

## Explicitly excluded

**T-INT (appliance-internal, never synced):**
- `src/tui/appliance/**` (UI overlays: `tui_hitl.c`, `tui_settings.c`, `tui_scheduler_view.c`, `tui_hidpi.c`)
- `include/spagat_{hitl,settings,scheduler_view,hidpi,history,m48,board_mode}.h` (overlay interface headers)

**Repo-specific (upstream keeps its own):**
- `Makefile`, `CMakeLists.txt`, `spagat.spec` (adapter refactor introduced `#ifdef SPAGAT_APPLIANCE_BUILD` we don't want to force here yet)
- `PLAN.md`, `PROPOSAL*.md`, `ARCHITECTURE.md`, `MEANING.md`
- `deploy/`, `docs/architecture/`, `docs/adr/`

## Source of truth

Appliance commit `fde0d8e34b40a0458621ed6530bc1f97196150e6`.

## Verification

- Grepped the copied tree for every T-INT symbol name; zero leaks.
- `src/tui/` in this branch has no `appliance/` subdir.
- `include/` in this branch has no `spagat_*.h` overlay headers (only `spagat.h` from before, unchanged, plus the new `appliance/` shim subdir).

## Test plan

- [ ] `cd SPAGAT-Librarian && make` on a Linux host — CLI compiles cleanly without `-DSPAGAT_APPLIANCE_BUILD`.
- [ ] `./spagat-console` launches the TUI kanban board.
- [ ] Skim `README.md` / `INSTALL.md` for the standalone install path (Photon 5 + Ubuntu 22.04 supported per the appliance docs).

**Do NOT auto-merge.** This is the first sync PR; per operator policy, first upstream sync PRs get manual operator review.
