### PR TITLE
phase-M task M161: Compare-VersionStrings Rule-8 guard + lenient reparse

### DIFF
--- a/photonos-package-report/photonos-package-report.ps1
+++ b/photonos-package-report/photonos-package-report.ps1
@@ -2052,6 +2052,56 @@ function CheckURLHealth {
                 if ($c1 -lt $v2.Components[0]) { return -1 }
                 return 0
             }
+            # M161: Rule 8 pre-processing — StandardVersion(latest) vs
+            # String(Source0) direction only. Rule 8's original code does
+            # `$v1.Value -gt/-lt $v2.Value`. When v1 is StandardVersion (no
+            # .Value) and v2 is String (letter-suffixed Source0), the
+            # comparison becomes `$null -lt <str>` = True → returns -1 →
+            # spuriously flags "Source0 higher than latest" for any
+            # pre-release suffix Parse-Version's Case 3b regex (single
+            # letter only) doesn't catch: rel<N>, rc<N>, pre<N>, "B."
+            # prefix, single trailing letter.
+            #
+            # The reverse direction (v1=String latest, v2=StandardVersion
+            # source0, e.g. openjdk21 latest 21.0.12+7 vs Source0 21.0.10)
+            # is NOT touched: there Rule 8's `<str> -gt $null = True`
+            # correctly returns +1 (propose the upgrade). Intercepting
+            # that would regress openjdk11/17/21 to silent.
+            #
+            # Strip a known-safe pattern from the String side and re-run
+            # Rule 3 IF the reparsed StandardVersion shares its first
+            # component with the StandardVersion side (guards against
+            # different-lineage cases such as libmspack 0.11alpha vs a
+            # scraped 1.11). Otherwise return $null — parity-neutral
+            # silence matching M159's cross-type guard pattern.
+            if ($v1.Type -eq 'StandardVersion' -and $v2.Type -eq 'String') {
+                $stripped = $null
+                # Pattern A: trailing "<digits><letters><digits>" — e.g. "2.92rel2", "1.0.7pre44"
+                if     ($Version -match '^(.*\d)[a-zA-Z]+\d+$')      { $stripped = $Matches[1] }
+                # Pattern B: leading "B." prefix — e.g. "B.02.19" (lshw)
+                elseif ($Version -match '^[Bb]\.(\d+(?:\.\d+)*)$')   { $stripped = $Matches[1] }
+                # Pattern C: trailing bare letter after StandardVersion — e.g. "3.1b" (tmux)
+                elseif ($Version -match '^(\d+(?:\.\d+)+)[a-zA-Z]$') { $stripped = $Matches[1] }
+
+                if ($null -ne $stripped) {
+                    $reparsed = Parse-Version -InputVersion $stripped
+                    if ($reparsed.Type -eq 'StandardVersion' `
+                        -and $reparsed.Components.Length -gt 0 `
+                        -and $v1.Components.Length -gt 0 `
+                        -and $reparsed.Components[0] -eq $v1.Components[0]) {
+                        # Rule 3 semantics: v1 (StandardVersion latest) vs reparsed Source0.
+                        $maxLength = [math]::Max($v1.Components.Length, $reparsed.Components.Length)
+                        for ($i = 0; $i -lt $maxLength; $i++) {
+                            $c1 = if ($i -lt $v1.Components.Length)       { $v1.Components[$i] }       else { 0 }
+                            $c2 = if ($i -lt $reparsed.Components.Length) { $reparsed.Components[$i] } else { 0 }
+                            if ($c1 -gt $c2) { return 1 }
+                            if ($c1 -lt $c2) { return -1 }
+                        }
+                        return 0
+                    }
+                }
+                return $null
+            }
             # Rule 8: Fallback to string comparison
             if ($v1.Value -gt $v2.Value) { return 1 }
             if ($v1.Value -lt $v2.Value) { return -1 }

--- a/photonos-package-report/photonos-package-report/src/version.c
+++ b/photonos-package-report/photonos-package-report/src/version.c
@@ -30,6 +30,10 @@ static pcre2_code *RE_QUARTERLY;      /* ^(\d{4})\.Q(\d+)\.(\d+)$ */
 static pcre2_code *RE_STANDARD;       /* ^\d+(\.\d+)+$ */
 static pcre2_code *RE_LETTER_EMBED;   /* ^\d+(\.\d+)*\.\d+[a-zA-Z]\d+$ */
 static pcre2_code *RE_INT;            /* ^\d+$ */
+/* M161 strip patterns — see pr_version_compare Rule-8 pre-processing. */
+static pcre2_code *RE_M161_STRIP_A;   /* ^(.*\d)[a-zA-Z]+\d+$ */
+static pcre2_code *RE_M161_STRIP_B;   /* ^[Bb]\.(\d+(?:\.\d+)*)$ */
+static pcre2_code *RE_M161_STRIP_C;   /* ^(\d+(?:\.\d+)+)[a-zA-Z]$ */
 
 static pthread_once_t g_re_once = PTHREAD_ONCE_INIT;
 
@@ -57,6 +61,9 @@ static void init_patterns(void)
     RE_STANDARD     = compile_or_die("^\\d+(\\.\\d+)+$");
     RE_LETTER_EMBED = compile_or_die("^\\d+(\\.\\d+)*\\.\\d+[a-zA-Z]\\d+$");
     RE_INT          = compile_or_die("^\\d+$");
+    RE_M161_STRIP_A = compile_or_die("^(.*\\d)[a-zA-Z]+\\d+$");
+    RE_M161_STRIP_B = compile_or_die("^[Bb]\\.(\\d+(?:\\.\\d+)*)$");
+    RE_M161_STRIP_C = compile_or_die("^(\\d+(?:\\.\\d+)+)[a-zA-Z]$");
 }
 
 /* Helper: PCRE2 match-only convenience. Returns 1 on match. */
@@ -484,6 +491,70 @@ int pr_version_compare(const char *a, const char *b)
         else                       result = 0;
         goto done;
     }
+    /* M161: Rule 8 pre-processing — StandardVersion(latest) vs
+     * String(Source0) direction only. Mirrors the same block in
+     * photonos-package-report.ps1 Compare-VersionStrings.
+     *
+     * In this direction Rule 8's `<null> -lt <str>` → -1 spuriously
+     * flags "Source0 higher than latest" for any pre-release suffix
+     * Case-3b's `[a-zA-Z]` (single-letter) regex doesn't catch: rel<N>,
+     * rc<N>, pre<N>, "B." prefix, single trailing letter.
+     *
+     * The reverse direction (v1=String latest, v2=StandardVersion
+     * source0, e.g. openjdk21 latest 21.0.12+7 vs Source0 21.0.10) is
+     * NOT touched: there Rule 8's `<str> -gt $null = True` returns +1
+     * correctly (propose upgrade). Intercepting that would regress
+     * openjdk11/17/21 to silent.
+     *
+     * Strip a known-safe pattern from the String Source0 and re-run
+     * Rule 3 IF the reparsed StandardVersion shares its first component
+     * with v1 (guards against different-lineage cases such as libmspack
+     * 0.11alpha vs a scraped 1.11). Otherwise return -2 — parity-neutral
+     * silence matching M159's cross-type guard. */
+    if (v1.type == PR_VER_STANDARD && v2.type == PR_VER_STRING) {
+        char *stripped = NULL;
+        char *caps[1] = {0};
+        /* Pattern A: trailing "<digits><letters><digits>" (dnsmasq, urw-fonts). */
+        if (re_match_groups(RE_M161_STRIP_A, b, caps, 1) == 1) {
+            stripped = caps[0]; caps[0] = NULL;
+        } else if (re_match_groups(RE_M161_STRIP_B, b, caps, 1) == 1) {
+            /* Pattern B: leading "B." prefix (lshw). */
+            stripped = caps[0]; caps[0] = NULL;
+        } else if (re_match_groups(RE_M161_STRIP_C, b, caps, 1) == 1) {
+            /* Pattern C: trailing bare letter after StandardVersion (tmux). */
+            stripped = caps[0]; caps[0] = NULL;
+        }
+        free(caps[0]);
+
+        if (stripped != NULL) {
+            pr_version_t reparsed = {0};
+            int ok = (pr_version_parse(stripped, &reparsed) == 0);
+            free(stripped);
+            if (ok
+                && reparsed.type == PR_VER_STANDARD
+                && reparsed.n_components > 0
+                && v1.n_components > 0
+                && reparsed.components[0] == v1.components[0]) {
+                /* Rule 3 semantics: v1 (StandardVersion latest) vs reparsed Source0. */
+                size_t maxn = v1.n_components > reparsed.n_components
+                                ? v1.n_components : reparsed.n_components;
+                int r3 = 0;
+                for (size_t i = 0; i < maxn; i++) {
+                    int c1 = i < v1.n_components       ? v1.components[i]       : 0;
+                    int c2 = i < reparsed.n_components ? reparsed.components[i] : 0;
+                    if (c1 > c2) { r3 = 1;  break; }
+                    if (c1 < c2) { r3 = -1; break; }
+                }
+                pr_version_free(&reparsed);
+                result = r3;
+                goto done;
+            }
+            pr_version_free(&reparsed);
+        }
+        /* Strip didn't fire or first-component mismatch: silent fallback. */
+        result = -2;
+        goto done;
+    }
     /* Rule 8: String fallback — compare .Value as strings. PS uses
      *   $v1.Value -gt $v2.Value
      * where .Value is set ONLY for the String type (the other-type
@@ -497,7 +568,9 @@ int pr_version_compare(const char *a, const char *b)
      * compared "21.0.6" vs "21.0.12+4" at byte 5 and returned -1 (latest
      * < Source0), triggering a bogus packaging-format warning. PS
      * compares "21.0.12+4" vs "" → +1 (latest > Source0, newer detected).
-     * Mirror that exactly: only consult str_value for PR_VER_STRING. */
+     * Mirror that exactly: only consult str_value for PR_VER_STRING.
+     * M161 intercepts the String-vs-StandardVersion sub-case above; this
+     * block still runs for String-vs-String and String-vs-Integer/Decimal. */
     {
         const char *s1 = (v1.type == PR_VER_STRING && v1.str_value) ? v1.str_value : "";
         const char *s2 = (v2.type == PR_VER_STRING && v2.str_value) ? v2.str_value : "";


### PR DESCRIPTION
## Summary

Fixes a Rule-8 misfire in `Compare-VersionStrings` (PS) / `pr_version_compare` (C) that spuriously flags "Source0 higher than detected latest" for any Source0 whose pre-release suffix Parse-Version's Case-3b regex (single letter only) doesn't cover: `rel<N>`, `rc<N>`, `pre<N>`, `beta<N>`, `alpha<N>`, `.b<N>`, `B.` prefix, single trailing letter, etc.

Root cause: Rule 8 does `$v1.Value -gt/-lt $v2.Value`, but `StandardVersion` parse-results have no `.Value` field (they're `Components`-only). When Namelatest is StandardVersion and Source0 is String, the comparison becomes `$null -lt <str>` = `$true` → returns -1 → warning fires and no `UpdateURL` is proposed.

Fleet-wide impact on today's 2026-07-12 PS+C pair (29188434604 / 29190441177): **22 warning rows across 6 branches (25% of the Cat-5 warning stream)**, covering 13 unique triples across 7 specs — dnsmasq, libmspack, linux, lshw, socat, tmux, urw-fonts. Both PS and C emit identical wrong warnings today (broken-on-both parity).

## Design

- Intercept only the `(StandardVersion, String)` direction. Reverse direction (openjdk11/17/21: `21.0.12+7` String latest vs `21.0.10` STANDARD Source0) is left to Rule 8's `<str> -gt $null` = `$true` → returns +1, which is correct.
- Try three narrow strip patterns on the String Source0:
  - **A**: trailing `<digits><letters><digits>` — e.g. `2.92rel2`, `1.0.7pre44`
  - **B**: leading `B.` prefix — e.g. `B.02.19`
  - **C**: trailing bare letter after StandardVersion — e.g. `3.1b`
- First-component guard: only accept the strip if `reparsed[0] == v1.Components[0]`. Blocks libmspack `0.11alpha` vs scraped `1.11` from being proposed as an upgrade.
- On strip acceptance, re-run Rule 3 (component-wise int compare).
- On rejection, return `$null` (PS) / `-2` (C) — parity-neutral silence matching M159's cross-type guard pattern (caller already handles `-2` at all three warning-emit sites).

## Expected per-spec outcomes

| Spec | Source0 | Latest | Today | Post-M161 |
|---|---|---|---|---|
| dnsmasq | 2.92rel2 | 2.93 | wrong warning | propose 2.93 |
| lshw | B.02.19 | 02.20 | wrong warning | propose 02.20 |
| tmux | 3.1b | 3.7 | wrong warning | propose 3.7 |
| urw-fonts | 1.0.7pre44 | 1.0.1 | warning (right-for-wrong reasons) | warning (right-for-right reasons) |
| libmspack | 0.11alpha | 1.11 | wrong warning (defends pin) | silent (defends pin) |
| socat | 2.0.0.b9 | 1.8.1.3 | warning (right-for-wrong reasons) | silent |
| linux | 6.1.83-acvp} | 6.1.177 | warning (subst leak) | silent |

## Test plan

- [x] 22-probe unit harness (7 target specs × up to 4 branches + 8 regression controls + 3 openjdk reverse-direction + std-eq/gt/lt + date-guard + case3b-eq)
- [x] PS-side probe 22/22 pass
- [x] C-side probe 22/22 pass, byte-identical to PS
- [x] `ctest --test-dir build` 14/14 pass
- [ ] Full PS+C cycle on all 7 branches (4.0,5.0,6.0,dev,common,master,main; exclusions chromium,firmware,aufs-linux) matching 2026-07-12 baseline
- [ ] Verify 22 M161-affected rows change as expected across the six affected branches
- [ ] Verify no other unrelated rows shift outside upstream-churn noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPpESSHAqpX158yiLtZ7Pz